### PR TITLE
XS-3198: Fix handling for deprecated items on facts - report the actual deprecated item.

### DIFF
--- a/dqc_us_rules/dqc_us_0018.py
+++ b/dqc_us_rules/dqc_us_0018.py
@@ -287,8 +287,9 @@ def _fact_uses_deprecated_item(val, fact):
     :type val: :class:'~arelle.ValidateXbrl.ValidateXbrl'
     :param fact: Fact to check
     :type fact: :class:'~arelle.ModelInstanceObject.ModelFact'
-    :return: Returns true if fact uses deprecated item
-    :rtype: False
+    :return: Returns true if fact uses deprecated item,
+        as well as the item's name.
+    :rtype: tuple(bool, str)
     """
 
     if _fact_checkable(fact):

--- a/dqc_us_rules/dqc_us_0018.py
+++ b/dqc_us_rules/dqc_us_0018.py
@@ -293,14 +293,15 @@ def _fact_uses_deprecated_item(val, fact):
 
     if _fact_checkable(fact):
         if _deprecated_concept(val, fact.concept):
-            return True
+            return True, fact.concept.name
 
         if fact.isItem:
             for dimConcept, modelDim in fact.context.segDimValues.items():
-                if ((_deprecated_concept(val, dimConcept) or
-                     _deprecated_dimension(val, modelDim))):
-                    return True
-    return False
+                if _deprecated_concept(val, dimConcept):
+                    return True, dimConcept.name
+                elif _deprecated_dimension(val, modelDim):
+                    return True, modelDim.name
+    return False, None
 
 
 def _catch_deprecated_fact_errors(val, deprecated_concepts):
@@ -313,10 +314,11 @@ def _catch_deprecated_fact_errors(val, deprecated_concepts):
     :rype: None
     """
     for fact in val.modelXbrl.facts:
-        if _fact_uses_deprecated_item(val, fact):
-            if not deprecated_concepts.get(fact.concept.name):
-                deprecated_concepts[fact.concept.name] = []
-            deprecated_concepts[fact.concept.name].append(fact)
+        fire, item = _fact_uses_deprecated_item(val, fact)
+        if fire:
+            if not deprecated_concepts.get(item):
+                deprecated_concepts[item] = []
+            deprecated_concepts[item].append(fact)
 
 
 __pluginInfo__ = {

--- a/dqc_us_rules/dqc_us_0018.py
+++ b/dqc_us_rules/dqc_us_0018.py
@@ -299,8 +299,8 @@ def _fact_uses_deprecated_item(val, fact):
             for dimConcept, modelDim in fact.context.segDimValues.items():
                 if _deprecated_concept(val, dimConcept):
                     return True, dimConcept.name
-                elif _deprecated_dimension(val, modelDim):
-                    return True, modelDim.name
+                elif _deprecated_dimension(val, modelDim.dimension):
+                    return True, modelDim.dimension.name
     return False, None
 
 

--- a/tests/unit_tests/test_dqc_us_0018.py
+++ b/tests/unit_tests/test_dqc_us_0018.py
@@ -114,7 +114,7 @@ class TestCompareFacts(unittest.TestCase):
            )
         )
 
-    def test_fact_uses_deprecated_item(self):
+    def test_fact_uses_deprecated_item_concept(self):
         """
         Tests to make sure that fact errors it it contains a deprecated member
         """
@@ -132,6 +132,80 @@ class TestCompareFacts(unittest.TestCase):
         context.segDimValues = {}
 
         fact = mock.Mock(concept=dep_concept, context=context)
+
+        fire, item = dqc_us_0018._fact_uses_deprecated_item(
+            val,
+            fact
+        )
+
+        self.assertTrue(fire)
+        self.assertEqual(item, 'old')
+
+    def test_fact_uses_deprecated_item_dimconcept(self):
+        """
+        Tests to make sure that fact errors it it contains a deprecated member
+        """
+        val = mock.Mock()
+        gaapDeps = {}
+        gaapDeps['old'] = (
+             "Element was deprecated. Possible replacement is "
+             "new."
+        )
+        val.usgaapDeprecations = gaapDeps
+        dep_concept = mock.Mock(spec=ModelConcept)
+        dep_concept.name = 'old'
+
+        good_concept = mock.Mock(spec=ModelConcept)
+        good_concept.name = 'trey'
+
+        context = mock.Mock()
+        context.segDimValues = {
+            dep_concept: mock.Mock()
+        }
+
+        fact = mock.Mock(
+            concept=good_concept,
+            context=context,
+            isItem=True
+        )
+
+        fire, item = dqc_us_0018._fact_uses_deprecated_item(
+            val,
+            fact
+        )
+
+        self.assertTrue(fire)
+        self.assertEqual(item, 'old')
+
+    def test_fact_uses_deprecated_item_dimvalue(self):
+        """
+        Tests to make sure that fact errors it it contains a deprecated member
+        """
+        val = mock.Mock()
+        gaapDeps = {}
+        gaapDeps['old'] = (
+             "Element was deprecated. Possible replacement is "
+             "new."
+        )
+        val.usgaapDeprecations = gaapDeps
+        dep_concept = mock.Mock(spec=ModelConcept)
+        dep_concept.name = 'old'
+
+        good_concept = mock.Mock(spec=ModelConcept)
+        good_concept.name = 'trey'
+
+        dep_dim = mock.Mock(dimension=dep_concept)
+
+        context = mock.Mock()
+        context.segDimValues = {
+            good_concept: dep_dim
+        }
+
+        fact = mock.Mock(
+            concept=good_concept,
+            context=context,
+            isItem=True
+        )
 
         fire, item = dqc_us_0018._fact_uses_deprecated_item(
             val,

--- a/tests/unit_tests/test_dqc_us_0018.py
+++ b/tests/unit_tests/test_dqc_us_0018.py
@@ -114,6 +114,33 @@ class TestCompareFacts(unittest.TestCase):
            )
         )
 
+    def test_fact_uses_deprecated_item(self):
+        """
+        Tests to make sure that fact errors it it contains a deprecated member
+        """
+        val = mock.Mock()
+        gaapDeps = {}
+        gaapDeps['old'] = (
+             "Element was deprecated. Possible replacement is "
+             "new."
+        )
+        val.usgaapDeprecations = gaapDeps
+        dep_concept = mock.Mock(spec=ModelConcept)
+        dep_concept.name = 'old'
+
+        context = mock.Mock()
+        context.segDimValues = {}
+
+        fact = mock.Mock(concept=dep_concept, context=context)
+
+        fire, item = dqc_us_0018._fact_uses_deprecated_item(
+            val,
+            fact
+        )
+
+        self.assertTrue(fire)
+        self.assertEqual(item, 'old')
+
     def test_catch_linkbase_deprecated_errors(self):
         """
         Tests for deprecated concepts in relationships


### PR DESCRIPTION
#### Changes:

- Changed the way we're handling the dimension objects returned from SegDimValues' values.  They're never modelConcepts, so our dimension check was useless.  Changed that to actual check on the ModelDimensionValue.dimension, which is its concept.
- When checking if a fact uses deprecated items, return the item if it's illegal.  We were previously always reporting fact.concept instead of the deprecated dimensionality item.
- Update tests.

Please review: @hefischer  @andrewperkins-wf