### PR TITLE
XS-3228 - dqc_us_rules.exception:AttributeError occurring in spiceweasel runs

### DIFF
--- a/dqc_us_rules/dqc_us_0018.py
+++ b/dqc_us_rules/dqc_us_0018.py
@@ -200,9 +200,10 @@ def _deprecated_concept(val, concept):
     :return: Returns true if the fact uses a deprecated concept
     :rtype: bool
     """
-    if not hasattr(val, "usgaapDeprecations"):
+    if not isinstance(concept, ModelConcept):
         return False
-    if concept.name in val.usgaapDeprecations:
+    elif ((hasattr(val, 'usgaapDeprecations') and
+           concept.name in val.usgaapDeprecations)):
         return True
     return False
 

--- a/tests/unit_tests/test_dqc_us_0018.py
+++ b/tests/unit_tests/test_dqc_us_0018.py
@@ -36,22 +36,24 @@ class TestCompareFacts(unittest.TestCase):
             "Possible replacement is "
             "AllowanceForDoubtfulAccountsReceivableWriteOffs."
         )
-        bad_fact = mock.Mock()
-        bad_fact.concept = mock.Mock()
-        bad_fact.concept.name = 'HealthCareOrganizationChangeInWriteOffs'
-
-        good_fact = mock.Mock()
-        good_fact.concept = mock.Mock()
-        good_fact.concept.name = (
+        bad_concept = mock.Mock(spec=ModelConcept)
+        bad_concept.name = 'HealthCareOrganizationChangeInWriteOffs'
+        good_concept = mock.Mock(spec=ModelConcept)
+        good_concept.name = (
             'AllowanceForDoubtfulAccountsReceivableWriteOffs'
         )
+        none_concept = None
 
         self.assertTrue(
-            dqc_us_0018._deprecated_concept(val, bad_fact.concept)
+            dqc_us_0018._deprecated_concept(val, bad_concept)
         )
 
         self.assertFalse(
-            dqc_us_0018._deprecated_concept(val, good_fact.concept)
+            dqc_us_0018._deprecated_concept(val, good_concept)
+        )
+
+        self.assertFalse(
+            dqc_us_0018._deprecated_concept(val, none_concept)
         )
 
     def test_deprecated_dimension(self):
@@ -69,6 +71,7 @@ class TestCompareFacts(unittest.TestCase):
         bad_dim.name = 'ComponentOfOtherExpenseNonoperatingAxis'
         good_dim = mock.Mock(spec=ModelConcept)
         good_dim.name = 'LegalEntityAxis'
+        none_dim = None
 
         self.assertTrue(
             dqc_us_0018._deprecated_dimension(
@@ -81,6 +84,13 @@ class TestCompareFacts(unittest.TestCase):
            dqc_us_0018._deprecated_dimension(
                val,
                good_dim
+           )
+        )
+
+        self.assertFalse(
+           dqc_us_0018._deprecated_dimension(
+               val,
+               none_dim
            )
         )
 
@@ -224,9 +234,9 @@ class TestCompareFacts(unittest.TestCase):
             "http://fasb.org/us-gaap/2015-01-31": [0]
         }
         deprecated_concept = "PolicyChargesInsurance"
-        from_model = mock.Mock()
+        from_model = mock.Mock(spec=ModelConcept)
         from_model.name = deprecated_concept
-        to_model = mock.Mock()
+        to_model = mock.Mock(spec=ModelConcept)
         to_model.name = deprecated_concept
         val.usgaapDeprecations = [deprecated_concept]
         relationship = mock.Mock(


### PR DESCRIPTION
### Changes:

- Added an isInstance check to dqc_us_0018.py in the _deprecated_concept method. This will catch all concepts that are None and return false. This will fix the attribute error from occurring.

Please review: @hefischer  @andrewperkins-wf please review for merge.

XS-3228