### PR TITLE
XS-3091 DQC Rule 1 Needs All Facts

### DIFF
--- a/dqc_us_rules/dqc_us_0001.py
+++ b/dqc_us_rules/dqc_us_0001.py
@@ -118,12 +118,12 @@ def _run_member_checks(axis, axis_config, relset, val, role):
         for child in _all_members_under(axis, relset):
             if ((not _is_extension(child, val) and
                  child.qname.localName in disallowed_children)):
-                fact = facts.axis_member_fact(
+                fact_list = facts.axis_member_fact(
                     axis.qname.localName,
                     child.qname.localName,
                     val.modelXbrl
                 )
-                if fact is not None:
+                if len(fact_list) != 0:
                     val.modelXbrl.error(
                         '{base_key}.{extension_key}'.format(
                             base_key=_CODE_NAME,
@@ -132,7 +132,7 @@ def _run_member_checks(axis, axis_config, relset, val, role):
                         messages.get_message(_CODE_NAME, _UGT_FACT_KEY),
                         axis=axis.label(),
                         member=child.label(),
-                        modelObject=fact,
+                        modelObject=fact_list,
                         ruleVersion=_RULE_VERSION
                     )
                 else:

--- a/dqc_us_rules/dqc_us_0001.py
+++ b/dqc_us_rules/dqc_us_0001.py
@@ -152,12 +152,12 @@ def _run_member_checks(axis, axis_config, relset, val, role):
         for child in _all_members_under(axis, relset):
             if ((not _is_extension(child, val) and
                  child.qname.localName not in allowed_children)):
-                fact = facts.axis_member_fact(
+                fact_list = facts.axis_member_fact(
                     axis.qname.localName,
                     child.qname.localName,
                     val.modelXbrl
                 )
-                if fact is not None:
+                if len(fact_list) != 0:
                     val.modelXbrl.error(
                         '{base_key}.{extension_key}'.format(
                             base_key=_CODE_NAME,
@@ -166,7 +166,7 @@ def _run_member_checks(axis, axis_config, relset, val, role):
                         messages.get_message(_CODE_NAME, _UGT_FACT_KEY),
                         axis=axis.label(),
                         member=child.label(),
-                        modelObject=fact,
+                        modelObject=fact_list,
                         ruleVersion=_RULE_VERSION
                     )
                 else:

--- a/dqc_us_rules/dqc_us_0006.py
+++ b/dqc_us_rules/dqc_us_0006.py
@@ -161,7 +161,7 @@ __pluginInfo__ = {
     'version': _RULE_VERSION,
     'description': (
         'Checks all of the specified types and concepts for their date '
-        'ranges to verify the ranges are within expected paramters for the '
+        'ranges to verify the ranges are within expected parameters for the '
         'fiscal periods'
     ),
     # Mount points

--- a/dqc_us_rules/util/facts.py
+++ b/dqc_us_rules/util/facts.py
@@ -356,7 +356,7 @@ def axis_member_fact(axis_name, member_name, model_xbrl):
             for dim in dims:
                 if dim.dimension.qname.localName == axis_name:
                     fact_list.append(fact)
-                    return fact_list
+            return fact_list
     return None
 
 

--- a/dqc_us_rules/util/facts.py
+++ b/dqc_us_rules/util/facts.py
@@ -342,6 +342,7 @@ def axis_member_fact(axis_name, member_name, model_xbrl):
     :return: The fact found or None
     :rtype: :class:'~arelle.InstanceModelObject.ModelFact' or None
     """
+    fact_list = []
     for fact in model_xbrl.facts:
         if _fact_components_valid(fact):
             dims = [
@@ -352,12 +353,10 @@ def axis_member_fact(axis_name, member_name, model_xbrl):
                     dim.member.qname.localName == member_name
                 )
             ]
-            fact_list = []
             for dim in dims:
                 if dim.dimension.qname.localName == axis_name:
                     fact_list.append(fact)
-            return fact_list
-    return None
+    return fact_list
 
 
 def _fact_components_valid(fact):

--- a/dqc_us_rules/util/facts.py
+++ b/dqc_us_rules/util/facts.py
@@ -352,9 +352,11 @@ def axis_member_fact(axis_name, member_name, model_xbrl):
                     dim.member.qname.localName == member_name
                 )
             ]
+            fact_list = []
             for dim in dims:
                 if dim.dimension.qname.localName == axis_name:
-                    return fact
+                    fact_list.append(fact)
+                    return fact_list
     return None
 
 

--- a/tests/unit_tests/test_dqc_us_0001.py
+++ b/tests/unit_tests/test_dqc_us_0001.py
@@ -72,7 +72,7 @@ class TestMemberChecks(unittest.TestCase):
 
     @patch(
         'dqc_us_rules.dqc_us_0001.facts.axis_member_fact',
-        return_value=None
+        return_value=[]
     )
     @patch('dqc_us_rules.dqc_us_0001._is_extension', return_value=False)
     @patch('dqc_us_rules.dqc_us_0001._all_members_under')
@@ -159,7 +159,7 @@ class TestMemberChecks(unittest.TestCase):
         Tests the excluded list with an associated fact.
         """
         mock_fact = Mock()
-        fact.return_value = mock_fact
+        fact.return_value = [mock_fact]
         mock_error_func = Mock()
         mock_model_xbrl = Mock(error=mock_error_func)
         mock_val = Mock(modelXbrl=mock_model_xbrl)
@@ -192,7 +192,7 @@ class TestMemberChecks(unittest.TestCase):
             ),
             axis=mock_axis.label(),
             member=mock_child.label(),
-            modelObject=mock_fact,
+            modelObject=[mock_fact],
             ruleVersion=dqc_us_0001._RULE_VERSION
         )
 

--- a/tests/unit_tests/test_dqc_us_0001.py
+++ b/tests/unit_tests/test_dqc_us_0001.py
@@ -204,7 +204,7 @@ class TestMemberChecks(unittest.TestCase):
         Tests the additional axis inclusions with a fact.
         """
         mock_fact = Mock()
-        fact.return_value = mock_fact
+        fact.return_value = [mock_fact]
         mock_error_func = Mock()
         mock_model_xbrl = Mock(error=mock_error_func)
         mock_val = Mock(modelXbrl=mock_model_xbrl)
@@ -237,13 +237,13 @@ class TestMemberChecks(unittest.TestCase):
             ),
             axis=mock_axis.label(),
             member=mock_child.label(),
-            modelObject=mock_fact,
+            modelObject=[mock_fact],
             ruleVersion=dqc_us_0001._RULE_VERSION
         )
 
     @patch(
         'dqc_us_rules.dqc_us_0001.facts.axis_member_fact',
-        return_value=None
+        return_value=[]
     )
     @patch('dqc_us_rules.dqc_us_0001._is_extension', return_value=False)
     @patch('dqc_us_rules.dqc_us_0001._all_members_under')

--- a/tests/unit_tests/test_dqc_us_0005.py
+++ b/tests/unit_tests/test_dqc_us_0005.py
@@ -259,5 +259,6 @@ class TestDeiChecks(unittest.TestCase):
             facts=[mock_doc_type_fact],
             nameConcepts=mock_name_concepts
         )
-        dqc_us_0005.validate_facts(self.mock_model)
+        mock_val = Mock(modelXbrl=self.mock_model)
+        dqc_us_0005.validate_facts(mock_val)
         self.assertFalse(get_end_of_period.called)

--- a/tests/unit_tests/util/test_facts.py
+++ b/tests/unit_tests/util/test_facts.py
@@ -816,13 +816,13 @@ class TestAllFactsUnder(unittest.TestCase):
             dimension=mock_dimension,
             isExplicit=True
         )
-        segDimValues = {'1': mock_dim, '2': mock_dim}
+        segDimValues = {'1': mock_dim}
         mock_context = Mock(segDimValues=segDimValues)
         mock_fact = Mock(context=mock_context)
         mock_modelxbrl = Mock(facts=[mock_fact])
         self.assertEqual(
             fact_lib.axis_member_fact('bar', 'foo', mock_modelxbrl),
-            mock_fact
+            [mock_fact]
         )
 
         mock_qname3 = Mock(localName="NOPE")
@@ -838,5 +838,5 @@ class TestAllFactsUnder(unittest.TestCase):
         mock_modelxbrl = Mock(facts=[mock_fact])
         self.assertEqual(
             fact_lib.axis_member_fact('bar', 'foo', mock_modelxbrl),
-            None
+            []
         )


### PR DESCRIPTION
##### Pull request for: [XS-3091](https://jira.webfilings.com/browse/XS-3091)
[XS-3091](https://jira.webfilings.com/browse/XS-3091) - DQC Rule 1 Needs All Facts

-
#### Changes:
- Changes to dqc_us_0001.py and /utils.facts.py to fix rule 1 so that all facts are used instead of a single fact
- Changes to test_dqc_us_0001.py to fix the unit tests that broke due to the abovementioned changes
- Changes to test_dqc_us_0005.py to fix a broken unit test.  This test was broke from the work in XS-3078 but was not caught in dev or QA during the work and testing for that ticket.

#### Testing:
- I have attached the doc to use for testing.  The doc was the doc used to test this rule when it was first implemented (XS-3026) and should fire DQC 1 five times.  Additionally, follow the testing suggestion noted in the description of the ticket.  

-
Please review: @jasonleinbach-wf @chrislococo-wf @andrewperkins-wf @brianmyers-wf @bradbenjamin-wf @derekgengenbacher-wf
