### PR TITLE
XS-3076 DQC 33_36 seems to have an incorrect calculation

### DIFF
--- a/dqc_us_rules/dqc_us_0033_0036.py
+++ b/dqc_us_rules/dqc_us_0033_0036.py
@@ -123,7 +123,7 @@ def _doc_period_end_date_check(model_xbrl):
                 fact_member = ''
                 for dim in fact.context.segDimValues.values():
                     fact_member = (str(dim.member.qname))
-                if ((str(fact_member) in not_valid_dped or
+                if ((fact_member in not_valid_dped or
                      fact.context is None or
                      fact.context.endDatetime is None or
                      fact.concept.periodType != 'duration'
@@ -167,8 +167,6 @@ def _setup_dei_facts(model_xbrl):
     dei_facts = facts.legal_entity_axis_facts_by_member(
         _get_dei_facts(model_xbrl, ignored_fact_list)
     )
-    # dei_facts = _get_dei_facts(model_xbrl, ignored_fact_list)
-    # lea_dei_facts = facts.legal_entity_axis_facts_by_member(dei_facts)
     dped_facts = facts.legal_entity_axis_facts_by_member(
         facts.get_facts_dei(['DocumentPeriodEndDate'], model_xbrl)
     )

--- a/dqc_us_rules/dqc_us_0033_0036.py
+++ b/dqc_us_rules/dqc_us_0033_0036.py
@@ -127,8 +127,7 @@ def _doc_period_end_date_check(model_xbrl):
                      )):
                     continue
 
-                should_continue = check_for_lea_member(fact, not_valid_dped)
-                if should_continue:
+                if check_for_lea_member(fact, not_valid_dped):
                     delta = context_eop_date - dateunionDate(
                         fact.context.endDatetime, subtractOneDay=True
                     )

--- a/dqc_us_rules/dqc_us_0033_0036.py
+++ b/dqc_us_rules/dqc_us_0033_0036.py
@@ -143,12 +143,22 @@ def _doc_period_end_date_check(model_xbrl):
     return result_group
 
 
-def check_for_lea_member(fact_items, not_valid_dped):
-    print('not_valid_dped = {}'.format(not_valid_dped))
-    for fact_axis, fact_dim_value in fact_items.context.segDimValues.items():
-        print(type(fact_dim_value))
-        print('fact_dim_value = {}'.format(fact_dim_value.memberQname.localName))
-        is_gonna_b_false = fact_dim_value.memberQname.localName in not_valid_dped
+def check_for_lea_member(fact, not_valid_dped):
+    """
+    Checks facts to determine whether the fact contains a LEA member that we
+    do not want to fire rule 33 for
+
+    :param fact: fact to check
+    :type fact: :class: "~arelle.InstanceModelObject.ModelFact"
+    :param not_valid_dped: list of LEA member's that we do not want to fire
+        rule 33 on
+    :type not_valid_dped: list
+    :return: False (so we don't continue) if the fact contains a LEA member
+        that is in the list of LEA members we do not want to fire rule 33 for.
+        True (so we do continue) otherwise.
+    :rtype: bool
+    """
+    for fact_axis, fact_dim_value in fact.context.segDimValues.items():
         if fact_dim_value.memberQname.localName in not_valid_dped:
             # If we find the member, we do not want to continue with rule 33
             # check

--- a/dqc_us_rules/dqc_us_0033_0036.py
+++ b/dqc_us_rules/dqc_us_0033_0036.py
@@ -124,10 +124,10 @@ def _doc_period_end_date_check(model_xbrl):
                      )):
                     continue
 
-                if context_eop_date != dateunionDate(
-                    fact.context.endDatetime,
-                    subtractOneDay=True
-                ):
+                delta = context_eop_date - dateunionDate(
+                    fact.context.endDatetime, subtractOneDay=True
+                )
+                if abs(delta.days) <= 3:
                     result_group.append((
                         '{}.2'.format(_CODE_NAME_33),
                         messages.get_message(_CODE_NAME_33),

--- a/dqc_us_rules/dqc_us_0033_0036.py
+++ b/dqc_us_rules/dqc_us_0033_0036.py
@@ -124,10 +124,17 @@ def _doc_period_end_date_check(model_xbrl):
                      )):
                     continue
 
+                print('context_eop_date = {}'.format(context_eop_date))
+                other_date = dateunionDate(
+                    fact.context.endDatetime, subtractOneDay=True
+                )
+                print('the other date = {}'.format(other_date))
+
                 delta = context_eop_date - dateunionDate(
                     fact.context.endDatetime, subtractOneDay=True
                 )
-                if abs(delta.days) <= 3:
+                print('DELTA = {}'.format(delta.days))
+                if 0 != abs(delta.days) <= 3:
                     result_group.append((
                         '{}.2'.format(_CODE_NAME_33),
                         messages.get_message(_CODE_NAME_33),

--- a/dqc_us_rules/dqc_us_0033_0036.py
+++ b/dqc_us_rules/dqc_us_0033_0036.py
@@ -86,9 +86,7 @@ def _doc_period_end_date_check(model_xbrl):
         delta = context_eop_date - fact_eop_date
         if abs(delta.days) > 3:
             for dim in eop_fact.context.segDimValues.values():
-                not_valid_dped = str(dim.member.qname)
-                # not_valid_dped.append(str(dim.member.qname))
-                model_xbrl.error('Print ONE = ', not_valid_dped)
+                not_valid_dped.append(str(dim.member.qname))
             result_group.append((
                 '{}.1'.format(_CODE_NAME_36),
                 messages.get_message(_CODE_NAME_36),
@@ -96,7 +94,7 @@ def _doc_period_end_date_check(model_xbrl):
                 eop_fact,
                 default_dped_fact
             ))
-    model_xbrl.error('not_valid = ', not_valid_dped)
+
     # Don't loop through them if the DPED date is bad, since the date
     # is incorrect.
 
@@ -125,26 +123,17 @@ def _doc_period_end_date_check(model_xbrl):
                 fact_member = ''
                 for dim in fact.context.segDimValues.values():
                     fact_member = (str(dim.member.qname))
-                    model_xbrl.error('fact_member = ', fact_member)
-                if ((str(fact_member) == not_valid_dped or
+                if ((str(fact_member) in not_valid_dped or
                      fact.context is None or
                      fact.context.endDatetime is None or
                      fact.concept.periodType != 'duration'
                      )):
-                    print('Did not check')
-                    model_xbrl.error('Did NOT CHECK', 'No CHECK')
                     continue
-
-                print('context_eop_date = {}'.format(context_eop_date))
-                other_date = dateunionDate(
-                    fact.context.endDatetime, subtractOneDay=True
-                )
-                print('the other date = {}'.format(other_date))
 
                 delta = context_eop_date - dateunionDate(
                     fact.context.endDatetime, subtractOneDay=True
                 )
-                print('DELTA = {}'.format(delta.days))
+
                 if 0 != abs(delta.days) <= 3:
                     result_group.append((
                         '{}.2'.format(_CODE_NAME_33),

--- a/dqc_us_rules/dqc_us_0033_0036.py
+++ b/dqc_us_rules/dqc_us_0033_0036.py
@@ -5,6 +5,7 @@ from .util import facts, messages
 
 from arelle.ModelValue import dateunionDate
 
+
 _CODE_NAME_33 = 'DQC.US.0033'
 _CODE_NAME_36 = 'DQC.US.0036'
 _RULE_VERSION = '1.0'
@@ -85,6 +86,7 @@ def _doc_period_end_date_check(model_xbrl):
         delta = context_eop_date - fact_eop_date
         if abs(delta.days) > 3:
             not_valid_dped.append(eop_fact.contextID)
+            # not_valid_dped.append(eop_fact.member_qname)
             result_group.append((
                 '{}.1'.format(_CODE_NAME_36),
                 messages.get_message(_CODE_NAME_36),
@@ -92,6 +94,7 @@ def _doc_period_end_date_check(model_xbrl):
                 eop_fact,
                 default_dped_fact
             ))
+    print('not_valid_dped = {}'.format(not_valid_dped))
     # Don't loop through them if the DPED date is bad, since the date
     # is incorrect.
 
@@ -122,6 +125,7 @@ def _doc_period_end_date_check(model_xbrl):
                      fact.context.endDatetime is None or
                      fact.concept.periodType != 'duration'
                      )):
+                    print('Did not check')
                     continue
 
                 print('context_eop_date = {}'.format(context_eop_date))
@@ -135,6 +139,7 @@ def _doc_period_end_date_check(model_xbrl):
                 )
                 print('DELTA = {}'.format(delta.days))
                 if 0 != abs(delta.days) <= 3:
+                    print('MADE IT HERE...')
                     result_group.append((
                         '{}.2'.format(_CODE_NAME_33),
                         messages.get_message(_CODE_NAME_33),
@@ -163,9 +168,12 @@ def _setup_dei_facts(model_xbrl):
         'EntityNumberOfEmployees',
         'EntityListingDepositoryReceiptRatio'
     ]
+
     dei_facts = facts.legal_entity_axis_facts_by_member(
         _get_dei_facts(model_xbrl, ignored_fact_list)
     )
+    # dei_facts = _get_dei_facts(model_xbrl, ignored_fact_list)
+    # lea_dei_facts = facts.legal_entity_axis_facts_by_member(dei_facts)
     dped_facts = facts.legal_entity_axis_facts_by_member(
         facts.get_facts_dei(['DocumentPeriodEndDate'], model_xbrl)
     )

--- a/dqc_us_rules/dqc_us_0033_0036.py
+++ b/dqc_us_rules/dqc_us_0033_0036.py
@@ -144,7 +144,11 @@ def _doc_period_end_date_check(model_xbrl):
 
 
 def check_for_lea_member(fact_items, not_valid_dped):
+    print('not_valid_dped = {}'.format(not_valid_dped))
     for fact_axis, fact_dim_value in fact_items.context.segDimValues.items():
+        print(type(fact_dim_value))
+        print('fact_dim_value = {}'.format(fact_dim_value.memberQname.localName))
+        is_gonna_b_false = fact_dim_value.memberQname.localName in not_valid_dped
         if fact_dim_value.memberQname.localName in not_valid_dped:
             # If we find the member, we do not want to continue with rule 33
             # check

--- a/dqc_us_rules/dqc_us_0033_0036.py
+++ b/dqc_us_rules/dqc_us_0033_0036.py
@@ -127,26 +127,29 @@ def _doc_period_end_date_check(model_xbrl):
                      )):
                     continue
 
-                should_break = False
-                for fact_axis, fact_dim_value in fact.context.segDimValues.items():
-                    if fact_dim_value.memberQname.localName in not_valid_dped:
-                        should_break = True
-                        break
-                if should_break:
-                    continue
-
-                delta = context_eop_date - dateunionDate(
-                    fact.context.endDatetime, subtractOneDay=True
-                )
-                if delta.days != 0 and abs(delta.days) <= 3:
-                    result_group.append((
-                        '{}.2'.format(_CODE_NAME_33),
-                        messages.get_message(_CODE_NAME_33),
-                        fact.concept.label(),
-                        fact,
-                        default_dped_fact
-                    ))
+                should_continue = check_for_lea_member(fact, not_valid_dped)
+                if should_continue:
+                    delta = context_eop_date - dateunionDate(
+                        fact.context.endDatetime, subtractOneDay=True
+                    )
+                    if delta.days != 0 and abs(delta.days) <= 3:
+                        result_group.append((
+                            '{}.2'.format(_CODE_NAME_33),
+                            messages.get_message(_CODE_NAME_33),
+                            fact.concept.label(),
+                            fact,
+                            default_dped_fact
+                        ))
     return result_group
+
+
+def check_for_lea_member(fact_items, not_valid_dped):
+    for fact_axis, fact_dim_value in fact_items.context.segDimValues.items():
+        if fact_dim_value.memberQname.localName in not_valid_dped:
+            # If we find the member, we do not want to continue with rule 33
+            # check
+            return False
+    return True
 
 
 def _setup_dei_facts(model_xbrl):

--- a/dqc_us_rules/dqc_us_0033_0036.py
+++ b/dqc_us_rules/dqc_us_0033_0036.py
@@ -85,8 +85,10 @@ def _doc_period_end_date_check(model_xbrl):
         )
         delta = context_eop_date - fact_eop_date
         if abs(delta.days) > 3:
-            not_valid_dped.append(eop_fact.contextID)
-            # not_valid_dped.append(eop_fact.member_qname)
+            for dim in eop_fact.context.segDimValues.values():
+                not_valid_dped = str(dim.member.qname)
+                # not_valid_dped.append(str(dim.member.qname))
+                model_xbrl.error('Print ONE = ', not_valid_dped)
             result_group.append((
                 '{}.1'.format(_CODE_NAME_36),
                 messages.get_message(_CODE_NAME_36),
@@ -94,7 +96,7 @@ def _doc_period_end_date_check(model_xbrl):
                 eop_fact,
                 default_dped_fact
             ))
-    print('not_valid_dped = {}'.format(not_valid_dped))
+    model_xbrl.error('not_valid = ', not_valid_dped)
     # Don't loop through them if the DPED date is bad, since the date
     # is incorrect.
 
@@ -120,12 +122,17 @@ def _doc_period_end_date_check(model_xbrl):
             # If the DocumentPeriodEndDate context check doesn't fire,
             # we will check all dei fact context end dates against it.
             for fact in fact_group:
-                if ((fact.contextID in not_valid_dped or
+                fact_member = ''
+                for dim in fact.context.segDimValues.values():
+                    fact_member = (str(dim.member.qname))
+                    model_xbrl.error('fact_member = ', fact_member)
+                if ((str(fact_member) == not_valid_dped or
                      fact.context is None or
                      fact.context.endDatetime is None or
                      fact.concept.periodType != 'duration'
                      )):
                     print('Did not check')
+                    model_xbrl.error('Did NOT CHECK', 'No CHECK')
                     continue
 
                 print('context_eop_date = {}'.format(context_eop_date))
@@ -139,7 +146,6 @@ def _doc_period_end_date_check(model_xbrl):
                 )
                 print('DELTA = {}'.format(delta.days))
                 if 0 != abs(delta.days) <= 3:
-                    print('MADE IT HERE...')
                     result_group.append((
                         '{}.2'.format(_CODE_NAME_33),
                         messages.get_message(_CODE_NAME_33),

--- a/dqc_us_rules/dqc_us_0033_0036.py
+++ b/dqc_us_rules/dqc_us_0033_0036.py
@@ -36,7 +36,7 @@ def _is_valid_eop_fact(eop_fact):
     """
     Checks to ensure that the eop_fact and the eop_fact.xValue is not None
     :param eop_fact: fact to check
-    :type eop_fact: :class: "~arelle.InstanceModelObject.ModelFact"
+    :type eop_fact: :class:'~arelle.InstanceModelObject.ModelFact'
     :return: True if the fact and the fact.xValue is not None
     :rtype: bool
     """
@@ -149,7 +149,7 @@ def check_for_lea_member(fact, not_valid_dped):
     do not want to fire rule 33 for
 
     :param fact: fact to check
-    :type fact: :class: "~arelle.InstanceModelObject.ModelFact"
+    :type fact: :class:'~arelle.InstanceModelObject.ModelFact'
     :param not_valid_dped: list of LEA member's that we do not want to fire
         rule 33 on
     :type not_valid_dped: list

--- a/dqc_us_rules/util/facts.py
+++ b/dqc_us_rules/util/facts.py
@@ -325,7 +325,7 @@ def legal_entity_axis_facts_by_member(facts):
             ]
             for dim in dims:
                 if dim.dimension.qname.localName == 'LegalEntityAxis':
-                    print('Got a LEA')
+                    print('Got an LEA')
                     legalDim = dim.member.qname.localName
                     break
             results[legalDim].append(fact)

--- a/dqc_us_rules/util/facts.py
+++ b/dqc_us_rules/util/facts.py
@@ -325,7 +325,6 @@ def legal_entity_axis_facts_by_member(facts):
             ]
             for dim in dims:
                 if dim.dimension.qname.localName == 'LegalEntityAxis':
-                    print('Got an LEA')
                     legalDim = dim.member.qname.localName
                     break
             results[legalDim].append(fact)

--- a/dqc_us_rules/util/facts.py
+++ b/dqc_us_rules/util/facts.py
@@ -325,6 +325,7 @@ def legal_entity_axis_facts_by_member(facts):
             ]
             for dim in dims:
                 if dim.dimension.qname.localName == 'LegalEntityAxis':
+                    print('Got a LEA')
                     legalDim = dim.member.qname.localName
                     break
             results[legalDim].append(fact)

--- a/tests/unit_tests/test_dqc_us_0033_0036.py
+++ b/tests/unit_tests/test_dqc_us_0033_0036.py
@@ -275,6 +275,8 @@ class TestDocPerEndDateChk(unittest.TestCase):
         )
 
         res = dqc_us_0033_0036._doc_period_end_date_check(mock_model)
+        for i in res:
+            print('Iiiiiiiii = {}'.format(i))
         self.assertEqual(len(res), 2)  # Because both 33 and 36 should fire
 
 
@@ -285,8 +287,9 @@ class TestDocPerEndDateChk(unittest.TestCase):
     )
     def test_33_no_fire_on_lea_that_fires_36(self, moc_func):
         """
-        Tests _doc_period_end_date_check when it should return a warning and an
-        error
+        Tests _doc_period_end_date_check to ensure that facts that should fire
+        rule 33 do not if rule 36 fires on a Legal Entity Axis and the rule 33
+        facts have a member of the Legal Entity Axis
         """
         mock_mem_qn = mock.Mock(localName='foo')
         mock_dim_qn = mock.Mock(localName='LegalEntityAxis')
@@ -304,18 +307,25 @@ class TestDocPerEndDateChk(unittest.TestCase):
         mock_edt_norm = mock.Mock()
         mock_edt_norm.date.return_value = date(year=2015, month=1, day=1)
 
-        mock_edt_off = mock.Mock()
         # This will cause 36 to fire
+        mock_edt_off = mock.Mock()
         mock_edt_off.date.return_value = date(year=2015, month=1, day=5)
         mock_off_context = mock.Mock(
             endDatetime=mock_edt_off, segDimValues=mock_more_dims
         )
 
-        mock_edt_off2 = mock.Mock()
         # This will cause 33 to fire
+        mock_edt_off2 = mock.Mock()
         mock_edt_off2.date.return_value = date(year=2015, month=1, day=3)
         mock_off2_context = mock.Mock(
             endDatetime=mock_edt_off2, segDimValues=mock_more_dims
+        )
+
+        # This will cause 33 to fire
+        mock_edt_off3 = mock.Mock()
+        mock_edt_off3.date.return_value = date(year=2015, month=1, day=2)
+        mock_off3_context = mock.Mock(
+            endDatetime=mock_edt_off3, segDimValues=mock_more_dims
         )
 
         m_qn_bad = mock.Mock(
@@ -329,15 +339,25 @@ class TestDocPerEndDateChk(unittest.TestCase):
             namespaceURI='http://xbrl.sec.gov/dei/2014-01-31',
             segDimValues=mock_more_dims
         )
-        self.fact_end.xValue = mock_edt_off
 
-        self.fact_good1.context = mock_off_context  # fact for 36
-        self.fact_shares.context = mock_off2_context  # fact for 33
+        # fact for 36
+        self.fact_end.xValue = mock_edt_off
+        self.fact_good1.xValue = mock_edt_off2
+        self.fact_good3.xValue = mock_edt_off3
+        self.fact_shares.xValue = mock_edt_off2
+
+        # facts for 33 but niether will fire because 36 fires on fact_end
+        self.fact_good1.context = mock_off2_context
+        self.fact_good3.context = mock_off3_context
+
+        # fact for 33 but won't fire because it is on the exclude list
+        self.fact_shares.context = mock_off2_context
+
         mock_model = mock.Mock(
             facts=[
                 self.fact_good1, self.fact_good2, self.fact_good3,
                 self.fact_bad1, self.fact_bad2, self.fact_bad3,
-                self.fact_end, mock_dped_off
+                self.fact_shares, self.fact_end, mock_dped_off
             ]
         )
 
@@ -345,8 +365,124 @@ class TestDocPerEndDateChk(unittest.TestCase):
         for i in res:
             print('Iiiiiiiii = {}'.format(i))
         # Because 33 shouldn't fire when 36 fires on an LEA axis
-        self.assertEqual(len(res), 2)
+        self.assertEqual(len(res), 5)
     # To Here...
+
+
+    # @mock.patch(
+    #     'dqc_us_rules.dqc_us_0033_0036.dateunionDate',
+    #     side_effect=lambda x, subtractOneDay: x.date()  # noqa
+    # )
+    # def test_33_no_fire_on_lea_that_fires_36(self, moc_func):
+    #     m_qn_one = mock.Mock(
+    #         localName='DocumentPeriodEndDate',
+    #         namespaceURI='http://xbrl.sec.gov/dei/2014-01-31'
+    #     )
+    #     m_qn_two = mock.Mock(
+    #         localName='EntityFilerCategory',
+    #         namespaceURI='http://xbrl.sec.gov/dei/2014-01-31'
+    #     )
+    #     m_qn_three = mock.Mock(
+    #         localName='MockConcept',
+    #         namespaceURI='http://xbrl.sec.gov/dei/2014-01-31'
+    #     )
+    #
+    #     concept_dur1 = mock.Mock(periodType='duration', qname=m_qn_one)
+    #     concept_dur2 = mock.Mock(periodType='duration', qname=m_qn_two)
+    #     concept_dur3 = mock.Mock(periodType='duration', qname=m_qn_three)
+    #
+    #     mock_mem_qn = mock.Mock(localName='foo')
+    #     mock_dim_qn = mock.Mock(localName='LegalEntityAxis')
+    #     mock_dim_dim = mock.Mock(qname=mock_dim_qn)
+    #     mock_member = mock.Mock(qname=mock_mem_qn)
+    #     mock_dim = mock.Mock(
+    #         isExplicit=True, member=mock_member, dimension=mock_dim_dim
+    #     )
+    #     mock_more_dims = mock.Mock()
+    #     mock_more_dims.values.return_value = [mock_dim]
+    #
+    #     mock_date1 = mock.Mock()
+    #     mock_date1.date.return_value = date(year=2015, month=1, day=5)
+    #     mock_date2 = mock.Mock()
+    #     mock_date2.date.return_value = date(year=2015, month=1, day=3)
+    #     mock_date3 = mock.Mock()
+    #     mock_date3.date.return_value = date(year=2015, month=1, day=1)
+    #
+    #     mock_context_one = mock.Mock(
+    #         endDatetime=mock_date1,
+    #         segDimValues=mock_more_dims
+    #     )
+    #     mock_context_two = mock.Mock(
+    #         endDatetime=mock_date2,
+    #         segDimValues=mock_more_dims
+    #     )
+    #     mock_context_three = mock.Mock(
+    #         endDatetime=mock_date3,
+    #         segDimValues=mock_more_dims
+    #     )
+    #
+    #     self.fact_one = mock.Mock(
+    #         concept=concept_dur1, qname=m_qn_one,
+    #         namespaceURI='http://xbrl.sec.gov/dei/2014-01-31',
+    #         context=mock_context_one
+    #     )
+    #     self.fact_two = mock.Mock(
+    #         concept=concept_dur2, qname=m_qn_two,
+    #         namespaceURI='http://xbrl.sec.gov/dei/2014-01-31',
+    #         context=mock_context_two
+    #     )
+    #     self.fact_three = mock.Mock(
+    #         concept=concept_dur3, qname=m_qn_three,
+    #         namespaceURI='http://xbrl.sec.gov/dei/2014-01-31',
+    #         context=mock_context_three
+    #     )
+    #     self.fact_four = mock.Mock(
+    #         concept=concept_dur3, qname=m_qn_three,
+    #         namespaceURI='http://xbrl.sec.gov/dei/2014-01-31',
+    #         context=mock_context_three
+    #     )
+    #     self.fact_five = mock.Mock(
+    #         concept=concept_dur3, qname=m_qn_three,
+    #         namespaceURI='http://xbrl.sec.gov/dei/2014-01-31',
+    #         context=mock_context_three
+    #     )
+    #
+    #     # concept_enddate = mock.Mock(qname=m_qn_one)
+    #     # mock_dped_bad1 = mock.Mock(
+    #     #     context=mock_context_one, xValue=mock_date1,
+    #     #     concept=concept_enddate, qname=m_qn_one,
+    #     #     namespaceURI='http://xbrl.sec.gov/dei/2014-01-31'
+    #     # )
+    #     # mock_dped_bad2 = mock.Mock(
+    #     #     context=mock_context_two, xValue=mock_date2,
+    #     #     concept=concept_enddate, qname=m_qn_one,
+    #     #     namespaceURI='http://xbrl.sec.gov/dei/2014-01-31'
+    #     # )
+    #     # mock_dped_good = mock.Mock(
+    #     #     context=mock_context_three, xValue=mock_date3,
+    #     #     concept=concept_enddate, qname=m_qn_one,
+    #     #     namespaceURI='http://xbrl.sec.gov/dei/2014-01-31'
+    #     # )
+    #
+    #     self.fact_one.xValue = mock_date1
+    #     self.fact_two.xValue = mock_date2
+    #     self.fact_three.xValue = mock_date3
+    #     # self.fact_one.context = mock_context_one
+    #     # self.fact_two.context = mock_context_two
+    #     # self.fact_three.context = mock_context_three
+    #
+    #     mock_model = mock.Mock(
+    #         facts=[
+    #             self.fact_one, self.fact_two, self.fact_three,
+    #             self.fact_four, self.fact_five
+    #         ]
+    #     )
+    #
+    #     res = dqc_us_0033_0036._doc_period_end_date_check(mock_model)
+    #     for i in res:
+    #         print('Iiiiiiiii = {}'.format(i))
+    #     # Because 33 shouldn't fire when 36 fires on an LEA axis
+    #     self.assertEqual(len(res), 2)
 
 
 class TestGetDefaultDped(unittest.TestCase):

--- a/tests/unit_tests/test_dqc_us_0033_0036.py
+++ b/tests/unit_tests/test_dqc_us_0033_0036.py
@@ -279,8 +279,6 @@ class TestDocPerEndDateChk(unittest.TestCase):
             print('Iiiiiiiii = {}'.format(i))
         self.assertEqual(len(res), 2)  # Because both 33 and 36 should fire
 
-
-    # From Here...
     @mock.patch(
         'dqc_us_rules.dqc_us_0033_0036.dateunionDate',
         side_effect=lambda x, subtractOneDay: x.date()  # noqa
@@ -301,8 +299,6 @@ class TestDocPerEndDateChk(unittest.TestCase):
 
         mock_more_dims = mock.Mock()
         mock_more_dims.values.return_value = [mock_dim]
-        mock_segdimvalues = mock.Mock()
-        mock_segdimvalues.values.return_value = []
 
         mock_edt_norm = mock.Mock()
         mock_edt_norm.date.return_value = date(year=2015, month=1, day=1)
@@ -314,14 +310,14 @@ class TestDocPerEndDateChk(unittest.TestCase):
             endDatetime=mock_edt_off, segDimValues=mock_more_dims
         )
 
-        # This will cause 33 to fire
+        # This will cause 33 to fire (except it won't in this test)
         mock_edt_off2 = mock.Mock()
         mock_edt_off2.date.return_value = date(year=2015, month=1, day=3)
         mock_off2_context = mock.Mock(
             endDatetime=mock_edt_off2, segDimValues=mock_more_dims
         )
 
-        # This will cause 33 to fire
+        # This will cause 33 to fire (except it won't in this test)
         mock_edt_off3 = mock.Mock()
         mock_edt_off3.date.return_value = date(year=2015, month=1, day=2)
         mock_off3_context = mock.Mock(
@@ -342,13 +338,13 @@ class TestDocPerEndDateChk(unittest.TestCase):
 
         # fact for 36
         self.fact_end.xValue = mock_edt_off
-        # self.fact_good1.xValue = mock_edt_off2
-        # self.fact_good3.xValue = mock_edt_off3
-        # self.fact_shares.xValue = mock_edt_off2
 
         # facts for 33 but neither will fire because 36 fires on fact_end
         self.fact_good1.context = mock_off2_context
         self.fact_good3.context = mock_off3_context
+
+        # Setting the dimensions on the fact_end fact
+        self.fact_end.context.segDimValues = mock_more_dims
 
         # fact for 33 but won't fire because it is on the exclude list
         self.fact_shares.context = mock_off2_context
@@ -357,16 +353,13 @@ class TestDocPerEndDateChk(unittest.TestCase):
             facts=[
                 self.fact_good1, self.fact_good2, self.fact_good3,
                 self.fact_bad1, self.fact_bad2, self.fact_bad3,
-                self.fact_shares, self.fact_end,  mock_dped_off
+                self.fact_shares, self.fact_end, mock_dped_off
             ]
         )
 
         res = dqc_us_0033_0036._doc_period_end_date_check(mock_model)
-        for i in res:
-            print('Iiiiiiiii = {}'.format(i))
-        # Because 33 shouldn't fire when 36 fires on an LEA axis
-        self.assertEqual(len(res), 5)
-    # To Here...
+        # Only 36 fires because 33 shouldn't fire when 36 fires on a LEA axis
+        self.assertEqual(len(res), 1)
 
 
 class TestGetDefaultDped(unittest.TestCase):

--- a/tests/unit_tests/test_dqc_us_0033_0036.py
+++ b/tests/unit_tests/test_dqc_us_0033_0036.py
@@ -352,76 +352,62 @@ class TestDocPerEndDateChk(unittest.TestCase):
 
     def test_check_for_lea_member(self):
         """
-        HERE>>>>Test to make sure True is returned if when the fact has the legal entity
+        Test to make sure False (so that the check for rule 33 is not hit) is
+        returned when the fact has the legal entity member
         """
         not_valid_dped = ['vault', 'bars', 'foo', 'beam', 'floor', 'boo']
-
-        # ModelInstanceObject has the ModelContext class and the ModelDimensionValue class (the MDV class has the memberQname function)
-        # ModelValue has the Qname class
 
         mock_mem1_qn = mock.Mock(spec=QName)
         mock_mem1_qn.localName = 'foo'
         mock_dim1_qn = mock.Mock(spec=QName)
         mock_dim1_qn.localName = 'LegalEntityAxis'
-        mock_dim1_dim = mock.Mock(spec=ModelDimensionValue, dimensionQname=mock_dim1_qn)
-        mock_member1 = mock.Mock(spec=ModelDimensionValue, memberQname=mock_mem1_qn)
+        mock_dim1_dim = mock.Mock(
+            spec=ModelDimensionValue, dimensionQname=mock_dim1_qn
+        )
         mock_dimension1 = mock.Mock(
-            spec=ModelDimensionValue, isExplicit=True, member=mock_member1, dimension=mock_dim1_dim
+            spec=ModelDimensionValue, isExplicit=True,
+            memberQname=mock_mem1_qn, dimension=mock_dim1_dim
         )
 
         mock_mem2_qn = mock.Mock(spec=QName)
-        mock_mem2_qn.localName = 'boo'
+        mock_mem2_qn.localName = 'moo'
         mock_dim2_qn = mock.Mock(spec=QName)
         mock_dim2_qn.localName = 'Scenario'
-        mock_dim2_dim = mock.Mock(spec=ModelDimensionValue, dimensionQname=mock_dim2_qn)
-        mock_member2 = mock.Mock(spec=ModelDimensionValue, memberQname=mock_mem2_qn)
-        mock_dimension2 = mock.Mock(
-            spec=ModelDimensionValue, isExplicit=True, member=mock_member2, dimension=mock_dim2_dim
+        mock_dim2_dim = mock.Mock(
+            spec=ModelDimensionValue, dimensionQname=mock_dim2_qn
         )
-
-        mock_mem3_qn = mock.Mock(spec=QName)
-        mock_mem3_qn.localName = 'moo'
-        mock_dim3_qn = mock.Mock(localName='LegalEntityAxis')
-        mock_dim3_dim = mock.Mock(spec=ModelDimensionValue, dimensionQname=mock_dim3_qn)
-        mock_member3 = mock.Mock(spec=ModelDimensionValue, memberQname=mock_mem3_qn)
-        mock_dimension3 = mock.Mock(
-            spec=ModelDimensionValue, isExplicit=True, member=mock_member3, dimension=mock_dim3_dim
+        mock_dimension2 = mock.Mock(
+            spec=ModelDimensionValue, isExplicit=True,
+            memberQname=mock_mem2_qn, dimension=mock_dim2_dim
         )
 
         mock_more_dims1 = {mock_dim1_dim: mock_dimension1}
         mock_more_dims2 = {mock_dim2_dim: mock_dimension2}
-        mock_more_dims3 = {mock_dim3_dim: mock_dimension3}
         mock_no_dimensions = {}
 
-        mock_context1 = mock.Mock(spec=ModelXbrl, segDimValues=mock_more_dims1)
-        mock_context2 = mock.Mock(spec=ModelXbrl, segDimValues=mock_more_dims2)
-        mock_context3 = mock.Mock(spec=ModelXbrl, segDimValues=mock_more_dims3)
-        mock_context4 = mock.Mock(spec=ModelXbrl, segDimValues=mock_no_dimensions)
-
-        print('mock_context4 = {}'.format(mock_no_dimensions))
+        mock_context1 = mock.Mock(
+            spec=ModelXbrl, segDimValues=mock_more_dims1
+        )
+        mock_context2 = mock.Mock(
+            spec=ModelXbrl, segDimValues=mock_more_dims2
+        )
+        mock_context3 = mock.Mock(
+            spec=ModelXbrl, segDimValues=mock_no_dimensions
+        )
 
         self.fact_one = mock.Mock(spec=ModelFact, context=mock_context1)
         self.fact_two = mock.Mock(spec=ModelFact, context=mock_context2)
         self.fact_three = mock.Mock(spec=ModelFact, context=mock_context3)
-        self.fact_four = mock.Mock(spec=ModelFact, context=mock_context4)
 
-        print('fact_one = {}'.format(self.fact_one))
-        print('fact_four = {}'.format(self.fact_four))
-
-        result1 = (dqc_us_0033_0036.check_for_lea_member(self.fact_one, not_valid_dped))
-        result2 = (dqc_us_0033_0036.check_for_lea_member(self.fact_two, not_valid_dped))
-        result3 = (dqc_us_0033_0036.check_for_lea_member(self.fact_three, not_valid_dped))
-        result4 = (dqc_us_0033_0036.check_for_lea_member(self.fact_four, not_valid_dped))
-
-        print('result1 = {}'.format(result1))
-        print('result2 = {}'.format(result2))
-        print('result3 = {}'.format(result3))
-        print('result4 = {}'.format(result4))
-
-        self.assertFalse(dqc_us_0033_0036.check_for_lea_member(self.fact_one, not_valid_dped))
-        self.assertTrue(dqc_us_0033_0036.check_for_lea_member(self.fact_two, not_valid_dped))
-        self.assertTrue(dqc_us_0033_0036.check_for_lea_member(self.fact_three, not_valid_dped))
-        self.assertTrue(dqc_us_0033_0036.check_for_lea_member(self.fact_four, not_valid_dped))
+        self.assertFalse(dqc_us_0033_0036.check_for_lea_member(
+            self.fact_one, not_valid_dped
+        ))
+        self.assertTrue(dqc_us_0033_0036.check_for_lea_member(
+            self.fact_two, not_valid_dped
+        ))
+        self.assertTrue(dqc_us_0033_0036.check_for_lea_member(
+            self.fact_three, not_valid_dped
+        ))
 
 
 

--- a/tests/unit_tests/test_dqc_us_0033_0036.py
+++ b/tests/unit_tests/test_dqc_us_0033_0036.py
@@ -342,11 +342,11 @@ class TestDocPerEndDateChk(unittest.TestCase):
 
         # fact for 36
         self.fact_end.xValue = mock_edt_off
-        self.fact_good1.xValue = mock_edt_off2
-        self.fact_good3.xValue = mock_edt_off3
-        self.fact_shares.xValue = mock_edt_off2
+        # self.fact_good1.xValue = mock_edt_off2
+        # self.fact_good3.xValue = mock_edt_off3
+        # self.fact_shares.xValue = mock_edt_off2
 
-        # facts for 33 but niether will fire because 36 fires on fact_end
+        # facts for 33 but neither will fire because 36 fires on fact_end
         self.fact_good1.context = mock_off2_context
         self.fact_good3.context = mock_off3_context
 
@@ -357,7 +357,7 @@ class TestDocPerEndDateChk(unittest.TestCase):
             facts=[
                 self.fact_good1, self.fact_good2, self.fact_good3,
                 self.fact_bad1, self.fact_bad2, self.fact_bad3,
-                self.fact_shares, self.fact_end, mock_dped_off
+                self.fact_shares, self.fact_end,  mock_dped_off
             ]
         )
 
@@ -367,122 +367,6 @@ class TestDocPerEndDateChk(unittest.TestCase):
         # Because 33 shouldn't fire when 36 fires on an LEA axis
         self.assertEqual(len(res), 5)
     # To Here...
-
-
-    # @mock.patch(
-    #     'dqc_us_rules.dqc_us_0033_0036.dateunionDate',
-    #     side_effect=lambda x, subtractOneDay: x.date()  # noqa
-    # )
-    # def test_33_no_fire_on_lea_that_fires_36(self, moc_func):
-    #     m_qn_one = mock.Mock(
-    #         localName='DocumentPeriodEndDate',
-    #         namespaceURI='http://xbrl.sec.gov/dei/2014-01-31'
-    #     )
-    #     m_qn_two = mock.Mock(
-    #         localName='EntityFilerCategory',
-    #         namespaceURI='http://xbrl.sec.gov/dei/2014-01-31'
-    #     )
-    #     m_qn_three = mock.Mock(
-    #         localName='MockConcept',
-    #         namespaceURI='http://xbrl.sec.gov/dei/2014-01-31'
-    #     )
-    #
-    #     concept_dur1 = mock.Mock(periodType='duration', qname=m_qn_one)
-    #     concept_dur2 = mock.Mock(periodType='duration', qname=m_qn_two)
-    #     concept_dur3 = mock.Mock(periodType='duration', qname=m_qn_three)
-    #
-    #     mock_mem_qn = mock.Mock(localName='foo')
-    #     mock_dim_qn = mock.Mock(localName='LegalEntityAxis')
-    #     mock_dim_dim = mock.Mock(qname=mock_dim_qn)
-    #     mock_member = mock.Mock(qname=mock_mem_qn)
-    #     mock_dim = mock.Mock(
-    #         isExplicit=True, member=mock_member, dimension=mock_dim_dim
-    #     )
-    #     mock_more_dims = mock.Mock()
-    #     mock_more_dims.values.return_value = [mock_dim]
-    #
-    #     mock_date1 = mock.Mock()
-    #     mock_date1.date.return_value = date(year=2015, month=1, day=5)
-    #     mock_date2 = mock.Mock()
-    #     mock_date2.date.return_value = date(year=2015, month=1, day=3)
-    #     mock_date3 = mock.Mock()
-    #     mock_date3.date.return_value = date(year=2015, month=1, day=1)
-    #
-    #     mock_context_one = mock.Mock(
-    #         endDatetime=mock_date1,
-    #         segDimValues=mock_more_dims
-    #     )
-    #     mock_context_two = mock.Mock(
-    #         endDatetime=mock_date2,
-    #         segDimValues=mock_more_dims
-    #     )
-    #     mock_context_three = mock.Mock(
-    #         endDatetime=mock_date3,
-    #         segDimValues=mock_more_dims
-    #     )
-    #
-    #     self.fact_one = mock.Mock(
-    #         concept=concept_dur1, qname=m_qn_one,
-    #         namespaceURI='http://xbrl.sec.gov/dei/2014-01-31',
-    #         context=mock_context_one
-    #     )
-    #     self.fact_two = mock.Mock(
-    #         concept=concept_dur2, qname=m_qn_two,
-    #         namespaceURI='http://xbrl.sec.gov/dei/2014-01-31',
-    #         context=mock_context_two
-    #     )
-    #     self.fact_three = mock.Mock(
-    #         concept=concept_dur3, qname=m_qn_three,
-    #         namespaceURI='http://xbrl.sec.gov/dei/2014-01-31',
-    #         context=mock_context_three
-    #     )
-    #     self.fact_four = mock.Mock(
-    #         concept=concept_dur3, qname=m_qn_three,
-    #         namespaceURI='http://xbrl.sec.gov/dei/2014-01-31',
-    #         context=mock_context_three
-    #     )
-    #     self.fact_five = mock.Mock(
-    #         concept=concept_dur3, qname=m_qn_three,
-    #         namespaceURI='http://xbrl.sec.gov/dei/2014-01-31',
-    #         context=mock_context_three
-    #     )
-    #
-    #     # concept_enddate = mock.Mock(qname=m_qn_one)
-    #     # mock_dped_bad1 = mock.Mock(
-    #     #     context=mock_context_one, xValue=mock_date1,
-    #     #     concept=concept_enddate, qname=m_qn_one,
-    #     #     namespaceURI='http://xbrl.sec.gov/dei/2014-01-31'
-    #     # )
-    #     # mock_dped_bad2 = mock.Mock(
-    #     #     context=mock_context_two, xValue=mock_date2,
-    #     #     concept=concept_enddate, qname=m_qn_one,
-    #     #     namespaceURI='http://xbrl.sec.gov/dei/2014-01-31'
-    #     # )
-    #     # mock_dped_good = mock.Mock(
-    #     #     context=mock_context_three, xValue=mock_date3,
-    #     #     concept=concept_enddate, qname=m_qn_one,
-    #     #     namespaceURI='http://xbrl.sec.gov/dei/2014-01-31'
-    #     # )
-    #
-    #     self.fact_one.xValue = mock_date1
-    #     self.fact_two.xValue = mock_date2
-    #     self.fact_three.xValue = mock_date3
-    #     # self.fact_one.context = mock_context_one
-    #     # self.fact_two.context = mock_context_two
-    #     # self.fact_three.context = mock_context_three
-    #
-    #     mock_model = mock.Mock(
-    #         facts=[
-    #             self.fact_one, self.fact_two, self.fact_three,
-    #             self.fact_four, self.fact_five
-    #         ]
-    #     )
-    #
-    #     res = dqc_us_0033_0036._doc_period_end_date_check(mock_model)
-    #     for i in res:
-    #         print('Iiiiiiiii = {}'.format(i))
-    #     # Because 33 shouldn't fire when 36 fires on an LEA axis
-    #     self.assertEqual(len(res), 2)
 
 
 class TestGetDefaultDped(unittest.TestCase):

--- a/tests/unit_tests/test_dqc_us_0033_0036.py
+++ b/tests/unit_tests/test_dqc_us_0033_0036.py
@@ -75,8 +75,7 @@ class TestDocPerEndDateChk(unittest.TestCase):
         concept_enddate = mock.Mock(qname=m_qn_bad3)
         mock_edt_norm = mock.Mock()
         mock_edt_norm.date.return_value = date(year=2015, month=1, day=1)
-        mock_segdimvalues = mock.Mock()
-        mock_segdimvalues.values.return_value = []
+        mock_segdimvalues = {}
         mock_context = mock.Mock(
             endDatetime=mock_edt_norm, segDimValues=mock_segdimvalues
         )
@@ -157,13 +156,13 @@ class TestDocPerEndDateChk(unittest.TestCase):
         Tests _doc_period_end_date_check to see of the length is right and that
         it returns the correct values
         """
-        mock_segdimvalues = mock.Mock()
-        mock_segdimvalues.values.return_value = []
+        mock_segdimvalues = {}
         mock_edt_norm = mock.Mock()
         mock_edt_norm.date.return_value = date(year=2015, month=1, day=1)
         mock_dped_context = mock.Mock(
             endDatetime=mock_edt_norm, segDimValues=mock_segdimvalues
         )
+
         mock_edt_off = mock.Mock()
         mock_edt_off.date.return_value = date(year=2015, month=2, day=1)
         self.fact_end.context = mock_dped_context
@@ -190,8 +189,7 @@ class TestDocPerEndDateChk(unittest.TestCase):
         """
         Tests _doc_period_end_date_check when it should return an error
         """
-        mock_segdimvalues = mock.Mock()
-        mock_segdimvalues.values.return_value = []
+        mock_segdimvalues = {}
         mock_edt_norm = mock.Mock()
         mock_edt_norm.date.return_value = date(year=2015, month=1, day=1)
         mock_edt_off = mock.Mock()
@@ -222,18 +220,7 @@ class TestDocPerEndDateChk(unittest.TestCase):
         Tests _doc_period_end_date_check when it should return a warning and an
         error
         """
-        mock_mem_qn = mock.Mock(localName='foo')
-        mock_dim_qn = mock.Mock(localName='LegalEntityAxis')
-        mock_dim_dim = mock.Mock(qname=mock_dim_qn)
-        mock_member = mock.Mock(qname=mock_mem_qn)
-        mock_dim = mock.Mock(
-            isExplicit=True, member=mock_member, dimension=mock_dim_dim
-        )
-
-        mock_more_dims = mock.Mock()
-        mock_more_dims.values.return_value = [mock_dim]
-        mock_segdimvalues = mock.Mock()
-        mock_segdimvalues.values.return_value = []
+        mock_segdimvalues = {}
 
         mock_edt_norm = mock.Mock()
         mock_edt_norm.date.return_value = date(year=2015, month=1, day=1)
@@ -295,8 +282,7 @@ class TestDocPerEndDateChk(unittest.TestCase):
             isExplicit=True, member=mock_member, dimension=mock_dim_dim
         )
 
-        mock_more_dims = mock.Mock()
-        mock_more_dims.values.return_value = [mock_dim]
+        mock_more_dims = {mock_dim_dim: mock_dim}
 
         mock_edt_norm = mock.Mock()
         mock_edt_norm.date.return_value = date(year=2015, month=1, day=1)

--- a/tests/unit_tests/test_dqc_us_0033_0036.py
+++ b/tests/unit_tests/test_dqc_us_0033_0036.py
@@ -275,8 +275,6 @@ class TestDocPerEndDateChk(unittest.TestCase):
         )
 
         res = dqc_us_0033_0036._doc_period_end_date_check(mock_model)
-        for i in res:
-            print('Iiiiiiiii = {}'.format(i))
         self.assertEqual(len(res), 2)  # Because both 33 and 36 should fire
 
     @mock.patch(
@@ -287,7 +285,7 @@ class TestDocPerEndDateChk(unittest.TestCase):
         """
         Tests _doc_period_end_date_check to ensure that facts that should fire
         rule 33 do not if rule 36 fires on a Legal Entity Axis and the rule 33
-        facts have a member of the Legal Entity Axis
+        facts the member of the Legal Entity Axis
         """
         mock_mem_qn = mock.Mock(localName='foo')
         mock_dim_qn = mock.Mock(localName='LegalEntityAxis')
@@ -310,14 +308,16 @@ class TestDocPerEndDateChk(unittest.TestCase):
             endDatetime=mock_edt_off, segDimValues=mock_more_dims
         )
 
-        # This will cause 33 to fire (except it won't in this test)
+        # This will cause 33 to fire (except it won't in this test as per the
+        # reason noted in the docstring)
         mock_edt_off2 = mock.Mock()
         mock_edt_off2.date.return_value = date(year=2015, month=1, day=3)
         mock_off2_context = mock.Mock(
             endDatetime=mock_edt_off2, segDimValues=mock_more_dims
         )
 
-        # This will cause 33 to fire (except it won't in this test)
+        # This will cause 33 to fire (except it won't in this test as per the
+        # reason noted in the docstring)
         mock_edt_off3 = mock.Mock()
         mock_edt_off3.date.return_value = date(year=2015, month=1, day=2)
         mock_off3_context = mock.Mock(


### PR DESCRIPTION
##### Pull request for: [XS-3076](https://jira.webfilings.com/browse/XS-3076)
[XS-3076](https://jira.webfilings.com/browse/XS-3076) - DQC 33_36 seems to have an incorrect calculation

-
#### Changes:
- Modified _doc_period_end_date_check() in dqc_us_0033_0036.py:
1.  To check for LEA/member by checking the dimensions rather than contextID
2.  To fire rule 33 if the date is within three days (+/- 3 days) of the DPED rather than if it is outside of the three days as it was previously configured to do

- Added a unit test to test that rule 33 does not fire when rule 36 fires on a LEA if the rule 33 fact contains the LEA/member

####Testing:
- I have included a project and filing documents to use in testing.  The filing documents should fire one 33 and one 36 error in arelle

-
Please review: @jasonleinbach-wf @chrislococo-wf @andrewperkins-wf @brianmyers-wf @bradbenjamin-wf @derekgengenbacher-wf
