### PR TITLE
XS-3139: Removed unneeded info from 0001 error messages.

### DIFF
--- a/dqc_us_rules/util/message_info.json
+++ b/dqc_us_rules/util/message_info.json
@@ -63,9 +63,9 @@
         "default": "The dimension default defined for the axis in the US GAAP taxonomy should not be changed in a company extension taxonomy. The default for the ${axis_name} in the base taxonomy is ${axis_default_name}, but the default has been replaced with ${def_name}."
         },
     "DQC.US.0001": {
-        "default": "The extension member, ${member}  is used on the axis ${axis} with the element ${fact1.label} with a value of ${fact1.value}.  Extension members should not be used with the ${axis}\nThe properties of this ${fact1.name} fact are:\nPeriod: ${fact1.period}\nDimensions: ${fact1.dimensions}\nUnit: ${fact1.unit}\nRule version: ${ruleVersion}",
-        "ext_fact": "The extension member, ${member}  is used on the axis ${axis} with the element ${fact1.label} with a value of ${fact1.value}.  Extension members should not be used with the ${axis}\nThe properties of this ${fact1.name} fact are:\nPeriod: ${fact1.period}\nDimensions: ${fact1.dimensions}\nUnit: ${fact1.unit}\nRule version: ${ruleVersion}",
-        "ugt_fact": "The member, ${member} is used on the axis ${axis} with the element ${fact1.label} with a value of ${fact1.value}.  This member should not be used with the ${axis}.\n\nThe properties of this ${fact1.name} fact are:\nPeriod: ${fact1.period}\nDimensions: ${fact1.dimensions}\nUnit: ${fact1.unit}\nRule version: ${ruleVersion}",
+        "default": "The extension member, ${member}  is used on the axis ${axis} with the element ${fact1.label}.  Extension members should not be used with the ${axis}\nThe properties of this ${fact1.name} fact are:\nPeriod: ${fact1.period}\nDimensions: ${fact1.dimensions}\nRule version: ${ruleVersion}",
+        "ext_fact": "The extension member, ${member}  is used on the axis ${axis} with the element ${fact1.label}.  Extension members should not be used with the ${axis}\nThe properties of this ${fact1.name} fact are:\nPeriod: ${fact1.period}\nDimensions: ${fact1.dimensions}\nRule version: ${ruleVersion}",
+        "ugt_fact": "The member, ${member} is used on the axis ${axis} with the element ${fact1.label}.  This member should not be used with the ${axis}.\n\nThe properties of this ${fact1.name} fact are:\nPeriod: ${fact1.period}\nDimensions: ${fact1.dimensions}\nRule version: ${ruleVersion}",
         "no_fact": "The member, ${member}, is used on the axis, ${axis} in the disclosure group ${group}. There are no facts associated with this member and axis.  Extension members should not be used with the ${axis.label}.\nRule version: ${ruleVersion}"
     }
 }


### PR DESCRIPTION
#### Changes:

- Updated 0001's error message to be congruent with the format described here https://github.com/DataQualityCommittee/dqc_us_rules/pull/146
- This means that unit and value were removed, as they were accurate for only one of potentially many results for a DQC-0001 error.

Please review: @hefischer  @andrewperkins-wf