### PR TITLE
XS-3710 DQC 0005 Adding members to StatementEquityComponentsAxis

### DIFF
--- a/dqc_us_rules/resources/DQC_US_0001/dqc_0001.json
+++ b/dqc_us_rules/resources/DQC_US_0001/dqc_0001.json
@@ -704,7 +704,9 @@
 			"AccumulatedDefinedBenefitPlansAdjustmentNetGainLossIncludingPortionAttributableToNoncontrollingInterestMember",
 			"AccumulatedDefinedBenefitPlansAdjustmentNetPriorServiceIncludingPortionAttributableToNoncontrollingInterestMember",
 			"AccumulatedDefinedBenefitPlansAdjustmentNetTransitionIncludingPortionAttributableToNoncontrollingInterestMember",
-			"ComprehensiveIncomeMember"
+			"ComprehensiveIncomeMember",
+			"TreasuryStockCommonMember",
+			"TreasuryStockPreferredMember"
 		],
 		"additional_axes":{},
 		"excluded_axes":{},


### PR DESCRIPTION
### Changes:

- Added TreasuryStockCommonMember and TreasuryStockPreferredMember to StatementEquityComponentsAxis due to taxonomy update.


### Pull request process

- [ ] Full description of changes provided above.
- [ ] Reviewed by another person. (+1)
- [ ] If this is a code change, reviewed by a second person. (+1)
- [ ] QA'd to the specifications listed [here](https://github.com/DataQualityCommittee/dqc_us_rules#quality-assurance-qa-of-a-pull-request). Documentation only changes do not require the formal code quality assurance process. (+10)

##### Once checklist is complete, @hefischer  @andrewperkins-wf please review for merge.

…eferredMember to the StatementEquityComponentsAxis