### PR TITLE
Fix formatting of bad if statement

### DIFF
--- a/dqc_us_rules/dqc_us_0004.py
+++ b/dqc_us_rules/dqc_us_0004.py
@@ -71,10 +71,9 @@ def _assets_eq_liability_equity(model_xbrl):
                 dec_assets = inferredDecimals(fact_assets)
                 dec_liabilities = inferredDecimals(fact_liabilities)
                 min_dec = min(dec_assets, dec_liabilities)
-                if ((_min_dec_valid(min_dec) and
-                     _values_unequal(
-                         fact_assets.xValue, fact_liabilities.xValue, min_dec
-                     ))):
+                if _values_unequal(
+                    fact_assets.xValue, fact_liabilities.xValue, min_dec
+                ):
                     yield fact_assets, fact_liabilities
 
 
@@ -108,6 +107,10 @@ def _values_unequal(val1, val2, dec_scale, margin_scale=2):
     :return: True if the values are not equal
     :rtype: bool
     """
+
+    if not _min_dec_valid(dec_scale):
+        return False
+
     round_val1 = roundValue(val1, decimals=dec_scale)
     round_val2 = roundValue(val2, decimals=dec_scale)
     margin_of_error = (


### PR DESCRIPTION
#### Changes:

- Moved _min_dec_valid call inside of _values_unequal call

Reasoning: _min_dec_valid was created to prevent the _values_unequal call from throwing an error so it is logical to check if min_dec is valid inside _values_unequal instead of in every if where _value_unequal is called 

Please review: @hefischer  @andrewperkins-wf