### PR TITLE
XS-3342 DQC Rules 5 and 15 having issue with iXBRL.

### DIFF
--- a/dqc_us_rules/dqc_us_0005.py
+++ b/dqc_us_rules/dqc_us_0005.py
@@ -131,7 +131,7 @@ def run_checks(val, fact, eop_results, lookup):
     :return: No direct return, throws errors when facts can't be validated
     :rtype: None
     """
-    if fact.localName == 'EntityCommonStockSharesOutstanding':
+    if fact.qname.localName == 'EntityCommonStockSharesOutstanding':
         fact_date = fact.context.endDatetime
         comparison_date = eop_results[lookup][1]
         # if a fact whose qname is

--- a/dqc_us_rules/dqc_us_0015.py
+++ b/dqc_us_rules/dqc_us_0015.py
@@ -5,6 +5,7 @@ import os
 import csv
 from .util import messages, neg_num
 from .util import facts as facts_util
+from arelle.XmlValidate import VALID
 
 _CODE_NAME = 'DQC.US.0015'
 _RULE_VERSION = '1.1.1'
@@ -72,8 +73,9 @@ def filter_negative_number_facts(val, blacklist_concepts):
     # other filters before running negative numbers check
     # numeric_facts has already checked if fact.value can be made into a number
     facts_to_check = [
-        f for f in numeric_facts if float(f.value) < 0 and
-        f.concept.type is not None and
+        #f for f in numeric_facts if float(f.value) < 0 and
+        f for f in numeric_facts if f.xValid >= VALID and f.xValue < 0 and
+	f.concept.type is not None and
         # facts with numerical values less than 0 and contexts and
         f.context is not None and
         # check xsd type of the concept

--- a/dqc_us_rules/dqc_us_0015.py
+++ b/dqc_us_rules/dqc_us_0015.py
@@ -73,7 +73,6 @@ def filter_negative_number_facts(val, blacklist_concepts):
     # other filters before running negative numbers check
     # numeric_facts has already checked if fact.value can be made into a number
     facts_to_check = [
-        #f for f in numeric_facts if float(f.value) < 0 and
         f for f in numeric_facts if f.xValid >= VALID and f.xValue < 0 and
 	f.concept.type is not None and
         # facts with numerical values less than 0 and contexts and

--- a/dqc_us_rules/dqc_us_0015.py
+++ b/dqc_us_rules/dqc_us_0015.py
@@ -74,7 +74,7 @@ def filter_negative_number_facts(val, blacklist_concepts):
     # numeric_facts has already checked if fact.value can be made into a number
     facts_to_check = [
         f for f in numeric_facts if f.xValid >= VALID and f.xValue < 0 and
-	f.concept.type is not None and
+        f.concept.type is not None and
         # facts with numerical values less than 0 and contexts and
         f.context is not None and
         # check xsd type of the concept


### PR DESCRIPTION
### Changes:

- Rule 5. Changed fact.localName reference to fact.qname.localName
- Rule 15. Inserted a check to ensure the xValue is valid to prevent errors in processing.

### Pull request process

- [ ] Full description of changes provided above.
- [ ] Reviewed by another person. (+1)
- [ ] If this is a code change, reviewed by a second person. (+1)
- [ ] QA'd to the specifications listed [here](https://github.com/DataQualityCommittee/dqc_us_rules#quality-assurance-qa-of-a-pull-request). Documentation only changes do not require the formal code quality assurance process. (+10)

##### Once checklist is complete, @hefischer  @andrewperkins-wf please review for merge.
