### PR TITLE
DQC US Rule 33 Single DPED Fix

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -42,6 +42,8 @@ __pluginInfo__ = {
     'name': 'DQC.SEC.ALL',
     'version': '1.0',
     'description': '''All Data Quality Committee SEC Filing Checks''',
+    'author': '',
+    'license': 'See accompanying license text',
     #Mount points
     'Validate.XBRL.Finally': run_checks,
 }

--- a/src/dqc_us_0033_0036.py
+++ b/src/dqc_us_0033_0036.py
@@ -93,7 +93,9 @@ def _get_default_dped(dped_facts):
     if len(keys) == 0:
         return None
     elif len(keys) == 1:
-        return [f for f in dped_facts.values()]
+        # Only one Document Period End Date, so that is our default
+        (_, value), = dped_facts.items()
+        return value
     else:
         return dped_facts.get('', [None])
 

--- a/src/dqc_us_0033_0036.py
+++ b/src/dqc_us_0033_0036.py
@@ -94,7 +94,7 @@ def _get_default_dped(dped_facts):
         return None
     elif len(keys) == 1:
         # Only one Document Period End Date, so that is our default
-        (_, value), = dped_facts.items()
+        value, = dped_facts.values()
         return value
     else:
         return dped_facts.get('', [None])

--- a/tests/unit_tests/test_dqc_us_0033_0036.py
+++ b/tests/unit_tests/test_dqc_us_0033_0036.py
@@ -144,3 +144,15 @@ class TestDocPerEndDateChk(unittest.TestCase):
 
         res = dpedc._doc_period_end_date_check(mock_model)
         self.assertEqual(len(res), 1)  # Only expect one because test 33 will not happen if 36 fires.
+
+
+class TestGetDefaultDped(unittest.TestCase):
+
+    def test_no_dped(self):
+        self.assertIsNone(dpedc._get_default_dped({}))
+
+    def test_length_one_dped(self):
+        self.assertEqual(['test_case'], dpedc._get_default_dped({'': ['test_case']}))
+
+    def test_multi_dped(self):
+        self.assertEqual(['test_case'], dpedc._get_default_dped({'': ['test_case'], 'foo': ['another test case']}))


### PR DESCRIPTION
# Problem
When a filing had only a singled Document Period End Date defined, we were generating an exception if rule #33 was being run.

# Solution
We were returning an embedded list of lists that caused this issue.  Fixed the mechanism that was getting the single element out of the dictionary of Document Period End Dates and added some unit tests to verify this functionality consistently.

Also did a minor update to the __init__.py plugin declaration to make it work properly with the Arelle UI.