### PR TITLE
XS-4717 Adding 2017 taxonomy support to rule 18

### DIFF
--- a/dqc_us_rules/__init__.py
+++ b/dqc_us_rules/__init__.py
@@ -67,7 +67,7 @@ def _plugins_to_run(mod, include_start=True):
 
 __pluginInfo__ = {
     'name': 'DQC.SEC.ALL',
-    'version': '3.3',
+    'version': '3.4',
     'description': 'All Data Quality Committee SEC Filing Checks',
     'author': '',
     'license': 'See accompanying license text',

--- a/dqc_us_rules/dqc_us_0018.py
+++ b/dqc_us_rules/dqc_us_0018.py
@@ -6,13 +6,13 @@ import os
 
 from .util import messages
 
-from arelle import XbrlConst, ModelXbrl
+from arelle import XbrlConst, ModelXbrl, ModelDocument
 from arelle.ModelDtsObject import ModelConcept
 from arelle.FileSource import openFileStream, openFileSource, saveFile
 
 
 _CODE_NAME = 'DQC.US.0018'
-_RULE_VERSION = '2.0.0'
+_RULE_VERSION = '3.4.0'
 _EARLIEST_US_GAAP_YEAR = 2014
 
 ugtDocs = (
@@ -33,6 +33,13 @@ ugtDocs = (
         "namespace": "http://fasb.org/us-gaap/2016-01-31",
         "docLB": "http://xbrl.fasb.org/us-gaap/2016/us-gaap-2016-01-31.zip/us-gaap-2016-01-31/elts/us-gaap-doc-2016-01-31.xml",  # noqa
         "entryXsd": "http://xbrl.fasb.org/us-gaap/2016/us-gaap-2016-01-31.zip/us-gaap-2016-01-31/entire/us-gaap-entryPoint-std-2016-01-31.xsd",  # noqa
+    },
+    {
+        "year": 2017,
+        "namespace": "http://fasb.org/us-gaap/2017-01-31",
+        # use change notices reference parts instead of doc LB
+        "docLB": "http://xbrl.fasb.org/us-gaap/2017/us-gaap-2017-01-31.zip/us-gaap-2017-01-31/elts/us-gaap-cn-ref-2017-01-31.xml",  # noqa
+        "entryXsd": "http://xbrl.fasb.org/us-gaap/2017/us-gaap-2017-01-31.zip/us-gaap-2017-01-31/entire/us-gaap-entryPoint-std-2017-01-31.xsd",  # noqa
     },
 )
 
@@ -142,18 +149,44 @@ def _create_cache(val):
 
                     if model_documentation.role == dep_label:
                         val.usgaapDeprecations[concept] = (
-                            model_documentation.text,
-                            val.usgaapDeprecations.get(concept, ('', ''))[0]
+                            val.usgaapDeprecations.get(concept, ('', ''))[0],
+                            model_documentation.text
                         )
                     elif model_documentation.role == dep_date_label:
                         val.usgaapDeprecations[concept] = (
                             model_documentation.text,
                             val.usgaapDeprecations.get(concept, ('', ''))[1]
                         )
+                dep_ref = 'http://fasb.org/us-gaap/role/changeNote/changeNote'
+                concept_reference = XbrlConst.conceptReference
+                relationship_set = (
+                    deprecations_instance.relationshipSet(concept_reference)
+                )
+                model_relationships = relationship_set.modelRelationships
+
+                for refRel in model_relationships:
+                    model_resource = refRel.toModelObject
+                    if model_resource.role == dep_ref:
+                        concept = refRel.fromModelObject.name
+                        for refPart in model_resource.iterchildren():
+                            if refPart.localName == "DeprecatedLabel":
+                                val.usgaapDeprecations[concept] = (
+                                    val.usgaapDeprecations.get(
+                                        concept,
+                                        ('', ''))[0],
+                                    refPart.text
+                                )
+                            elif refPart.localName == "DeprecatedDate":
+                                val.usgaapDeprecations[concept] = (
+                                    refPart.text,
+                                    val.usgaapDeprecations.get(
+                                        concept,
+                                        ('', ''))[1]
+                                )
                 json_str = str(
                     json.dumps(
                         val.usgaapDeprecations,
-                        ensure_ascii=False, indent=0
+                        ensure_ascii=False, indent=0, sort_keys=True
                     )
                 )  # might not be unicode in 2.7
                 saveFile(cntlr, deprecations_json_file, json_str)

--- a/dqc_us_rules/dqc_us_0018.py
+++ b/dqc_us_rules/dqc_us_0018.py
@@ -6,7 +6,7 @@ import os
 
 from .util import messages
 
-from arelle import XbrlConst, ModelXbrl, ModelDocument
+from arelle import XbrlConst, ModelXbrl
 from arelle.ModelDtsObject import ModelConcept
 from arelle.FileSource import openFileStream, openFileSource, saveFile
 

--- a/dqc_us_rules/resources/DQC_US_0018/2014_deprecated-concepts.json
+++ b/dqc_us_rules/resources/DQC_US_0018/2014_deprecated-concepts.json
@@ -1,5533 +1,53 @@
 {
-"FairValueAssetsMeasuredOnRecurringBasisCashAndCashEquivalentsValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
-],
-"TypesOfItemsHedgedByCreditRiskDerivatives": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are members of UnderlyingAssetClassAxis."
-],
-"FairValueByBalanceSheetGroupingSignificantAssumptionsFinancialLiabilitiesAbstract": [
-"2012-01-31",
-"This element was removed because its children were deprecated after the disclosure was dimensionalized."
-],
-"ServicingAssetAtFairValueChangesInFairValueLocationInIncomeStatementDescription": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionGainLossOnDisposition1 and members of IncomeStatementLocationAxis."
-],
-"DefinedBenefitPlanOtherPlanAssets": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are DefinedBenefitPlanWeightedAverageAssetAllocations and members of DefinedBenefitPlanByPlanAssetCategoriesAxis."
-],
-"OtherMember": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is OtherCreditDerivativesMember."
-],
-"PublicUtilitiesPropertyPlantAndEquipmentGenerationEstimatedUsefulLife": [
-"2013-01-31",
-"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentGenerationUsefulLife."
-],
-"LeveragedBuyoutClosingFeesAndExpense": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DepreciableAssetsMember": [
-"2014-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"PremiumsEarnedNetFinancialGuaranteeInsuranceContractsAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"OtherComprehensiveIncomeLossReclassificationAdjustmentOnDerivativesIncludedInNetIncomeTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIOnDerivativesTax."
-],
-"CapitalizedInterestCostsMember": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"FinancingReceivableModificationsSubsequentDefaultNumberOfContracts": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is FinancingReceivableModificationsSubsequentDefaultNumberOfContracts1."
-],
-"DerivativeExchangeRateCap": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is DerivativeExchangeRateCap1."
-],
-"AccumulatedDepreciationDepletionAndAmortizationWritedownOfPropertyPlantAndEquipment": [
-"2013-01-31",
-"Element was deprecated because it has credit balance attribute. Possible replacement is ImpairmentOfLongLivedAssetsHeldForUse."
-],
-"FairValueAssetsMeasuredOnRecurringBasisCostMethodInvestmentsValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
-],
-"FairValueAssetsMeasuredOnNonrecurringBasisValuationTechniquesIndefiniteLivedIntangibleAssetsExcludingGoodwill": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
-],
-"ComponentOfOtherExpenseNonoperatingAxis": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"DerivativeFinancialInstrumentsLiabilitiesFairValueDisclosure": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DerivativeLiabilities."
-],
-"FairValueAssetsMeasuredOnNonrecurringBasisValuationTechniquesInvestmentsInAffiliatesSubsidiariesAssociatesAndJointVentures": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
-],
-"NewContractMember": [
-"2012-01-31",
-"Element was deprecated because the dimension of the financial reporting concept was remodeled."
-],
-"RelatedPartyTransactionRevenuesFromTransactionsWithRelatedParty": [
-"2012-01-31",
-"Element was deprecated due to redundancy. Possible replacement is RevenueFromRelatedParties."
-],
-"DefinedBenefitPlanEstimatedFutureBenefitPaymentsDescription": [
-"2012-01-31",
-"Element was deprecated because it has a stringItemType. Possible replacement is ScheduleOfExpectedBenefitPaymentsTableTextBlock."
-],
-"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareLiquidatingInvestmentRemainingPeriodAbstract": [
-"2012-01-31",
-"Element has been deprecated."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseClaimsPaidCurrentYear": [
-"2014-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseClaimsPaidCurrentYear1."
-],
-"RealEstateTaxesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is RealEstateTaxExpense."
-],
-"ForeignCurrencyDerivativeLiabilitiesAtFairValue": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeFairValueOfDerivativeLiability and ForeignExchangeContractMember."
-],
-"ProceedsFromRecoveriesOfLoansPreviouslyChargedOff": [
-"2012-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is ProceedsFromRecoveriesOfLoanPreviouslyChargedOff."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAdjustmentOfOpeningBalanceLineItems": [
-"2014-01-31",
-"Element was deprecated."
-],
-"DerivativeNonmonetaryNotionalAmountPricePerUnit": [
-"2013-01-31",
-"Element was deprecated because the intended concept conveyed is the underlying. Possible replacements are UnderlyingDerivativeAsset, UnderlyingDerivativeLiability and UnderlyingDerivative."
-],
-"CashFlowHedgeGainLossReclassifiedToOtherExpenseNetAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"HealthCareOrganizationChangeInWriteOffs": [
-"2014-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacement is AllowanceForDoubtfulAccountsReceivableWriteOffs."
-],
-"ExchangeFeesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ExchangeFees."
-],
-"MarketingExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is MarketingExpense."
-],
-"GainsLossesOnSalesOfOtherAssets": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is GainLossOnSaleOfOtherAssets."
-],
-"FiniteLivedRoyaltyGross": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FiniteLivedIntangibleAssetsGross and members of FiniteLivedIntangibleAssetsByMajorClassAxis."
-],
-"SignificantPurchaseCommitmentRemainingMinimumAmountCommitted": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is PurchaseCommitmentRemainingMinimumAmountCommitted."
-],
-"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsAmountsRecognizedInBalanceSheetAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"PhaseInPlanNetChangeInAmountOfCostsDeferredForRateMakingPurposesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"BusinessCombinationGoodwillRecognizedSegmentAllocation": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is Goodwill and members of StatementBusinessSegmentsAxis."
-],
-"PurchasePriceAllocationAdjustmentsMember": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"OtherAssetsFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
-],
-"FiniteLivedTransmissionServiceAgreementGross": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FiniteLivedIntangibleAssetsGross and members of FiniteLivedIntangibleAssetsByMajorClassAxis."
-],
-"SuppliesExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is SuppliesExpense."
-],
-"BusinessAcquisitionPurchasePriceAllocationEquipment": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FairValueConvertibleDebtValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
-],
-"SubsequentEventDateEvaluatedDescription": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"FairValueLevel2ToLevel1TransfersDescription": [
-"2012-01-31",
-"Element was deprecated. Possible replacements are FairValueAssetsLevel2ToLevel1TransfersAmount, FairValueLiabilitiesLevel2ToLevel1TransfersAmount, or FairValueEquityLevel2ToLevel1TransfersAmount."
-],
-"FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisAssetGainLossIncludedInEarnings": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisAssetGainLossIncludedInEarnings1."
-],
-"LoansPayableFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
-],
-"AcquiredFiniteLivedIntangibleAssetAmount": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is FinitelivedIntangibleAssetsAcquired1."
-],
-"IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingGeneralPartnershipUnit": [
-"2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingGeneralPartnershipUnit1."
-],
-"NotionalAmountOfForeignCurrencyDerivativeInstrumentsNotDesignatedAsHedgingInstruments": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and HedgingDesignationAxis."
-],
-"OtherComprehensiveIncomeForeignCurrencyTransactionAndTranslationReclassificationAdjustmentRealizedUponSaleOrLiquidationNetOfTax": [
-"2012-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossForeignCurrencyTransactionAndTranslationReclassificationAdjustmentFromAOCIRealizedUponSaleOrLiquidationNetOfTax."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsRawMaterials": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FinancingReceivableTroubledDebtRestructuringsThatSubsequentlyDefaultedDomain": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is FinancingReceivableTroubledDebtRestructuringDomain."
-],
-"AssumedPremiumsEarnedOtherInsurance": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAdjustmentOfOpeningBalanceAmount": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseOpeningBalanceAdjustments."
-],
-"FurnitureAndEquipmentRentalExpenseOperatingLeaseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is LeaseAndRentalExpense."
-],
-"DepositAssetsOrLiabilitiesEffectOfChangeInPresentValueAssumptionsResultingInReductionsInExpectedRecoveries": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DepositAssetsEffectOfChangeInPresentValueAssumptionsResultingInReductionsToExpectedRecoveries and DepositLiabilitiesEffectOfChangeInPresentValueAssumptionsResultingInReductionsToExpectedRecoveries."
-],
-"ForeignCurrencyContractAssetFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
-],
-"AssumedPremiumsEarnedPropertyAndCasualty": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"CertainLoansAcquiredInTransferAccountedForAsAvailableForSaleDebtSecuritiesOtherThanTemporaryImpairmentCharges": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsAvailableforsaleDebtSecuritiesOtherthanTemporaryImpairmentChargesCreditLoss."
-],
-"EffectiveDateDeferralSFAS157": [
-"2012-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CollaborativeArrangementsCopromotionAgreementAggregatedDisclosureMember": [
-"2013-01-31",
-"Element was deprecated because of unnecessary level of disaggregation in a parent-child relationship."
-],
-"AmortizationOfRegulatoryAssetMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is AmortizationOfRegulatoryAsset."
-],
-"AvailableForSaleSecuritiesDebtMaturitiesAmortizedCost": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AvailableForSaleDebtSecuritiesAmortizedCostBasis."
-],
-"OtherComprehensiveIncomeDefinedBenefitPlansTax": [
-"2012-01-31",
-"Element was deprecated because it has no balance attribute. Possible replacement is OtherComprehensiveIncomeLossPensionAndOtherPostretirementBenefitPlansTax."
-],
-"ProductRecallAxis": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"ClearanceFeesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ClearanceFees."
-],
-"BusinessExitCosts": [
-"2013-01-31",
-"Element was deprecated. Possible replacement is BusinessExitCosts1."
-],
-"VariableInterestEntityNonconsolidatedComparisonOfCarryingAmountOfAssetsAndLiabilitiesToMaximumLossExposureExplanationQuantitativeInformationAdvantageous": [
-"2012-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"TradingAccountAssetsFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
-],
-"BusinessAcquisitionCostOfAcquiredEntityPurchasePrice": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"NettingAndCollateralMember": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are DerivativeAssetFairValueGrossLiability, DerivativeAssetCollateralObligationToReturnCashOffset, DerivativeAssetFairValueGrossLiabilityAndObligationToReturnCashOffset, SecuritiesPurchasedUnderAgreementsToResellLiability, SecuritiesBorrowedLiability, DerivativeAssetSecuritiesPurchasedUnderAgreementsToResellSecuritiesBorrowedLiability, DerivativeLiabilityFairValueGrossAsset, DerivativeLiabilityCollateralRightToReclaimCashOffset, DerivativeLiabilityFairValueGrossAssetAndRightToReclaimCashOffset, SecuritiesSoldUnderAgreementsToRepurchaseAsset, SecuritiesLoanedAsset, or DerivativeLiabilitySecuritiesSoldUnderAgreementsToResellSecuritiesLoanedAsset."
-],
-"FiniteLivedIntangibleAssetsUsefulLife": [
-"2012-01-31",
-"Element was deprecated because it has an integerItemType. Possible replacement is FiniteLivedIntangibleAssetUsefulLife."
-],
-"AssetsHeldForSaleLongLived": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DisposalGroupIncludingDiscontinuedOperationLongLivedAssetsNoncurrent, DisposalGroupIncludingDiscontinuedOperationLongLivedAssetsCurrent or DisposalGroupIncludingDiscontinuedOperationLongLivedAssets."
-],
-"FinancingReceivableModificationsPostModificationRecordedInvestment": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is FinancingReceivableModificationsPostModificationRecordedInvestment2."
-],
-"PresentValueOfFutureInsuranceProfitsDecreases": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsDecrease."
-],
-"NotionalAmountOfDerivativeInstrumentsDesignatedAsNetInvestmentHedges": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
-],
-"FinancingReceivableModificationsNumberOfContracts": [
-"2012-01-31",
-"Element was deprecated. Possible replacements are FinancingReceivableModificationsNumberOfContracts2 and FinancingReceivableModificationsSubsequentDefaultNumberOfContracts1."
-],
-"CededPremiumsWrittenOtherInsurance": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"ManagementFeeAmountPaid": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is PaymentForManagementFee."
-],
-"RatioOfIndebtednessToNetCapital": [
-"2012-01-31",
-"Element deprecated because it is decimalItemType. If you have used in the past, Possible replacement is RatioOfIndebtednessToNetCapital1."
-],
-"DeferredCompensationArrangementWithIndividualCashAwardsGrantedAmount": [
-"2013-01-31",
-"Element was deprecated because it has debit balance and duration period type attributes. Possible replacement is DeferredCompensationArrangementWithIndividualCashAwardGrantedAmount."
-],
-"FinancingReceivableModificationsNumberOfContracts1": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is FinancingReceivableModificationsNumberOfContracts2."
-],
-"DerivativeLowerRemainingMaturityRange": [
-"2012-01-31",
-"Element was deprecated because it has a durationStringItemType. Possible replacement is DerivativeLowerRemainingMaturityRange1."
-],
-"RevenuesFromTransactionsWithOtherOperatingSegmentsOfSameEntity": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Possible replacement is Revenues and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
-],
-"DefinedBenefitPlanAmountsRecognizedInOtherComprehensiveIncomeNetGainLossBeforeTax": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is DefinedBenefitPlanAmountsRecognizedInOtherComprehensiveIncomeLossNetGainLossBeforeTax."
-],
-"CededPremiumsLifeInsuranceInForce": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is LifeInsuranceInForceCeded."
-],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardAwardVestingPeriod": [
-"2012-01-31",
-"Element was deprecated because it has a durationStringItemType. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardAwardVestingPeriod1."
-],
-"LossContingencySettlementAgreementConsideration": [
-"2012-01-31",
-"Element was deprecated because it has a stringItemType attribute. Possible replacement is LitigationSettlementAmount."
-],
-"NondebtorReorganizationItemsNetGainLossOnSettlementOfOtherClaims": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is NondebtorReorganizationItemsNetGainLossOnSettlementOfOtherClaims1."
-],
-"FairValueOptionChangesInFairValueGainLoss": [
-"2012-01-31",
-"Element was deprecated. Possible replacements are FairValueOptionChangesInFairValueGainLoss1 qualified by IncomeStatementLocationAxis and EligibleItemOrGroupForFairValueOptionAxis and their members."
-],
-"SegmentReportingInformationInventoryNet": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Possible replacement is corresponding primary line items and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
-],
-"IncreaseDecreaseInFilmCosts": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is IncreaseDecreaseInFilmCosts1."
-],
-"DepositAssetsOrLiabilitiesEffectOfChangeInPresentValueAssumptionsRecordedAsExpense": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DepositAssetsEffectOfChangeInPresentValueAssumptionsRecordedAsExpense and DepositLiabilitiesEffectOfChangeInPresentValueAssumptionsRecordedAsExpense."
-],
-"IncomeLossBeforeExtraordinaryItemsAndCumulativeEffectOfChangeInAccountingPrinciplePerOutstandingGeneralPartnershipUnit": [
-"2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromOperationsBeforeExtraordinaryItemsPerOutstandingGeneralPartnershipUnitNetOfTax."
-],
-"LifeInsuranceInForcePremiumsPercentageAssumedToNet": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is LifeInsuranceInForcePercentageAssumedToNet."
-],
-"BusinessAcquisitionPurchasePriceAllocationNoncurrentAssetsDescription": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AdjustmentsToAdditionalPaidInCapitalShareBasedCompensationNonvestedSharesRequisiteServicePeriodRecognition": [
-"2013-01-31",
-"Element was deprecated due to redundancy."
-],
-"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureCashInflows": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesCashInflows."
-],
-"AdjustmentsToAdditionalPaidInCapitalReallocationOfMinorityInterest": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is NoncontrollingInterestIncreaseFromSubsidiaryEquityIssuance."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisGainLossIncludedInEarningsDescription": [
-"2012-01-31",
-"Element was deprecated due to redundancy. Possible replacement is FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisLiabilityGainLossIncludedInEarningsDescription."
-],
-"PremiumsNetLifeInsuranceInForce": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is LifeInsuranceInForceNet."
-],
-"InstrumentAxis": [
-"2013-01-31",
-"Element was deprecated because it was incorrectly defined. Possible replacement is EnergyAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentLiabilitiesDeferredRevenue": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"OtherComprehensiveIncomeReclassificationAdjustmentForWriteDownOfSecuritiesIncludedInNetIncomeTax": [
-"2012-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForWritedownOfSecuritiesTax."
-],
-"NoninterestExpenseInvestmentAdvisoryFeesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpenseInvestmentAdvisoryFees."
-],
-"BusinessAcquisitionPurchasePriceAllocationLiabilitiesAssumed": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"PublicUtilitiesPropertyPlantAndEquipmentTransmissionEstimatedUsefulLife": [
-"2013-01-31",
-"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentTransmissionUsefulLife."
-],
-"OtherComprehensiveIncomeReclassificationOfDefinedBenefitPlansNetGainLossRecognizedInNetPeriodicBenefitCostNetOfTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetGainLossNetOfTax."
-],
-"SubsequentEventAmount": [
-"2013-01-31",
-"Element was deprecated because it is an invalid concept."
-],
-"CommunicationsDataProcessingAndOccupancyMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is CommunicationsInformationTechnologyAndOccupancy."
-],
-"ShareBasedGoodsAndNonemployeeServicesTransactionExpense": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is IssuanceOfStockAndWarrantsForServicesOrClaims."
-],
-"OtherComprehensiveIncomeMinimumPensionLiabilityNetAdjustmentTax": [
-"2012-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"BusinessAcquisitionPurchasePriceAllocationNoncurrentLiabilitiesRestructuringCostAccrual": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"OtherAssetsFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
-],
-"InterestRevenueExpense": [
-"2012-01-31",
-"Element was deprecated due to redundancy. Possible replacements are InterestRevenueExpenseNet or InterestIncomeExpenseNet."
-],
-"DistributionMadeToMemberOrLimitedPartnerLineItems": [
-"2013-01-31",
-"Element was deprecated."
-],
-"PremiumsEarnedNetByProductSegmentAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"AccountingStandardsUpdate201001Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"NonmonetaryNotionalAmountOfPriceRiskDerivatives": [
-"2013-01-31",
-"Element was deprecated because the intended concept conveyed is the underlying. Possible replacements are UnderlyingDerivativeAsset, UnderlyingDerivativeLiability, UnderlyingDerivative and members of DerivativeInstrumentRiskAxis."
-],
-"PublicUtilitiesPropertyPlantAndEquipmentOtherPropertyPlantAndEquipmentEstimatedUsefulLife": [
-"2013-01-31",
-"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentOtherPropertyPlantAndEquipmentUsefulLife."
-],
-"EquityMethodInvestmentsFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
-],
-"FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInOtherIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
-],
-"DebtInstrumentIncreaseAdditionalBorrowings": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute.  Possible replacement is ProceedsFromIssuanceOfDebt."
-],
-"BusinessCombinationConsiderationTransferred": [
-"2013-01-31",
-"Element was deprecated because it has debit balance and instant period type attributes.  Possible replacement is BusinessCombinationConsiderationTransferred1."
-],
-"IncomeLossFromDispositionOfDiscontinuedOperationsForOtherStockPerBasicShare": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is IncomeLossFromDiscontinuedOperationsNetOfTaxPerBasicShare."
-],
-"EquityIssuanceNumberOfEquitySecuritiesIssuedForCash": [
-"2012-01-31",
-"Element was deprecated because it has an instant period type and a decimalItemType. Possible replacement is StockIssuedDuringPeriodSharesIssuedForCash."
-],
-"OriginationOfMortgageServicingRightsMSRs": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ServicingAssetAtFairValueAdditions."
-],
-"ScheduleOfCostMethodInvestmentsAxis": [
-"2013-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is MajorTypesOfDebtAndEquitySecuritiesAxis."
-],
-"AverageBalanceDuringPeriodOfLoansSecuritized": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"EnvironmentalCostsOfPropertyForSaleDisposalOrAbandonmentBalanceSheetCaption": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is EnvironmentalExitCostsCostsAccruedToDate and members of BalanceSheetLocationAxis."
-],
-"GainLossFromSaleOfFinancialAssetsInSecuritizationsOrAssetBackedFinancingArrangement": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is SecuritizationFinancialAssetForWhichTransferIsAccountedAsSaleGainLossOnSale."
-],
-"FederalHomeLoanBankAdvancesMaturitiesSummaryByInterestRateType": [
-"2012-01-31",
-"Element deprecated due to redundancy. Possible replacement is AdvancesFromFederalHomeLoanBanks."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInInvestmentIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueLiabilitiesMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
-],
-"IntermediateLifePlantsEstimatedUsefulLife": [
-"2013-01-31",
-"Element was deprecated because it is has a stringItemType attribute. Possible replacement is IntermediateLifePlantsUsefulLife."
-],
-"AssetsOrLiabilitiesFromTransfersOfFinancialAssetsHavingNoReasonableEstimateOfFairValueTable": [
-"2012-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"OptionIndexedToIssuersEquityStrikePrice": [
-"2014-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is OptionIndexedToIssuersEquityStrikePrice1."
-],
-"CumulativeEffectAdjustmentBifurcationOfHybridsGrossLosses": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"RevenueFromAdministrativeServicesAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"ConsumerCreditScoreMember": [
-"2013-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is InternalCreditAssessmentDomain."
-],
-"LiabilitiesForGuaranteesOnLongDurationContractsIncurredBenefits": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is LiabilitiesForGuaranteesOnLongDurationContractsIncurredBenefits1."
-],
-"AvailableforsaleSecuritiesContinuousUnrealizedLossPosition12MonthsOrLongerAggregateLosses2": [
-"2013-01-31",
-"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is AvailableForSaleSecuritiesContinuousUnrealizedLossPosition12MonthsOrLongerAggregateLosses."
-],
-"BusinessAcquisitionPurchasePriceAllocationAssetsAcquired": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"IncreaseDecreaseInFairValueOfHedgedItemInInterestRateFairValueHedge": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is IncreaseDecreaseInFairValueOfHedgedItemInInterestRateFairValueHedge1."
-],
-"DefinedBenefitPlanExpectedFutureBenefitPaymentsInYearTwo": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is DefinedBenefitPlanExpectedFutureBenefitPaymentsYearTwo."
-],
-"TimeSharingTransactionsWeightedAverageOfStatedInterestRatesForNotesReceivable": [
-"2012-01-31",
-"Element was deprecated because it has an integerItemType. Possible replacement is TimeSharingTransactionsWeightedAverageOfStatedInterestRatesForNotesReceivable1."
-],
-"LineItemForGainLossOnCreditRiskDerivativeOnIncomeStatement": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are members of IncomeStatementLocationAxis."
-],
-"AmountOfRegulatoryAssistanceReceived": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is AmountOfRegulatoryAssistanceReceived1."
-],
-"LossContingencySettlementAgreementConsideration1": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is LitigationSettlementAmount."
-],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsGrantsInPeriodWeightedAverageExercisePrice": [
-"2012-01-31",
-"Element was deprecated because it has an instant period type. Possible replacement is ShareBasedCompensationArrangementsByShareBasedPaymentAwardOptionsGrantsInPeriodWeightedAverageExercisePrice."
-],
-"DeferredCompensationArrangementWithIndividualExcludingShareBasedPaymentsAndPostretirementBenefitsByTitleOfIndividualAxis": [
-"2013-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is TitleofIndividualAxis."
-],
-"FairValueAssetsMeasuredOnRecurringBasisFederalFundsSoldAndSecuritiesBorrowedOrPurchasedUnderAgreementsToResellValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationIntangibleAssetsNotAmortizable": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"OtherOperatingExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OtherCostAndExpenseOperating."
-],
-"RevenueFromFranchisedOutlets": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is FranchiseRevenue."
-],
-"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInNextRollingTwelveMonths": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInNextRollingTwelveMonths."
-],
-"IncomeLossFromEquityMethodInvestmentsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is IncomeLossFromEquityMethodInvestments."
-],
-"StockRepurchaseProgramRemainingAuthorizedRepurchaseAmount": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is StockRepurchaseProgramRemainingAuthorizedRepurchaseAmount1."
-],
-"DebtorReorganizationItemsGainLossOnSettlementOfOtherClaimsNet": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is DebtorReorganizationItemsGainLossOnSettlementOfOtherClaimsNet1."
-],
-"DescriptionOfChangeInReinvestmentRateOfReturnEstimate": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"NotionalAmountOfNetInvestmentHedgingInstruments": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount,  DerivativeNotionalAmount or NotionalAmountOfNonderivativeInstruments and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
-],
-"DeferredPolicyAcquisitionCostsAndPresentValueOfFutureProfitsAmortization": [
-"2012-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is DeferredPolicyAcquisitionCostsAndPresentValueOfFutureProfitsAmortization1."
-],
-"FederalHomeLoanBankBorrowingsFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisAccountsPayableValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
-],
-"SharebasedCompensationArrangementBySharebasedPaymentAwardOptionsOutstandingWeightedAverageRemainingContractualTerm1": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is SharebasedCompensationArrangementBySharebasedPaymentAwardOptionsOutstandingWeightedAverageRemainingContractualTerm2."
-],
-"OtherCostAndExpenseDisclosureOperatingAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"CharityCareOtherMeasurementBasisDescription": [
-"2012-01-31",
-"Element was deprecated due to redundancy. Possible replacement is CharityCareMethodology."
-],
-"CashFlowHedgeGainLossReclassifiedToCostOfSalesNetAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"CumulativeEffectAdjustmentAbstract": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CumulativeEffectOnRetainedEarningsTax": [
-"2012-01-31",
-"Element was deprecated because it has an instant period type. Possible replacement is CumulativeEffectOnRetainedEarningsTax1."
-],
-"MinorityInterestExpenseIncomeRealEstateInvestmentsAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"CapitalLeaseExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is CapitalLeasesIncomeStatementInterestExpense."
-],
-"MortgageBackedSecuritiesHeldToMaturityFairValueDisclosureAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
-],
-"FairValueAssetsMeasuredOnRecurringBasisGainLossIncludedInTradingRevenue": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisAssetGainLossIncludedInEarnings1 and members of IncomeStatementLocationAxis."
-],
-"EquityFinancingForLeveragedBuyoutAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"NetInvestmentIncomeInsuranceEntityOtherLongTermInvestments": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NetInvestmentIncome and members of InvestmentTypeAxis."
-],
-"OtherExpenseOfInsuranceEntitiesAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"OtherComprehensiveIncomeLossReclassificationAdjustmentForWritedownOfSecuritiesIncludedInNetIncomeNetOfTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForWritedownOfSecuritiesNetOfTax."
-],
-"ServicingAssetsAtAmortizedValueByTypesOfFinancialInstrumentsAxis": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is FinancialInstrumentAxis."
-],
-"ConvertibleDebtFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
-],
-"CreditDerivativesByUnderlyingAssetClassAxis": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is UnderlyingAssetClassAxis."
-],
-"NotionalAmountOfForeignCurrencyDerivatives": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis."
-],
-"ForeignCurrencyExchangeRateRemeasurement": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is ForeignCurrencyExchangeRateRemeasurement1."
-],
-"NotionalAmountOfDerivativesAdditionalCategoriesOfDerivativesAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"BusinessAcquisitionPurchasePriceAllocationNoncurrentLiabilitiesDescription": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LineOfCreditFacilityExpirationDate": [
-"2012-01-31",
-"Element was deprecated because it has a dateStringItemType. Possible replacement is LineOfCreditFacilityExpirationDate1."
-],
-"IncomeTaxExaminationPenaltiesFromExamination": [
-"2013-01-31",
-"Element was deprecated due to redundancy.  Possible replacement is IncomeTaxExaminationPenaltiesExpense."
-],
-"StockRepurchaseProgramAuthorizedAmount": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is StockRepurchaseProgramAuthorizedAmount1."
-],
-"LinesOfCreditFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
-],
-"AssetOrLiabilityFromTransfersOfFinancialAssetsHavingNoReasonableEstimateOfFairValueReasonWhyNotEstimated": [
-"2012-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DebtorReorganizationItemsInterestIncomeOnAccumulatedCash": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is DebtorReorganizationItemsInterestIncomeOnAccumulatedCash1."
-],
-"TravelAndEntertainmentExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is TravelAndEntertainmentExpense."
-],
-"ChangeInUnrealizedGainLossOnHedgedItemInForeignCurrencyFairValueHedge": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is ChangeInUnrealizedGainLossOnHedgedItemInForeignCurrencyFairValueHedge1."
-],
-"ForeignEarningsRepatriatedUnderAmericanJobsCreationActOf2004RepatriatedEarnings": [
-"2013-01-31",
-"Element was deprecated because the guidance related to this element is no longer effective.  Possible replacement is ForeignEarningsRepatriated."
-],
-"CumulativeEffectAdjustmentApplicationOfFairValueOptionGrossGains": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticable": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are:\nDeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticableUndistributedEarningsOfForeignSubsidiaries\nDeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticableUndistributedEarningsOfDomesticSubsidiaries\nDeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticableBadDebtReserveForTaxPurposesOfQualifiedLender\nDeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticablePolicyholdersSurplus."
-],
-"BusinessDevelopmentMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is BusinessDevelopment."
-],
-"EffectOfChangeInAverageTrancheLifeEstimate": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"SourcesAndUsesOfCashForLeveragedBuyoutTextBlock": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DebtInstrumentIssuanceDate": [
-"2012-01-31",
-"Element was deprecated because it has a dateStringItemType. Possible replacement is DebtInstrumentIssuanceDate1."
-],
-"TradingActivityGainsAndLossesByIncomeStatementLocationDomain": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is IncomeStatementLocationDomain."
-],
-"FiniteLivedIntangibleAssetsUsefulLifeMaximum": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacements are FiniteLivedIntangibleAssetUsefulLife and RangeAxis (MaximumMember)."
-],
-"LeveragedBuyoutOptionCostPreviouslyRecognized": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"ClosedBlockAssetsAndLiabilities": [
-"2012-01-31",
-"Element was deprecated because it has a stringItemType. Possible replacement is ScheduleOfClosedBlockAssetsAndLiabilities."
-],
-"CumulativeEffectAdjustmentGrossGains": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"OtherComprehensiveIncomeLossReclassificationAdjustmentForSaleOfSecuritiesIncludedInNetIncomeBeforeTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForSaleOfSecuritiesBeforeTax."
-],
-"PremiumsReceivableFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
-],
-"FiniteLivedIntangibleAssetsWeightedAveragePeriodPriorToNextRenewalOrExtension": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is FiniteLivedIntangibleAssetWeightedAveragePeriodBeforeNextRenewalOrExtension."
-],
-"ScheduleOfImpairedIntangibleAssetsTable": [
-"2012-01-31",
-"Element was deprecated. Possible replacements are ScheduleOfIndefiniteLivedIntangibleAssetsTable and/or ScheduleOfFiniteLivedIntangibleAssetsTable."
-],
-"IncomeLossBeforeExtraordinaryItemsAndCumulativeEffectOfChangeInAccountingPrinciplePerOutstandingLimitedPartnershipUnitDiluted": [
-"2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromOperationsBeforeExtraordinaryItemsNetOfTaxPerOutstandingLimitedPartnershipUnitDiluted."
-],
-"ForeignCurrencyDerivativeAssetsAtFairValue": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeFairValueOfDerivativeAsset and ForeignExchangeContractMember."
-],
-"LeveragedBuyoutUsesOfCashInLeveragedBuyoutTransaction": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"BusinessAcquisitionEffectiveDateOfAcquisition": [
-"2012-01-31",
-"Element was deprecated because it has a dateStringItemType. Possible replacement is BusinessAcquisitionEffectiveDateOfAcquisition1."
-],
-"DevelopmentStageEnterpriseCumulativeCashInflows": [
-"2012-01-31",
-"Element was deprecated because different elements should not be used to tag cash inflows for the period and to tag cash inflows since inception. Possible replacement is the appropriate cash flow element to tag both fact values."
-],
-"OtherComprehensiveIncomeDerivativesQualifyingAsHedgesBeforeTaxPeriodIncreaseDecrease": [
-"2012-01-31",
-"Element was deprecated because it has no balance attribute. Possible replacement is OtherComprehensiveIncomeLossDerivativesQualifyingAsHedgesBeforeTax."
-],
-"DefinedBenefitPlanActuarialNetGainsLosses": [
-"2012-01-31",
-"Element deprecated because it has a debit balance attribute. Possible replacement is DefinedBenefitPlanActuarialGainLoss."
-],
-"NotionalAmountOfPriceRiskDerivativeInstrumentsNotDesignatedAsHedgingInstruments": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and HedgingDesignationAxis."
-],
-"ComponentOfOtherOperatingCostAndExpenseTable": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"CompetitiveTransitionChargeMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is StrandedCostsMember."
-],
-"OtherComprehensiveIncomeLossReclassificationAdjustmentOnDerivativesIncludedInNetIncomeNetOfTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIOnDerivativesNetOfTax."
-],
-"SaleLeasebackTransactionGrossProceeds": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are SaleLeasebackTransactionGrossProceedsInvestingActivities or SaleLeasebackTransactionGrossProceedsFinancingActivities."
-],
-"IncomeLossFromContinuingOperationsPerOutstandingGeneralPartnershipUnit": [
-"2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromContinuingOperationsPerOutstandingGeneralPartnershipUnitNetOfTax."
-],
-"NonmonetaryNotionalAmountOfPriceRiskDerivativeInstrumentsNotDesignatedAsHedgingInstruments": [
-"2013-01-31",
-"Element was deprecated because the intended concept conveyed is the underlying. Possible replacements are UnderlyingDerivativeAsset, UnderlyingDerivativeLiability, UnderlyingDerivative and members of HedgingDesignationAxis and DerivativeInstrumentRiskAxis."
-],
-"BusinessAcquisitionPreacquisitionContingencyDescriptionOfSettlement": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"MajorTypesOfTradingSecuritiesAndAssetsDomain": [
-"2012-01-31",
-"Element was deprecated due to redundancy. Possible replacement is MajorTypesOfDebtAndEquitySecuritiesDomain."
-],
-"OtherComprehensiveIncomeFinalizationOfPensionAndNonPensionPostretirementPlanValuationBeforeTax": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is OtherComprehensiveIncomeLossFinalizationOfPensionAndNonPensionPostretirementPlanValuationBeforeTax."
-],
-"OtherComprehensiveIncomeDerivativesQualifyingAsHedgesTaxEffectPeriodIncreaseDecrease": [
-"2012-01-31",
-"Element was deprecated because it has no balance attribute. Possible replacement is OtherComprehensiveIncomeLossDerivativesQualifyingAsHedgesTax."
-],
-"ServicingAssetsAtFairValueByTypeOfFinancialInstrumentAxis": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is FinancialInstrumentAxis."
-],
-"HeldToMaturitySecuritiesDebtMaturitiesNetCarryingAmount": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is HeldToMaturitySecurities."
-],
-"AvailableforsaleSecuritiesContinuousUnrealizedLossPositionAggregateLosses2": [
-"2013-01-31",
-"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is AvailableForSaleSecuritiesContinuousUnrealizedLossPositionAggregateLosses."
-],
-"DeferredPolicyAcquisitionCostsAndPresentValueOfFutureProfits": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DeferredPolicyAcquisitionCostsAndValueOfBusinessAcquired."
-],
-"FiveYearDisclosureDomain": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept modeled as a dimension was replaced with line items. Possible replacements are line items within ScheduleOfLifeSettlementContractsFairValueMethodTextBlock and ScheduleOfLifeSettlementContractsInvestmentMethodTextBlock."
-],
-"SubsequentEventDateFinancialStatementsIssued": [
-"2012-01-31",
-"Element was deprecated."
-],
-"FairValueOptionQuantitativeDisclosuresByEligibleItemOrGroupAxis": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is EligibleItemOrGroupForFairValueOptionAxis."
-],
-"ContractsReceivable": [
-"2012-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AccountsReceivableBilledForLongTermContractsOrPrograms."
-],
-"DepositAssetsOrLiabilitiesEffectOfChangeInPresentValueAssumptionsResultingInAdditionsToExpectedRecoveries": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DepositAssetsEffectOfChangeInPresentValueAssumptionsResultingInAdditionsToExpectedRecoveries and DepositLiabilitiesEffectOfChangeInPresentValueAssumptionsResultingInAdditionsToExpectedRecoveries."
-],
-"OtherComprehensiveIncomeDefinedBenefitPlansNetUnamortizedGainLossArisingDuringPeriodBeforeTax": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is OtherComprehensiveIncomeLossPensionAndOtherPostretirementBenefitPlansNetUnamortizedGainLossArisingDuringPeriodBeforeTax."
-],
-"DescriptionAndEffectsOfChangesInPrepaymentEstimateAssumptionsForCMOsAndREMICsLineItems": [
-"2013-01-31",
-"Element was deprecated."
-],
-"AverageRemainingMaturityOfForeignCurrencyDerivatives": [
-"2012-01-31",
-"Element was deprecated because it has a durationStringItemType. Possible replacement is AverageRemainingMaturityOfForeignCurrencyDerivatives1."
-],
-"DerivativeFinancialInstrumentsAssetsFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
-],
-"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureDevelopmentCosts1": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesDevelopmentCosts."
-],
-"ForeignCurrencyDerivativesAtFairValueNetAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"ComponentOfOtherOperatingCostAndExpenseGeneralAxis": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"DebtInstrumentCollateralFees": [
-"2012-01-31",
-"Element was deprecated because it has a stringItemType. Possible replacement is DebtInstrumentCollateralFee."
-],
-"LiabilityForTitleClaimsAndClaimsAdjustmentExpenseKnownClaims": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseReportedClaimsAmount and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"PremiumsEarnedNetAccidentAndHealthAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"OtherTaxCarryforwardGrossAmount": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TaxCreditCarryforwardAmount."
-],
-"OtherComprehensiveIncomeLossForeignCurrencyTransactionAndTranslationReclassificationAdjustmentRealizedUponSaleOrLiquidationBeforeTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossForeignCurrencyTransactionAndTranslationReclassificationAdjustmentFromAOCIRealizedUponSaleOrLiquidationBeforeTax."
-],
-"OtherTaxCarryforwardLimitationsOnUse": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TaxCreditCarryforwardLimitationsOnUse."
-],
-"CashOrStockAvailableForDistributionsDescription": [
-"2012-01-31",
-"Element was deprecated because it has a stringItemType. Possible replacements are CashAvailableForDistributions or StockOrUnitsAvailableForDistributions."
-],
-"CollaborativeArrangementsAndNoncollaborativeArrangementTransactionsAxis": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TypeOfArrangementAxis."
-],
-"TradingSecuritiesDebtCurrent": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TradingSecuritiesDebt."
-],
-"FinancialInstrumentsOwnedAndPledgedAsCollateralCaption": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is SecurityOwnedAndPledgedAsCollateralFairValue and members of BalanceSheetLocationAxis."
-],
-"ClassOfWarrantOrRightExercisePriceOfWarrantsOrRights": [
-"2014-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is ClassOfWarrantOrRightExercisePriceOfWarrantsOrRights1."
-],
-"EmployeeServiceShareBasedCompensationAllocationOfRecognizedPeriodCostsReportLineDomain": [
-"2013-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is IncomeStatementLocationDomain."
-],
-"FairValueAssetsMeasuredOnRecurringBasisPremiumsReceivableValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
-],
-"BusinessAcquisitionEntityAcquiredAndReasonForAcquisitionAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"AssumedPremiumsWrittenFinancialGuaranteeInsuranceContracts": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"IncomeLossFromContinuingOperationsPerOutstandingLimitedPartnershipUnitDiluted": [
-"2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromContinuingOperationsNetOfTaxPerOutstandingLimitedPartnershipUnitDiluted."
-],
-"PutOptionsWrittenMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PutOptionMember with ShortMember."
-],
-"AvailableForSaleSecuritiesGrossUnrealizedGainLoss": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is AvailableForSaleSecuritiesGrossUnrealizedGainLoss1."
-],
-"FinancingDomain": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"ClosedBlockOperationsChangeInPolicyholderDividendObligation": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ClosedBlockDividendObligationPeriodIncreaseDecrease."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisGainLossIncludedInEarningsAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"MembersOrLimitedPartnersSubsequentDistributionAmount": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberCashDistributionsPaid and members of SubsequentEventTypeAxis or DistributionMadeToLimitedPartnerCashDistributionsPaid and members of SubsequentEventTypeAxis."
-],
-"SignificantChangeInUnrecognizedTaxBenefitsNatureOfUncertainty": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacement is ReasonablyPossibleSignificantChangeInUnrecognizedTaxBenefitsByItemAxis and extension member elements."
-],
-"FinancingReceivableModificationsNatureAndExtentOfTransaction": [
-"2012-01-31",
-"Element was deprecated. Possible replacements are FinancingReceivableModificationsDeterminationOfAllowanceForCreditLosses1 and FinancingReceivableModificationsSubsequentDefaultDeterminationOfAllowanceForCreditLosses."
-],
-"ServicingAssetsAndServicingLiabilitiesAtFairValueAssumptionsUsedToEstimateFairValueWeightedAverageLife": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is ServicingAssetsAndServicingLiabilitiesAtFairValueAssumptionsUsedToEstimateFairValueWeightedAverageLife1."
-],
-"AgingOfCapitalizedExploratoryWellCostsNumberOfProjectsAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"EarningsPerShareDilutedMember": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"SaleMember": [
-"2012-01-31",
-"Element was deprecated because the dimension of the financial reporting concept was remodeled."
-],
-"FiveYearScheduleOfMaturitiesOfParentCompanyRepaymentOfPrincipleInYearThree": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInYearThree."
-],
-"OtherResearchAndDevelopmentExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OtherResearchAndDevelopmentExpense."
-],
-"CededPremiumsWrittenAccidentAndHealth": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"TaxBenefitFromStockOptionsExercised": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is DeferredTaxExpenseFromStockOptionsExercised."
-],
-"ContractsInForceSubjectToParticipationThroughReinsuranceValue": [
-"2013-01-31",
-"Element was deprecated."
-],
-"PurchasedCallOptionMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CallOptionMember with LongMember."
-],
-"IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingLimitedPartnershipAndGeneralPartnershipUnitBasic": [
-"2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingLimitedPartnershipAndGeneralPartnershipUnitBasic1."
-],
-"TradingAccountAssetsFairValueDisclosure": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TradingSecurities."
-],
-"NotionalAmountOfDerivativesTotalAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"DebtInstrumentSinkingFundAmount": [
-"2012-01-31",
-"Element was deprecated. Possible replacements are DebtInstrumentSinkingFundPayment or DebtInstrumentCumulativeSinkingFundPayments."
-],
-"OtherComprehensiveIncomeReclassificationAdjustmentForHeldToMaturityTransferredToAvailableForSaleSecuritiesNetOfTax": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is OtherComprehensiveIncomeLossTransfersFromHeldToMaturityToAvailableForSaleSecuritiesNetOfTax."
-],
-"ReinsuranceNote": [
-"2013-01-31",
-"Element was deprecated due to remodeling of reinsurance topic area."
-],
-"MaximumTermOfCreditRiskDerivatives": [
-"2012-01-31",
-"Element was deprecated because it has a durationStringItemType. Possible replacement is MaximumTermOfCreditRiskDerivatives1."
-],
-"NoninterestExpenseRelatedToPerformanceFeesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpenseRelatedtoPerformanceFees."
-],
-"MinimumRemainingTermsOfLeasesAndConcessionsOnUndevelopedAcreage": [
-"2012-01-31",
-"Element was deprecated because it has an integerItemType. Possible replacement is MinimumRemainingTermsOfLeasesAndConcessionsOnUndevelopedAcreage1."
-],
-"AvailableForSaleSecuritiesFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
-],
-"AllowanceForNotesReceivable": [
-"2012-01-31",
-"Element was deprecated due to redundancy. Possible replacement is FinancingReceivableAllowanceForCreditLosses."
-],
-"BusinessAcquisitionPurchasePriceAllocationAmortizableIntangibleAssets": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CategoriesOfInvestmentsMarketableSecuritiesTradingSecuritiesMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TradingAccountAssetsMember."
-],
-"FairValueAssetsMeasuredOnNonrecurringBasisValuationTechniquesHeldToMaturitySecurities": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
-],
-"AverageBalanceDuringPeriodOfLoansHeldForSaleOrSecuritization": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"NetIncomeLossPerOutstandingLimitedPartnershipUnit": [
-"2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is NetIncomeLossPerOutstandingLimitedPartnershipUnitBasicNetOfTax."
-],
-"PrescriptionDrugBenefitEffectOfSubsidyOnNetPeriodicPostretirementBenefitCost": [
-"2012-01-31",
-"Element was deprecated because it has an instant period type. Possible replacement is PrescriptionDrugBenefitEffectOfSubsidyOnNetPeriodicPostretirementBenefitCost1."
-],
-"SeparateAccountsAsset": [
-"2012-01-31",
-"Element was deprecated due to redundancy. Possible replacement is SeparateAccountAssets."
-],
-"HeldtomaturitySecuritiesDebtMaturityDateRangeHigh": [
-"2012-01-31",
-"Element was deprecated because it has a durationStringItemType. Possible replacements are HeldtomaturitySecuritiesDebtMaturitiesDate and RangeAxis (MaximumMember)."
-],
-"ImpairmentInValueOfAssetAxis": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"BusinessAcquisitionPreacquisitionContingencyAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"CommonStockIncludingAdditionalPaidInCapital": [
-"2013-01-31",
-"Element was deprecated due to ambiguous definition. Possible replacement is CommonStocksIncludingAdditionalPaidInCapital."
-],
-"NotionalAmountOfInterestRateDerivativeInstrumentsNotDesignatedAsHedgingInstruments": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and HedgingDesignationAxis."
-],
-"RedeemableNoncontrollingInterestAbstract": [
-"2012-01-31",
-"This element was deprecated because its children were relocated."
-],
-"BusinessAcquisitionPurchasePriceAllocationPlant": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsFinishedGoods": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FairValueAssetsMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInInvestmentIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueAssetsMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
-],
-"QualitativeAndQuantitativeInformationAssetsOrLiabilitiesForTransferorsContinuingInvolvementInSecuritizationOrAssetbackedFinancingArrangementPrincipalAmountsOutstanding": [
-"2014-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is ContinuingInvolvementWithTransferredFinancialAssetsPrincipalAmountOutstanding."
-],
-"RetrospectiveEffectOfChangeInAccountingPrincipleTabularPresentationByFinancialStatementLineItemAmountAfterApplicationAbstract": [
-"2012-01-31",
-"This element was deprecated because the children of this abstract were deprecated."
-],
-"FiniteLivedIntangibleAssetsFutureAmortizationExpense": [
-"2012-01-31",
-"Element was deprecated because it has a duration period type. Possible replacement is FiniteLivedIntangibleAssetsNet."
-],
-"BusinessAcquisitionPreexistingRelationshipGainLossRecognized": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is BusinessCombinationSeparatelyRecognizedTransactionsNetGainsAndLosses and members of BusinessCombinationSeparatelyRecognizedTransactionsAxis."
-],
-"AlternativeInvestmentsFairValueDisclosureInputs": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
-],
-"DeferredCompensationArrangementWithIndividualShareBasedPaymentsByTitleOfIndividualAxis": [
-"2013-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is TitleofIndividualAxis."
-],
-"GuaranteesFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
-],
-"CashFlowHedgeLossReclassifiedToOtherIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is OtherIncome and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"CompensatingBalancesCashAndCashEquivalentsAxis": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is CashAndCashEquivalentsAxis."
-],
-"OtherComprehensiveIncomeReclassificationOfDefinedBenefitPlansNetGainLossRecognizedInNetPeriodicBenefitCostTax": [
-"2012-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetGainLossTax."
-],
-"DescriptionOfDerivativeInstrumentsByRiskExposure": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DerivativeUnderlyingRisk."
-],
-"PublicUtilitiesPropertyPlantAndEquipmentAmountOfAcquisitionAdjustments": [
-"2012-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentAmountOfAcquisitionAdjustments1."
-],
-"CertainLoansAcquiredInTransferAccountedForAsHeldToMaturityDebtSecuritiesOtherThanTemporaryImpairmentCharges": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsHeldtomaturityDebtSecuritiesOtherthanTemporaryImpairmentChargesCreditLoss."
-],
-"AssetManagementMember": [
-"2013-01-31",
-"Element was deprecated due to rationalization of dimensions."
-],
-"GainLossOnDispositionOfOtherAssetsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnSaleOfOtherAssets."
-],
-"LoansToFinanceLeveragedBuyout": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"RefinancingOfDebtMember": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"ProductLiabilityContingencyAccrualDiscountAmount": [
-"2012-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LossContingencyAccrualProductLiabilityDiscount."
-],
-"ForeignCurrencyContractAssetFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
-],
-"EntityWideDisclosureOnGeographicAreasRevenueFromExternalCustomersAttributedToEntitysCountryOfDomicile": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Possible replacement is Revenues and members of StatementGeographicalAxis."
-],
-"RevenueFromAdministrativeServicesOther": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AdministrativeServicesRevenue and members of LegalEntityAxis."
-],
-"NetIncomeLossPerOutstandingGeneralPartnershipUnit": [
-"2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is NetIncomeLossPerOutstandingGeneralPartnershipUnitNetOfTax."
-],
-"TradingSecuritiesCurrent": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TradingSecurities."
-],
-"RevenuesFromExternalCustomers": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Possible replacement is Revenues and members of ProductOrServiceAxis or MajorCustomersAxis."
-],
-"TargetOrTrackingStockStockClassAxis": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is StatementClassOfStockAxis."
-],
-"PolicyChargesInsurance": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is InsuranceCommissionsAndFees."
-],
-"CashFlowHedgeGainReclassifiedToOtherExpense": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is OtherCostAndExpenseOperating and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationBuildings": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AvailableforsaleSecuritiesContinuousUnrealizedLossPositionLessThan12MonthsAggregateLosses1": [
-"2012-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is AvailableForSaleSecuritiesContinuousUnrealizedLossPositionLessThan12MonthsAggregateLosses."
-],
-"LeveragedBuyoutUsesOfCashInLeveragedBuyoutTransactionAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"BusinessAcquisitionPurchasePriceAllocationNoncurrentLiabilities": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"IndefiniteLivedIntangibleAssets": [
-"2012-01-31",
-"Element was deprecated due to redundancy. Possible replacement is IndefiniteLivedIntangibleAssetsExcludingGoodwill."
-],
-"NetInvestmentIncomeInsuranceEntityMortgageLoansOnRealEstate": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NetInvestmentIncome and members of InvestmentTypeAxis."
-],
-"GainLossOnSaleOfInterestInProjectsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"BusinessAcquisitionPeriodResultsIncludedInCombinedEntity": [
-"2012-01-31",
-"Element was deprecated because it has a dateStringItemType. Possible replacement is BusinessAcquisitionPeriodResultsIncludedInCombinedEntity1."
-],
-"DevelopmentStageEnterpriseCumulativeExpense": [
-"2012-01-31",
-"Element was deprecated because different elements should not be used to tag expenses for the period and to tag expenses since inception. Possible replacement is CostsAndExpenses."
-],
-"FiniteLivedCopyrightsGross": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FiniteLivedIntangibleAssetsGross and members of FiniteLivedIntangibleAssetsByMajorClassAxis."
-],
-"LifeSettlementContractsFairValueMethodDisclosureItemsLineItems": [
-"2012-01-31",
-"This element has been deprecated as the maturity schedule has been remodeled using line items instead of dimensions. If you have used this element in the past, use the line items found as children of ScheduleOfLifeSettlementContractsFairValueMethodTextBlock."
-],
-"PaymentAndPerformanceRiskCreditRatingAxis": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are CreditRatingAMBestAxis, CreditRatingMoodysAxis, CreditRatingStandardPoorsAxis, CreditRatingFitchAxis, ExternalCreditRatingByGroupingAxis, InternalCreditAssessmentAxis."
-],
-"DirectPremiumsWrittenFinancialGuaranteeInsuranceContracts": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"DistributionMadeToMemberOrLimitedPartnerDateOfRecord1": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberDateOfRecord or DistributionMadeToLimitedPartnerDateOfRecord."
-],
-"AdvancePaymentsByBorrowersForTaxesAndInsuranceRelatedText": [
-"2012-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AdvancePaymentsByBorrowersForTaxesAndInsuranceSummary."
-],
-"ReinsurancePremiumsForInsuranceCompaniesByProductSegmentPercentageOfAmountAssumedToNet": [
-"2013-01-31",
-"Element was deprecated. Possible replacement is PremiumsPercentageAssumedToNet."
-],
-"InitialMeasurementOfInterestsContinuedToBeHeldByTransferorWhenSecuritizedFinancialAssetsAreAccountedForAsSalePolicy": [
-"2012-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DistributionMadeToMemberOrLimitedPartnerShareDistribution": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberUnitDistribution or DistributionMadeToLimitedPartnerUnitDistribution."
-],
-"PremiumsWrittenNetFinancialGuaranteeInsuranceContracts": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PremiumsWrittenNet and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"NewAccountingPronouncementOrChangeInAccountingPrincipleCumulativeEffectOfChangeOnEquityOrNetAssets": [
-"2012-01-31",
-"Element was deprecated because it has a duration period type. Possible replacement is NewAccountingPronouncementOrChangeInAccountingPrincipleCumulativeEffectOfChangeOnEquityOrNetAssets1."
-],
-"MortgageBackedSecuritiesAvailableForSaleFairValueDisclosureAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
-],
-"FairValueAssetsMeasuredOnRecurringBasisGainLossIncludedInOtherIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisAssetGainLossIncludedInEarnings1 and members of IncomeStatementLocationAxis."
-],
-"CededPremiumsEarnedOtherInsurance": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"FinancingReceivableInformationByPortfolioSegmentAxis": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is FinancingReceivableRecordedInvestmentByClassOfFinancingReceivableAxis."
-],
-"SharebasedCompensationSharesAuthorizedUnderStockOptionPlansExercisePriceRangeOutstandingOptionsWeightedAverageRemainingContractualTerm1": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is SharebasedCompensationSharesAuthorizedUnderStockOptionPlansExercisePriceRangeOutstandingOptionsWeightedAverageRemainingContractualTerm2."
-],
-"RealizedGainLossOnSaleOfInvestmentsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is RealizedInvestmentGainsLosses."
-],
-"ContractHolderReceivables": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is PremiumsReceivableGross."
-],
-"HeldToMaturitySecuritiesContinuousUnrealizedLossPositionAggregateLosses": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is HeldToMaturitySecuritiesContinuousUnrealizedLossPositionAggregateLoss."
-],
-"CreditDerivativeCurrentFairValue": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is CreditRiskDerivativeLiabilitiesAtFairValue."
-],
-"SubsequentEventDateFinancialStatementsIssued1": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"GainLossOnDispositionOfProperty": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is GainLossOnDispositionOfAssets."
-],
-"FairValueByBalanceSheetGroupingMethodologyAndAssumptionsAbstract": [
-"2012-01-31",
-"This element was removed because its children were deprecated after the disclosure was dimensionalized."
-],
-"EffectOfChangeInCashFlowProjectionEstimate": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseReportedClaimsCommentary": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilityForClaimsAndClaimsAdjustmentExpenseMethodologiesAndAssumptions."
-],
-"DerecognizedAssetsSecuritizedOrAssetbackedFinancingArrangementAssetsAndAnyOtherFinancialAssetsManagedTogetherByTypeOfFinancialInstrumentAxis": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is FinancialInstrumentAxis."
-],
-"ComponentOfOtherIncomeNonoperatingAxis": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"BusinessAcquisitionContingentConsiderationSharesIssuableDescription": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"SecuritiesSoldNotYetPurchasedFairValueDisclosure": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is FinancialInstrumentsSoldNotYetPurchasedAtFairValue."
-],
-"MaterialEffectOnLiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseFromChangeInAccountingPrincipleMember": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are members of AdjustmentsForChangeInAccountingPrincipleAxis."
-],
-"BadDebtReserveForTaxPurposesOfUSSavingsAndLoanAssociationsOrOtherQualifiedThriftLenderMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are BadDebtReserveForTaxPurposesOfQualifiedLender, DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferenceBadDebtReserveForTaxPurposesOfQualifiedLender, DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxableBadDebtReserveForTaxPurposesOfQualifiedLender, DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityBadDebtReserveForTaxPurposesOfQualifiedLender,  and DeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticableBadDebtReserveForTaxPurposesOfQualifiedLender."
-],
-"LiabilitiesSubjectToCompromiseBalanceAtBankruptcyEffectiveDate": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilitiesSubjectToCompromise."
-],
-"ScheduleOfLifeSettlementContractsFairValueMethodFiveYearDisclosureAxis": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept modeled as a dimension was replaced with line items. Possible replacement is line items within ScheduleOfLifeSettlementContractsFairValueMethodTextBlock."
-],
-"NotionalAmountOfCreditRiskDerivatives": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of CreditDerivativesByContractTypeAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentLiabilitiesAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"SaleDomain": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"DerivativeAverageForwardExchangeRate": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is DerivativeAverageForwardExchangeRate1."
-],
-"FairValueAssetsMeasuredOnRecurringBasisGainLossIncludedInEarningsAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"AccountingStandardsUpdate200915Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"ExpropriationOfAssetsDomain": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"NotionalAmountOfPriceRiskCashFlowHedgeDerivatives": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis and DerivativeInstrumentRiskAxis."
-],
-"TaxBenefitFromStockOptionsExercised1": [
-"2013-01-31",
-"Element was deprecated because it was incorrectly defined. Possible replacement is DeferredTaxExpenseFromStockOptionsExercised."
-],
-"AmortizationOfDeferredSalesCommissionsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"FinancingReceivableModificationsPreModificationRecordedInvestment1": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is FinancingReceivableModificationsPreModificationRecordedInvestment2."
-],
-"NotionalAmountOfPriceRiskFairValueHedgeDerivatives": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
-],
-"BusinessAcquisitionCostOfAcquiredEntityCashPaid": [
-"2013-01-31",
-"Element was deprecated because it has debit balance and instant period type attributes. Possible replacement is PaymentsToAcquireBusinessesGross."
-],
-"CededPremiumsEarnedLife": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"SegmentReportingGeneralInformation": [
-"2012-01-31",
-"Element was deprecated. Possible replacements are FactorsUsedToIdentifyEntitysReportableSegments or DescriptionOfTypesOfProductsAndServicesFromWhichEachReportableSegmentDerivesItsRevenues."
-],
-"CumulativeEffectAdjustmentApplicationOfFairValueOptionUnrealizedLossesUnrecognized": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReserves10PercentAnnualDiscountForEstimatedTimingOfCashFlows": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesTenPercentAnnualDiscountForEstimatedTimingOfCashFlows."
-],
-"TaxesAndLicensesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is TaxesAndLicenses."
-],
-"CommonStockIncludingAdditionalPaidInCapitalNetOfDiscount": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is CommonStocksIncludingAdditionalPaidInCapitalNetOfDiscount."
-],
-"DistributionPaymentFormsOtherThanCashOrStockDescription": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionPaymentMadeToLimitedLiabilityCompanyLLCMemberFormsOtherThanCashOrStockDescription or DistributionPaymentMadeToLimitedPartnerFormsOtherThanCashOrStockDescription."
-],
-"CorporateCreditQualityIndicatorMember": [
-"2013-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is InternalCreditAssessmentDomain."
-],
-"CededCreditRiskAmountAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"FairValueByBalanceSheetGroupingDisclosureItemAmountsAxis": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is FairValueByMeasurementBasisAxis."
-],
-"TradingAccountAssetsFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
-],
-"InternallyAssignedGradeMember": [
-"2013-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is InternalCreditAssessmentDomain."
-],
-"HeldToMaturitySecuritiesDebtMaturitiesFairValue": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is HeldToMaturitySecuritiesFairValue."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsInventoryAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"CashForLeveragedBuyoutBySourceAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"IncreaseDecreaseInFairValueOfUnhedgedDerivativeInstruments": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DerivativeInstrumentsNotDesignatedAsHedgingInstrumentsGainLossNet."
-],
-"CapitalizedExploratoryWellCostsGreaterThanOrEqualToThreeYearsAndLessThanFourYears": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CapitalizedExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
-],
-"FairValueAssetsMeasuredOnNonrecurringBasisValuationTechniquesAssetsHeldForSaleLongLived": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
-],
-"SaleLeasebackTransactionCumulativeGainRecognized": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is SaleLeasebackTransactionCumulativeGainRecognized1."
-],
-"DebtInstrumentOfferingDate": [
-"2012-01-31",
-"Element was deprecated because it has a dateStringItemType. Possible replacement is DebtInstrumentOfferingDate1."
-],
-"CategoriesOfInvestmentsMarketableSecuritiesHeldToMaturitySecuritiesMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is HeldtomaturitySecuritiesMember."
-],
-"LiabilitiesRelatedToInvestmentContractsFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseClaimsPaidPriorYears": [
-"2014-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseClaimsPaidPriorYears1."
-],
-"ScheduleOfEquityIssuedSinceInceptionTable": [
-"2012-01-31",
-"Element was deprecated because it used a dimension to differentiate equity issuances. Possible replacement is the date context to differentiate equity issuances."
-],
-"RealEstateWriteDownOrReserveByPropertyAxis": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is RealEstateAndAccumulatedDepreciationDescriptionOfPropertyAxis."
-],
-"FairValueAssetsMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInTradingRevenue": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueAssetsMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
-],
-"OtherComprehensiveIncomeReclassificationAdjustmentForSaleOfSecuritiesIncludedInNetIncomeBeforeTax": [
-"2012-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForSaleOfSecuritiesBeforeTax."
-],
-"BusinessAcquisitionCostOfAcquiredEntityEquityInterestsIssuedAndIssuable": [
-"2013-01-31",
-"Element deprecated because it has a debit balance attribute and instant period type. Possible replacement is BusinessCombinationConsiderationTransferredEquityInterestsIssuedAndIssuable."
-],
-"BusinessAcquisitionPurchasePriceAllocationNotesPayableAndLongTermDebt": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsExpirationsInPeriodWeightedAverageExercisePrice": [
-"2012-01-31",
-"Element was deprecated because it has an instant period type. Possible replacement is ShareBasedCompensationArrangementsByShareBasedPaymentAwardOptionsExpirationsInPeriodWeightedAverageExercisePrice."
-],
-"UndistributedDomesticEarningsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are UndistributedEarningsOfDomesticSubsidiaries, DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferenceUndistributedEarningsOfDomesticSubsidiaries, DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxableUndistributedEarningsOfDomesticSubsidiaries, DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityUndistributedEarningsOfDomesticSubsidiaries, or DeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticableUndistributedEarningsOfDomesticSubsidiaries."
-],
-"DerivativeInstrumentsLossRecognizedInIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeLossOnDerivative and members of HedgingDesignationAxis."
-],
-"AvailableforsaleSecuritiesDebtMaturityDateRangeHigh": [
-"2012-01-31",
-"Element was deprecated because it has a durationStringItemType. Possible replacements are AvailableforsaleSecuritiesDebtMaturitiesDate and RangeAxis (MaximumMember)."
-],
-"EquityClassOfTreasuryStockAxis": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is StatementClassOfStockAxis."
-],
-"ChangeInUnrealizedGainLossOnForeignCurrencyFairValueHedgingInstruments": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is ChangeInUnrealizedGainLossOnForeignCurrencyFairValueHedgingInstruments1."
-],
-"UnusualOrInfrequentItemGross": [
-"2012-01-31",
-"Element was deprecated because it represented both a gain and a loss. Possible replacement for a gain is UnusualOrInfrequentItemGainGross, or UnusualOrInfrequentItemLossGross to represent a loss."
-],
-"BusinessAcquisitionPurchasePriceAllocationNegativeGoodwillDescription": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"BusinessAcquisitionPurchasePriceAllocationNaturalResources": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FairValueAssetsMeasuredOnNonrecurringBasisValuationTechniquesInvestmentsInPowerAndDistributionProjects": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
-],
-"LeaseConcessions": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AmortizationOfLeaseIncentives."
-],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardCompensationCost": [
-"2012-01-31",
-"Element was deprecated. Possible replacements are AllocatedShareBasedCompensationExpense and/or EmployeeServiceShareBasedCompensationAllocationOfRecognizedPeriodCostsCapitalizedAmount."
-],
-"DistributionMadeToMemberOrLimitedPartnerDateOfRecord": [
-"2012-01-31",
-"Element was deprecated because it has a dateStringItemType. If you have used this element in the past, consider replacing it with DistributionMadeToLimitedLiabilityCompanyLLCMemberDateOfRecord or DistributionMadeToLimitedPartnerDateOfRecord."
-],
-"DefinedBenefitPlanRecognizedNetGainLossDueToSettlements": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is DefinedBenefitPlanRecognizedNetGainLossDueToSettlements1."
-],
-"FinancingReceivableAllowanceForCreditLossesIndividuallyEvaluatedForImpairment": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is FinancingReceivableAllowanceForCreditLossesIndividuallyEvaluatedForImpairment1."
-],
-"CumulativeEffectOnRetainedEarningsNetOfTax": [
-"2012-01-31",
-"Element was deprecated because it has an instant period type. Possible replacement is CumulativeEffectOnRetainedEarningsNetOfTax1."
-],
-"PutOptionsPurchasedMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PutOptionMember with LongMember."
-],
-"SubsequentEventRevisedFinancialStatementsDateEvaluatedDescription": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"SeveranceCosts": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area. Possible replacement is SeveranceCosts1."
-],
-"FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisGainLossIncludedInEarningsAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"DefinedBenefitPlanExpectedFutureBenefitPaymentsInYearOne": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is DefinedBenefitPlanExpectedFutureBenefitPaymentsNextTwelveMonths."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisSubordinatedDebtObligationsValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
-],
-"BusinessIntersegmentEliminationsMember": [
-"2012-01-31",
-"Element was deprecated due to redundancy. Possible replacement is IntersegmentEliminationMember."
-],
-"SecuritiesLoanedOrSoldUnderAgreementsToRepurchaseFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
-],
-"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesStandardizedMeasure": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is StandardizedMeasureOfDiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReserves."
-],
-"LeveragedBuyoutPercentageOfPurchasePriceAllocatedToAssetsAndLiabilitiesAcquiredAtFairValue": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"ComponentOfOtherIncomeNonoperatingTable": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"MortgageLoansOnRealEstateFederalIncomeTaxBasis": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is MortgageLoansOnRealEstateFederalIncomeTaxBasis1."
-],
-"SubsequentEventDateThroughWhichEvaluated": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"SubsequentEventRevisedFinancialStatementsDateEvaluated": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"GasAndOilAcreageDevelopedGross": [
-"2012-01-31",
-"Element was deprecated because it has an integerItemType. Possible replacement is GasAndOilAreaDevelopedGross."
-],
-"DebtInstrumentConvertibleRemainingDiscountAmortizationPeriod": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is DebtInstrumentConvertibleRemainingDiscountAmortizationPeriod1."
-],
-"DebtorReorganizationItemsGainLossOnAssetSalesNet": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is DebtorReorganizationItemsGainLossOnAssetSalesNet1."
-],
-"BusinessAcquisitionPurchasePriceAllocationOtherLiabilities": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"ServicingLiabilityAtAmortizedValueFairValue": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is ServicingLiabilityAtAmortizedValueFairValue1."
-],
-"NewAccountingPronouncementOrChangeInAccountingPrincipleProFormaDisclosuresRevenueRecognizedAmount": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisGuaranteesValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
-],
-"AllowanceForLoanAndLeaseLossesProvisionForLossNet": [
-"2013-01-31",
-"Element was deprecated because it is an invalid concept. Possible replacement is ProvisionForLoanAndLeaseLosses."
-],
-"NotionalAmountOfForeignCurrencyDerivativePurchaseContracts": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and PositionAxis."
-],
-"ChangeInUnrealizedGainLossOnHedgedItemInFairValueHedge": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is ChangeInUnrealizedGainLossOnHedgedItemInFairValueHedge1."
-],
-"ForwardContractIndexedToIssuersEquitySettlementAlternativesAtFairValue": [
-"2012-01-31",
-"Element was deprecated because it has a stringItemType. Possible replacements are ForwardContractIndexedToIssuersEquitySettlementAlternativesCashAtFairValue or ForwardContractIndexedToIssuersEquitySettlementAlternativesSharesAtFairValue."
-],
-"FederalFundsPurchasedFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
-],
-"BankruptcyDomain": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"BusinessAcquisitionPreexistingRelationshipDescription": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is BusinessCombinationSeparatelyRecognizedTransactionsDescription and members of BusinessCombinationSeparatelyRecognizedTransactionsAxis."
-],
-"DefinedBenefitPlanEffectOfOnePercentagePointDecreaseOnAccumulatedPostretirementBenefitObligation": [
-"2012-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is DefinedBenefitPlanEffectOfOnePercentagePointDecreaseOnAccumulatedPostretirementBenefitObligation1."
-],
-"DefinedBenefitPlanTargetAllocationPercentagesOfAssetsOtherAbstract": [
-"2012-01-31",
-"This element has been deprecated."
-],
-"CategoriesOfInvestmentsMarketableSecuritiesAvailableForSaleSecuritiesMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AvailableforsaleSecuritiesMember."
-],
-"OtherComprehensiveIncomeLossForeignCurrencyTranslationReclassificationAdjustmentRealizedUponSaleOrLiquidationTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossForeignCurrencyTransactionAndTranslationReclassificationAdjustmentFromAOCIRealizedUponSaleOrLiquidationTax."
-],
-"NoninterestExpensePrintingAndFulfillmentMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpensePrintingandFulfillment."
-],
-"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionRangeOfRestrictionPeriodLowEnd": [
-"2012-01-31",
-"Element was deprecated because it has an instant period type. Possible replacement is FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionPeriod and members of RangeAxis."
-],
-"InvestmentOwnedZeroBalanceMayReflectAmountRoundedToZeroFlag": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is InvestmentOwnedZeroBalanceMayReflectAmountRoundedToZeroFlag1."
-],
-"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureProductionCosts": [
-"2013-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesProductionCosts."
-],
-"FiniteLivedTradeSecretsGross": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FiniteLivedIntangibleAssetsGross and members of FiniteLivedIntangibleAssetsByMajorClassAxis."
-],
-"MinorRestatementOfOpeningLiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseSAB108Member": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are members of ErrorCorrectionsAndPriorPeriodAdjustmentsRestatementByRestatementPeriodAndAmountAxis."
-],
-"GainLossOnCondemnationNetOfTaxMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"TimeSharingTransactionsRangeOfStatedInterestRatesForNotesReceivable": [
-"2012-01-31",
-"Element was deprecated because it has an integerItemType. Possible replacements are TimeSharingTransactionsStatedInterestRatesForNotesReceivableMinimum or TimeSharingTransactionsStatedInterestRatesForNotesReceivableMaximum."
-],
-"OtherComprehensiveIncomeLossForeignCurrencyTransactionAndTranslationReclassificationAdjustmentRealizedUponSaleOrLiquidationNetOfTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossForeignCurrencyTransactionAndTranslationReclassificationAdjustmentFromAOCIRealizedUponSaleOrLiquidationNetOfTax."
-],
-"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsMinimumPensionLiabilityAdjustment": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"NotesPayableFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
-],
-"BusinessCombinationConsiderationTransferredIncludingEquityInterestInAcquireeHeldPriorToCombination": [
-"2013-01-31",
-"Element was deprecated because it has debit balance and instant period type attributes. Possible replacement is BusinessCombinationConsiderationTransferredIncludingEquityInterestInAcquireeHeldPriorToCombination1."
-],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsOutstandingWeightedAverageRemainingContractualTerm": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsOutstandingWeightedAverageRemainingContractualTerms."
-],
-"LossesGainsOnSalesOfAssetsAndAssetImpairmentCharges": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is GainLossOnSalesOfAssetsAndAssetImpairmentCharges."
-],
-"BorrowingsToFinanceLeveragedBuyoutAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"DefinedBenefitPlanDebtSecurities": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacement is DefinedBenefitPlanWeightedAverageAssetAllocations."
-],
-"OtherInterestIncomeMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is InterestIncomeOther."
-],
-"TimeSharingTransactionsAdditionsToAllowanceForCurrentPeriodSales": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is TimeSharingTransactionsAdditionsToAllowanceForCurrentPeriodSales1."
-],
-"ResaleAgreementCounterpartyWeightedAverageMaturityOfAgreements": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is ResaleAgreementCounterpartyWeightedAverageMaturityOfAgreements1."
-],
-"FairValuePlanAssetMeasurementDomain": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is FairValueMeasurementsFairValueHierarchyDomain."
-],
-"SalesCommissionsAndFeesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is SalesCommissionsAndFees."
-],
-"OtherComprehensiveIncomeReclassificationAdjustmentOnDerivativesIncludedInNetIncomeNetOfTax": [
-"2012-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIOnDerivativesNetOfTax."
-],
-"DeferredTaxLiabilitiesPrepaidPensionCosts": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DisposalGroupIncludingDiscontinuedOperationGoodwill": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DisposalGroupIncludingDiscontinuedOperationGoodwillNoncurrent, DisposalGroupIncludingDiscontinuedOperationGoodwillCurrent or DisposalGroupIncludingDiscontinuedOperationGoodwill1."
-],
-"CashFlowHedgeGainReclassifiedToInterestExpense": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is InterestExpense and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationNoncurrentLiabilitiesAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"DebtInstrumentInterestRateIncrease": [
-"2013-01-31",
-"Element was deprecated because it has a pureItemType attribute. Possible replacement is DebtInstrumentInterestRateIncreaseDecrease."
-],
-"HeldtomaturitySecuritiesUnrecognizedHoldingGain": [
-"2013-01-31",
-"Element was deprecated because it has debit balance and instant period type attributes. Possible replacement is HeldtomaturitySecuritiesUnrecognizedHoldingGains."
-],
-"NoninterestExpenseCommissionExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpenseCommissionExpense."
-],
-"DepositAssetsOrLiabilitiesAmortizationExpenseFromExpirations": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacement is DepositAssetsAmortizatonExpenseFromExpirations."
-],
-"FiveYearScheduleOfMaturitiesOfDebtOfParentCompanyAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"ReinsuranceEffectOnClaimsAndBenefitsIncurredNetAmount": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is PolicyholderBenefitsAndClaimsIncurredNet."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsDescription": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"MembersOrLimitedPartnersSubsequentDistributionDate": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberDistributionDate and members of SubsequentEventTypeAxis or DistributionMadeToLimitedPartnerDistributionDate and members of SubsequentEventTypeAxis."
-],
-"CashFlowHedgeGainLossReclassifiedToOtherExpenseNet": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is OtherCostAndExpenseOperating and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"AmortizationPeriodOfDeferredGainLossOnDiscontinuationOfPriceRiskFairValueHedge": [
-"2012-01-31",
-"Element was deprecated because it has a durationStringItemType. Possible replacement is AmortizationPeriodOfDeferredGainLossOnDiscontinuationOfPriceRiskFairValueHedge1."
-],
-"MinorityInterestInNetIncomeLossJointVenturePartners": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacement is NoncontrollingInterestInNetIncomeLossJointVenturePartnersNonredeemable or NoncontrollingInterestInNetIncomeLossJointVenturePartnersRedeemable."
-],
-"FiniteLivedFranchiseRightsGross": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FiniteLivedIntangibleAssetsGross and members of FiniteLivedIntangibleAssetsByMajorClassAxis."
-],
-"ReinsurancePremiumsForInsuranceCompaniesByProductSegmentNetAmount": [
-"2013-01-31",
-"Element was deprecated. Possible replacement is PremiumsEarnedNet."
-],
-"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionLapseDate": [
-"2012-01-31",
-"Element was deprecated because it has a dateStringItemType. Possible replacement is FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionLapseDate1."
-],
-"SecuritizedAssetsAndAnyOtherFinancialAssetsManagedTogetherByTypeOfFinancialInstrumentAxis": [
-"2014-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is FinancialInstrumentAxis."
-],
-"FairValueAssetsMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInOtherIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueAssetsMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
-],
-"ShareBasedGoodsAndNonemployeeServicesTransactionValuationMethodExpectedTerm": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is ShareBasedGoodsAndNonemployeeServicesTransactionValuationMethodExpectedTerm1."
-],
-"GasAndOilAcreageUndevelopedNet": [
-"2012-01-31",
-"Element was deprecated because it has an integerItemType. Possible replacement is GasAndOilAreaUndevelopedNet."
-],
-"FairValueEstimateNotPracticableReasonsRetainedInterest": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CertainLoansAcquiredInTransferNotAccountedForAsDebtSecuritiesAllowanceForLoanLossesDecreases": [
-"2012-01-31",
-"Element was deprecated because it has an instant period type. Possible replacement is CertainLoansAcquiredInTransferNotAccountedForAsDebtSecuritiesAllowanceForLoanLossesDecreases1."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInTradingRevenue": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueLiabilitiesMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseClaimsPaid": [
-"2014-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is PaymentsForLossesAndLossAdjustmentExpense."
-],
-"OtherMaterialNoncashItems": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Possible replacement is corresponding primary line items and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
-],
-"ConcentrationRiskPercentage": [
-"2012-01-31",
-"This element has been deprecated as it has a period type of instant. If you have used it in the past, use ConcentrationRiskPercentage1."
-],
-"EnvironmentalRemediationExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is EnvironmentalRemediationExpense."
-],
-"FairValueAssetsMeasuredOnRecurringBasisNotesReceivableValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
-],
-"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationEstimatedAmountAmortizedYearThree": [
-"2012-01-31",
-"Element was deprecated because it has a duration period type and a credit balance attribute. Possible replacement is IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationAmortizationExpenseYearThree."
-],
-"EquityIssuanceTotalDollarAmount": [
-"2012-01-31",
-"Element was deprecated because it has an instant period type. Possible replacements are StockIssuedDuringPeriodValueIssuedForCash or StockIssuedDuringPeriodValueIssuedForNoncashConsiderations."
-],
-"CumulativeEffectOfChangeInAccountingPrincipleTabularPresentationByFinancialStatementLineItemAdjustmentAmount": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are NewAccountingPronouncementsOrChangeInAccountingPrincipleTable to model the financial reporting concept. Line items that can be used instead of this element include, but are not limited to, IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest, ProfitLoss, EarningsPerShareBasic, and EarningsPerShareDiluted."
-],
-"LinesOfCreditFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
-],
-"OtherTaxCarryforwardDataByItemAxis": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TaxCreditCarryforwardAxis."
-],
-"CededPremiumsEarnedFinancialGuaranteeInsuranceContracts": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"FairValueAssetsMeasuredOnNonrecurringBasisValuationTechniquesRegulatoryAssetsNoncurrent": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
-],
-"FairValueLevel1ToLevel2TransfersAmount": [
-"2012-01-31",
-"Element was deprecated. Possible replacements are FairValueAssetsLevel1ToLevel2TransfersAmount, FairValueLiabilitiesLevel1ToLevel2TransfersAmount, or FairValueEquityLevel1ToLevel2TransfersAmount."
-],
-"SubsequentEventAmountHigherRange": [
-"2013-01-31",
-"Element was deprecated because it is an invalid concept."
-],
-"LossContingencyRelatedReceivableCarryingValue": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is LossContingencyReceivable."
-],
-"FairValueByBalanceSheetGroupingMethodologyFinancialAssetsAbstract": [
-"2012-01-31",
-"This element was removed because its children were deprecated after the disclosure was dimensionalized."
-],
-"AccountingStandardsUpdate200913Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentLiabilitiesOtherLiabilities": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DerivativeInstrumentsGainLossRecognizedInIncomeNetAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"FairValueByBalanceSheetGroupingMethodologyFinancialLiabilitiesAbstract": [
-"2012-01-31",
-"This element was removed because its children were deprecated after the disclosure was dimensionalized."
-],
-"BusinessAcquisitionCostOfAcquiredEntityLiabilitiesIncurred": [
-"2013-01-31",
-"Element was deprecated because it has debit balance and instant period type attributes.  Possible replacement is BusinessCombinationConsiderationTransferredLiabilitiesIncurred."
-],
-"DebtInstrumentDecreaseRepayments": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replace is RepaymentsOfDebt."
-],
-"EffectsOfReinsuranceAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"CashFlowHedgeLossReclassifiedToEarnings": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProfitLoss and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"DerivativeLiabilityFairValueNet": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is DerivativeFairValueOfDerivativeLiabilityAmountNotOffsetAgainstCollateral."
-],
-"LeveragedBuyoutPercentageOfPurchasePriceAllocatedToAssetsAndLiabilitiesAcquiredAtCarryoverBasis": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DebtorReorganizationItemsNetGainLossOnRejectionOfLeasesAndOtherExecutoryContracts": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is DebtorReorganizationItemsNetGainLossOnRejectionOfLeasesAndOtherExecutoryContracts1."
-],
-"IntangibleAssetsArisingAcquiredInBusinessCombinationEstimatedAmountAmortizedYearOne": [
-"2012-01-31",
-"Element was deprecated because it has a period type of duration and a credit balance attribute. Possible replacement is IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationAmortizationExpenseNextTwelveMonths."
-],
-"GuaranteedBenefitsIncurred": [
-"2013-01-31",
-"Element was deprecated because it has a stringItemType attribute. Possible replacement is LiabilitiesForGuaranteesOnLongDurationContractsIncurredBenefits1."
-],
-"CommonStockholdersEquity": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is StockholdersEquity."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsMerchandise": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AmortizationPeriodOfDeferredGainLossOnDiscontinuationOfInterestRateFairValueHedge": [
-"2012-01-31",
-"Element was deprecated because it has a durationStringItemType. Possible replacement is AmortizationPeriodOfDeferredGainLossOnDiscontinuationOfInterestRateFairValueHedge1."
-],
-"ChangeInHistoricalClaimsRateExperienceMember": [
-"2014-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"FairValueNotesPayableValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
-],
-"MaximumLengthOfTimeHedgedInForeignCurrencyCashFlowHedge": [
-"2013-01-31",
-"Element was deprecated because it is has a stringItemType attribute. Possible replacement is MaximumLengthOfTimeForeignCurrencyCashFlowHedge."
-],
-"SiteContingencyNatureOfContingencyDomain": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are EnvironmentalRemediationSiteDomain or EnvironmentalRemediationContingencyDomain."
-],
-"DerivativeFairValueGrossAmountNotOffsetAgainstCollateralNet": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DerivativeFairValueOfDerivativeNet."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentLiabilitiesDescription": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsExercisableWeightedAverageRemainingContractualTerm": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsExercisableWeightedAverageRemainingContractualTerm1."
-],
-"DirectPremiumsEarnedPropertyAndCasualty": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"OtherTaxCarryforwardExpirationDates": [
-"2013-01-31",
-"Element was deprecated because it is has a stringItemType attribute. Possible replacement is TaxCreditCarryforwardExpirationDate."
-],
-"FederalHomeLoanBankAdvancesGeneralDebtObligationsDisclosuresRepaymentsAndPenalties": [
-"2012-01-31",
-"Element was deprecated because it has a stringItemType. Possible replacement is FederalHomeLoanBankAdvancesGeneralDebtObligationsDisclosuresRepaymentAndPenalties."
-],
-"ReceivablesFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
-],
-"SegmentReportingInformationNetAssets": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Possible replacement is corresponding primary line items and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationNoncurrentAssetsAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"ServicingAssetAtAmortizedValueChangesInCarryingAmountLocationInIncomeStatementDescription": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ServicingAssetAtAmortizedValue and members of IncomeStatementLocationAxis."
-],
-"DerivativeInstrumentsGainLossReclassificationFromAccumulatedOCIToIncomeEstimateOfTimeToTransfer": [
-"2012-01-31",
-"Element was deprecated because it has a durationStringItemType. Possible replacement is DerivativeInstrumentsGainLossReclassificationFromAccumulatedOCIToIncomeEstimateOfTimeToTransfer1."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentLiabilities": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FinancingReceivableModificationsPreModificationRecordedInvestment": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is FinancingReceivableModificationsPreModificationRecordedInvestment2."
-],
-"OtherThanTemporaryImpairmentLossesInvestmentsAvailableforsaleSecuritiesPortionRecognizedInEarningsNetQualitativeDisclosuresThirdPartyGuaranteesDescription": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AvailableforsaleSecuritiesInUnrealizedLossPositionsQualitativeDisclosureOtherThirdPartyGuaranteesDescription."
-],
-"MaterialErrorInLiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseMember": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are members of ErrorCorrectionsAndPriorPeriodAdjustmentsRestatementByRestatementPeriodAndAmountAxis."
-],
-"ScheduleOfCalculationOfNumeratorAndDenominatorInEarningsPerShareTableTextBlock": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ScheduleOfEarningsPerShareBasicAndDilutedTableTextBlock."
-],
-"FairValueServicingLiabilityValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
-],
-"MortgageLoansOnRealEstatePeriodicPaymentTermsBalloonPaymentAmount": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are MortgageLoansOnRealEstatePeriodicPaymentTermsBalloonPaymentToBeReceived or DebtInstrumentPeriodicPaymentTermsBalloonPaymentToBePaid."
-],
-"DistributionMadeToMemberOrLimitedPartnerCashDistributionsDeclared": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberCashDistributionsDeclared or DistributionMadeToLimitedPartnerCashDistributionsDeclared."
-],
 "AccountingStandardsUpdate200905Member": [
 "2014-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CededCreditRiskOtherRisks": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"SquareFootageOfRealEstateProperty": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is AreaOfRealEstateProperty."
-],
-"NotionalAmountOfForeignCurrencyDerivativeSaleContracts": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and PositionAxis."
-],
-"AssetOrLiabilityFromTransfersOfFinancialAssetsHavingNoReasonableEstimateOfFairValueNameDomain": [
-"2012-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"RealEstateWriteDownOrReserveAmount": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is SECScheduleIIIRealEstateWriteDownOrReserveAmount."
-],
-"MortgagesHeldForSaleFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
-],
-"BusinessAcquisitionContingentConsiderationAtFairValue": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AssumedPremiumsWrittenOtherInsurance": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"SiteContingencyByNatureAxis": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are EnvironmentalRemediationSiteAxis or EnvironmentalRemediationContingencyAxis."
-],
-"AssumedPremiumsEarnedLife": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"PresentValueOfFutureInsuranceProfitsAmortizationExpense": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsAmortizationExpense1."
-],
-"ChangeInTaxStatusMember": [
-"2012-01-31",
-"Element was deprecated because the dimension of the financial reporting concept was remodeled."
-],
-"PrescriptionDrugSubsidyReceiptsYearOne": [
-"2012-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is PrescriptionDrugSubsidyReceiptsNextTwelveMonths."
-],
-"DeferredTaxLiabilityNotRecognizedAxis": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"SegmentReportingInformationAverageAssets": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Possible replacement is Assets and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
-],
-"PremiumsEarnedNetLifeAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"MinorityInterestExpenseIncomeRealEstateInvestments": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacement is NetIncomeLossFromRealEstateInvestmentPartnershipAttributableToParent."
-],
-"IncomeLossFromDiscontinuedOperationsNetOfTaxPerOutstandingGeneralPartnershipUnit": [
-"2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromDiscontinuedOperationsNetOfTaxPerOutstandingGeneralPartnershipUnit1."
-],
-"ForeignEarningsRepatriatedUnderAmericanJobsCreationActOf2004Abstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"NetInvestmentIncomeInsuranceEntityEquitySecurities": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NetInvestmentIncome and members of InvestmentTypeAxis."
-],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsGrantsInPeriodForfeited": [
-"2012-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsForfeituresInPeriod."
-],
-"CededPremiumsWrittenFinancialGuaranteeInsuranceContracts": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"OtherComprehensiveIncomeLossAmortizationPensionAndOtherPostretirementBenefitPlansNetPriorServiceCostRecognizedInNetPeriodicPensionCostNetOfTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossAmortizationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetPriorServiceCostCreditNetOfTax."
-],
-"DistributionMadeToMemberOrLimitedPartnerDistributionDate": [
-"2012-01-31",
-"Element was deprecated because it has a dateStringItemType. If you have used this element in the past, consider replacing it with DistributionMadeToLimitedLiabilityCompanyLLCMemberDistributionDate or DistributionMadeToLimitedPartnerDistributionDate."
-],
-"BusinessAcquisitionPurchasePriceAllocationPropertyPlantAndEquipmentAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"BusinessCombinationProFormaInformationAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"DefinedBenefitPlanAccumulatedOtherComprehensiveIncomeLossAfterTax": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AccumulatedOtherComprehensiveIncomeLossDefinedBenefitPensionAndOtherPostretirementPlansNetOfTax."
-],
-"OtherComprehensiveIncomeAmortizationOfDefinedBenefitPlanNetPriorServiceCostRecognizedInNetPeriodicPensionCostTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossAmortizationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetPriorServiceCostCreditTax."
-],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardFairValueAssumptionsExpectedTerm": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is SharebasedCompensationArrangementBySharebasedPaymentAwardFairValueAssumptionsExpectedTerm1."
-],
-"PropertyPlantAndEquipmentUsefulLifeMaximum": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType and the financial reporting concept was modeled as a dimension. Possible replacements are PropertyPlantAndEquipmentUsefulLife and RangeAxis (MaximumMember) ."
-],
-"CreditDerivativeOriginAndPurpose": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DiscussionOfObjectivesForUsingCreditRiskDerivativeInstruments."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseIncurredClaimsCurrentYear": [
-"2014-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is SupplementalInformationForPropertyCasualtyInsuranceUnderwritersCurrentYearClaimsAndClaimsAdjustmentExpense."
-],
-"NotionalAmountOfNonderivativeInstrumentsDesignatedAsNetInvestmentHedges": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NotionalAmountOfNonderivativeInstruments and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationOtherAssets": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"TradingActivityGainsAndLossesByIncomeStatementLocationAxis": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is IncomeStatementLocationAxis."
-],
-"BusinessAcquisitionContingentConsiderationAtFairValueCurrent": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseReportedAndIncurredButNotReportedIBNRClaimsDisclosureAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"DisposalGroupIncludingDiscontinuedOperationInventory": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is InventoriesPropertyHeldForSaleCurrent."
-],
-"IncomeTaxExaminationLiabilityRecorded": [
-"2013-01-31",
-"Element was deprecated due to redundancy.  Possible replacement is IncomeTaxExaminationPenaltiesAndInterestAccrued."
-],
-"IncomeLossFromContinuingOperationsPerOutstandingLimitedPartnershipUnit": [
-"2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromContinuingOperationsPerOutstandingLimitedPartnershipUnitBasicNetOfTax."
-],
-"LoanProcessingFeeMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is LoanProcessingFee."
-],
-"EquityIssuanceAbstract": [
-"2012-01-31",
-"This element has been deprecated because its children have been relocated."
-],
-"LeveragedBuyoutCostOfTransactionDescription": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DefinedBenefitPlanEffectOfOnePercentagePointDecreaseOnServiceAndInterestCostComponents": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is DefinedBenefitPlanEffectOfOnePercentagePointDecreaseOnServiceAndInterestCostComponents1."
-],
-"EquityContributionsToFinanceLeveragedBuyout": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"OtherComprehensiveIncomeFinalizationOfPensionAndNonPensionPostretirementPlanValuationNetOfTax": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is OtherComprehensiveIncomeLossFinalizationOfPensionAndNonPensionPostretirementPlanValuationNetOfTax."
-],
-"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalRollingMaturityAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"RealEstateTaxesAndInsuranceMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is RealEstateTaxesAndInsurance."
-],
-"FiveYearScheduleOfMaturitiesOfParentCompanyRepaymentsOfPrincipalAfterYearFive": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalAfterYearFive."
-],
-"LongTermPurchaseCommitmentTimePeriod": [
-"2014-01-31",
-"Element was deprecated because it has a stringItemType attribute. Possible replacement is LongtermPurchaseCommitmentPeriod."
-],
-"CostMethodInvestmentsFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
-],
-"CashAndCashEquivalentsFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
-],
-"TradingActivityGainsAndLossesNet": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TradingGainsLosses."
-],
-"ForeignReinsuranceUnderOpenYearMethodAdditions": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"BorrowedFunds": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DebtAndCapitalLeaseObligations."
-],
-"StockholdersEquityNoteStockSplitConversionRatio": [
-"2013-01-31",
-"Element was deprecated because it has a decimalItemType attribute. Possible replacement is StockholdersEquityNoteStockSplitConversionRatio1."
-],
-"SellingExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is SellingExpense."
-],
-"HedgeDesignationsUsedForCreditRiskDerivatives": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationTangibleAssetsAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"FiniteLivedDistributionRightsGross": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FiniteLivedIntangibleAssetsGross and members of FiniteLivedIntangibleAssetsByMajorClassAxis."
-],
-"LeveragedBuyoutDescriptionOfEquityDebitResultingFromCarryoverBasis": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FloorBrokerageExchangeClearanceFeesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is FloorBrokerageExchangeAndClearanceFees."
-],
-"OperatingLeaseExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is LeaseAndRentalExpense."
-],
-"LeveragedBuyoutRepaymentOfExistingDebt": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"PendingOrThreatenedLitigationMember": [
-"2012-01-31",
-"Element was deprecated. Possible replacements are PendingLitigationMember or ThreatenedLitigationMember."
-],
-"ServicingLiabilityAtAmortizedValueByTypesOfFinancialAssetsAxis": [
-"2013-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is FinancialInstrumentAxis."
-],
-"AccountsReceivableFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
-],
-"OtherNonrecurringExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OtherNonrecurringExpense."
-],
-"CurrentIncomeTaxExpenseBenefitAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"OperationsCommencedDate": [
-"2012-01-31",
-"Element was deprecated because it has a dateStringItemType. Possible replacement is OperationsCommencedDate1."
-],
-"ScheduleOfAssetsOrLiabilitiesFromTransfersOfFinancialAssetsHavingNoReasonableEstimateOfFairValueTextBlock": [
-"2012-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"ScheduleOfInvestmentIncomeReportedAmountsByCategoryAxis": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is InvestmentTypeAxis."
-],
-"MaximumFutureEarningsFromClosedBlockAssetsAndLiabilities1": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ClosedBlockAssetsAndLiabilitiesMaximumFutureEarningsToBeRecognized."
-],
-"OtherComprehensiveIncomeLossNetOfTaxPeriodIncreaseDecrease": [
-"2012-01-31",
-"Element was deprecated because it has no balance attribute. Possible replacement is OtherComprehensiveIncomeLossNetOfTax."
-],
-"DeferredGainOnEarlyExtinguishmentOfDebtAmountMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DeferredLossOnEarlyExtinguishmentOfDebtMember."
-],
-"FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisGainLossIncludedInTradingRevenue": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisInstrumentsClassifiedInShareholdersEquityGainLossIncludedInEarnings and members of IncomeStatementLocationAxis."
-],
-"IncomeLossFromDiscontinuedOperationsNetOfTaxPerOutstandingLimitedPartnershipUnitDiluted": [
-"2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromDiscontinuedOperationsNetOfTaxPerOutstandingLimitedPartnershipUnitDiluted1."
-],
-"NetInvestmentIncomeInsuranceEntityPolicyLoans": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NetInvestmentIncome and members of InvestmentTypeAxis."
-],
-"ForeignCurrencyContractsFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
-],
-"UnrecognizedTaxBenefitsResultingInNetOperatingLossCarryforward": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FairValueAssetsMeasuredOnRecurringBasisTradingAccountAssetsValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
-],
-"QualitativeAndQuantitativeInformationAssetOrLiabilityTransferorsContinuingInvolvementSecuritizationOrAssetbackedFinancingPrincipalAmountOutstandingDerecognizedAmount": [
-"2014-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is DerecognizedAssetsSecuritizedOrAssetbackedFinancingArrangementAssetsAndAnyOtherFinancialAssetsManagedTogetherPrincipalAmountOutstanding."
-],
-"FairValueByBalanceSheetGroupingSignificantAssumptionsFinancialAssetsAbstract": [
-"2012-01-31",
-"This element was removed because its children were deprecated after the disclosure was dimensionalized."
-],
-"DebtInstrumentMaturityDateRangeEnd": [
-"2012-01-31",
-"Element was deprecated because it has a dateStringItemType. Possible replacement is DebtInstrumentMaturityDateRangeEnd1."
-],
-"DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifference": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferenceUndistributedEarningsOfForeignSubsidiaries, DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferenceUndistributedEarningsOfDomesticSubsidiaries, DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferenceBadDebtReserveForTaxPurposesOfQualifiedLender, and DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferencePolicyholdersSurplus."
-],
-"LeveragedBuyoutPrepaymentPenaltiesOnRetiredDebt": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CumulativeEffectAdjustmentApplicationOfFairValueOptionGrossLosses": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"BusinessAcquisitionPurchasePriceAllocationUnfavorableContractAccrual": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"IncreaseDecreaseInFairValueOfPriceRiskFairValueHedgingInstruments": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is IncreaseDecreaseInFairValueOfPriceRiskFairValueHedgingInstruments1."
-],
-"GuarantorObligationsByUnderlyingAssetClassAxis": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is UnderlyingAssetClassAxis."
-],
-"DerivativeRemainingMaturity": [
-"2012-01-31",
-"Element was deprecated because it has a durationStringItemType. Possible replacement is DerivativeRemainingMaturity1."
-],
-"ReportingEntityMember": [
-"2014-01-31",
-"Element was deprecated because it is an invalid concept."
-],
-"ScheduleOfEmployeeServiceShareBasedCompensationAllocationOfRecognizedPeriodCostsByReportLineAxis": [
-"2013-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is IncomeStatementLocationAxis."
-],
-"AssetOrLiabilityFromTransfersOfFinancialAssetsHavingNoReasonableEstimateOfFairValueAtCarryingValue": [
-"2012-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DerivativesFairValueByBalanceSheetLocationAxis": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is BalanceSheetLocationAxis."
-],
-"AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionGainLossOnDisposition": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionGainLossOnDisposition1."
-],
-"OtherComprehensiveIncomeLossAmortizationPensionAndOtherPostretirementBenefitPlansNetPriorServiceCostRecognizedInNetPeriodicPensionCostTaxEffect": [
-"2012-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossAmortizationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetPriorServiceCostCreditTax."
-],
-"EntityWideDisclosureOnGeographicAreasLongLivedAssetsInForeignCountries": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Possible replacement is NoncurrentAssets and members of StatementGeographicalAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsWorkInProgress": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"OrderFlowFeesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OrderFlowFees."
-],
-"SegmentGeographicalGroupsOfCountriesGroupTwoMember": [
-"2013-01-31",
-"Element deprecated because it was inappropriately modeled."
-],
-"NoninterestExpenseOfferingCostMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpenseOfferingCost."
-],
-"CapitalizedExploratoryWellCostsGreaterThanOrEqualToFourYearsAndLessThanFiveYearsNumberOfProjects": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProjectsThatHaveExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
-],
-"RealEstateAndAccumulatedDepreciationLifeUsedForDepreciation": [
-"2012-01-31",
-"Element deprecated because it is modeled as decimalItemType. If you have used, Possible replacement is RealEstateAndAccumulatedDepreciationLifeUsedForDepreciation1."
-],
-"ShareholderLoansToFinanceLeveragedBuyout": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"BusinessAcquisitionPurchasePriceAllocationOtherNoncurrentLiabilities": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisForeignCurrencyContractsValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
-],
-"EquityIssuanceSinceInceptionLineItems": [
-"2012-01-31",
-"This element has been deprecated because filers should not use a dimension to differentiate equity issuances. Filers should use the date context to differentiate equity issuances."
-],
-"MoreThanThreeAndWithinFourYearsFromBalanceSheetDateMember": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept modeled as a dimension was replaced with line items. Possible replacements are line items within ScheduleOfLifeSettlementContractsFairValueMethodTextBlock and ScheduleOfLifeSettlementContractsInvestmentMethodTextBlock."
-],
-"ConcentrationOfCededCreditRisk": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ConcentrationRiskCreditRiskReinsurance."
-],
-"DeferredPolicyAcquisitionCostsTextBlock": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacement is DeferredPolicyAcquisitionCostsTextBlock1 or CapitalizationOfDeferredPolicyAcquisitionCostsPolicy."
-],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsVestedAndExpectedToVestExercisableWeightedAverageRemainingContractualTerm": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is SharebasedCompensationArrangementBySharebasedPaymentAwardOptionsVestedAndExpectedToVestExercisableWeightedAverageRemainingContractualTerm1."
-],
-"CausesOfIncreaseDecreaseInLiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAmount": [
-"2014-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is SupplementalInformationForPropertyCasualtyInsuranceUnderwritersPriorYearClaimsAndClaimsAdjustmentExpense."
-],
-"FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInInvestmentIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
-],
-"DeferredCompensationArrangementWithIndividualPostretirementBenefitsByTitleOfIndividualAxis": [
-"2013-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is TitleofIndividualAxis."
-],
-"AccruedLiabilitiesFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
-],
-"LoansReceivableFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
-],
-"RealEstateAccumulatedDepreciationDepreciationExpense": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is SECScheduleIIIRealEstateAccumulatedDepreciationDepreciationExpense."
-],
-"AccountsPayableFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
-],
-"IncreaseDecreaseInFairValueOfHedgedItemInPriceRiskFairValueHedge": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is IncreaseDecreaseInFairValueOfHedgedItemInPriceRiskFairValueHedge1."
-],
-"FinancingReceivableModificationsSubsequentDefaultRecordedInvestment": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is FinancingReceivableModificationsSubsequentDefaultRecordedInvestment1."
-],
-"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsNetAmountRecognized": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LoansAndLeasesReceivableMortgageAndMortgageBackedSecuritiesValuationPolicy": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LoansAndLeasesReceivableValuationPolicy."
-],
-"EffectsOfChangesInPrepaymentEstimateAssumptionsForCMOsAndREMICsByAffectedItemAxis": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"SaleLeasebackTransactionRelatedPartyTransaction": [
-"2013-01-31",
-"Element was deprecated due to redundancy.  Possible replacement is RelatedPartyTransactionDescriptionOfTransaction."
-],
-"ServicingLiabilityAtAmortizedValueAmortization": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance type. Possible replacement is ServicingLiabilityAtAmortizedCostAmortization."
-],
-"EffectsOfChangesInPrepaymentEstimateAssumptionsForCMOsAndREMICsTable": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisFederalFundsPurchasedValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
-],
-"OtherComprehensiveIncomeForeignCurrencyTransactionAndTranslationAdjustmentBeforeTaxPeriodIncreaseDecrease": [
-"2012-01-31",
-"Element was deprecated because it has no balance attribute. Possible replacement is OtherComprehensiveIncomeLossForeignCurrencyTransactionAndTranslationAdjustmentBeforeTax."
-],
-"BusinessAcquisitionCostOfAcquiredEntityDescriptionOfPurchasePriceComponents": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"ImpairmentOrDisposalOfLongLivedIntangibleAssetsImpairmentPolicy": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is ImpairmentOrDisposalOfLongLivedAssetsIncludingIntangibleAssetsPolicyPolicyTextBlock."
-],
-"CapitalizedExploratoryWellCostsGreaterThanOrEqualToFourYearsAndLessThanFiveYears": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CapitalizedExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseIncurredButNotReportedIBNRClaimsCommentary": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilityForClaimsAndClaimsAdjustmentExpenseMethodologiesAndAssumptions."
-],
-"OtherNonrecurringGainMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OtherNonrecurringGain."
-],
-"TransfersAccountedForAsSecuredBorrowingsClassificationAssets": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is TransfersAccountedForAsSecuredBorrowingsAssetsCarryingAmount and members of BalanceSheetLocationAxis."
-],
-"CededCreditRiskClaimsReceivable": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"DirectPremiumsEarnedFinancialGuaranteeInsuranceContracts": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisSecuritiesLoanedOrSoldUnderAgreementsToRepurchaseValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
-],
-"DeferredCompensationArrangementWithIndividualMaximumContractualTerm": [
-"2014-01-31",
-"Element was deprecated because it has a stringItemType attribute. Possible replacement is DeferredCompensationArrangementWithIndividualMaximumContractualTerm1."
-],
-"ReceivablesHeldForSaleNetAmount": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DisposalGroupIncludingDiscontinuedOperationAccountsNotesAndLoansReceivableNet."
-],
-"LifeInsuranceInForceMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are LifeInsuranceInForceGross, LifeInsuranceInForceCeded, LifeInsuranceInForceAssumed, LifeInsuranceInForceNet, or LifeInsuranceInForcePercentageAssumedToNet."
-],
-"ProvisionForLossesOnOperatingAndOrDevelopmentPropertyMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"AccrualForEnvironmentalLossContingenciesNetRollingMaturityAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"ScheduleOfExpectedAmortizationExpenseTableTextBlock": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ScheduleofFiniteLivedIntangibleAssetsFutureAmortizationExpenseTableTextBlock."
-],
-"AdvertisingExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is AdvertisingExpense."
-],
-"MaximumPotentialFutureExposureOnCreditRiskDerivatives": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is CreditDerivativeMaximumExposureUndiscounted."
-],
-"HeldToMaturitySecuritiesFairValueDisclosure": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is HeldToMaturitySecuritiesFairValue."
-],
-"CashFlowHedgeLossReclassifiedToOtherExpense": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is OtherCostAndExpenseOperating and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionLapseDateNotEstimatableFlag": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionLapseDateNotEstimableFlag."
-],
-"TemporaryEquityCarryingAmountAttributableToNoncontrollingInterestAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"ServicingAssetAtAmortizedValueOtherThanTemporaryImpairments": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is ServicingAssetAtAmortizedCostOtherThanTemporaryImpairments."
-],
-"MandatorilyRedeemablePreferredStockFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
-],
-"LiabilityForTitleClaimsAndClaimsAdjustmentExpenseIncurredButNotReportedIBNR": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseIncurredButNotReportedIBNRClaimsAmount and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"LeveragedBuyoutOptionCostChargedToExpense": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"InsuranceRatiosComment": [
-"2013-01-31",
-"Element was deprecated."
-],
-"BusinessInterruptionInsuranceRecoveryStatementOfIncomeLineItems": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is GainOnBusinessInterruptionInsuranceRecovery and members of IncomeStatementLocationAxis."
-],
-"FutureAmortizationExpenseYearOne": [
-"2012-01-31",
-"Element was deprecated because it has a duration period type. Possible replacement is FiniteLivedIntangibleAssetsAmortizationExpenseNextTwelveMonths."
-],
-"DerivativeAssetFairValueNet": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DerivativeFairValueOfDerivativeAssetAmountNotOffsetAgainstCollateral."
-],
-"FutureAmortizationExpenseYearFive": [
-"2012-01-31",
-"Element was deprecated because it has a duration period type. Possible replacement is FiniteLivedIntangibleAssetsAmortizationExpenseYearFive."
-],
-"IssuanceOfDebtMember": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"ProjectWithExploratoryWellCostsCapitalizedForMoreThanOneYearNameDomain": [
-"2013-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is ProjectMember."
-],
-"LiquidationDate": [
-"2012-01-31",
-"Element was deprecated because it has a dateStringItemType. Possible replacement is LiquidationDate1."
-],
-"USGovernmentAndGovernmentAgenciesAndAuthoritiesMember": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is USTreasuryAndGovernmentMember."
-],
-"ScheduleOfDistributionsMadeToMemberOrLimitedPartnerTable": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacement is DistributionsMadeToLimitedLiabilityCompanyLLCMemberTable or DistributionsMadeToLimitedPartnerTable."
-],
-"CumulativeEffectAdjustmentApplicationOfFairValueOptionGrossGainsAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"FutureAmortizationExpenseAfterYearFive": [
-"2012-01-31",
-"Element was deprecated because it has a duration period type. Possible replacement is FiniteLivedIntangibleAssetsAmortizationExpenseAfterYearFive."
-],
-"DirectPremiumsWrittenLife": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"CollaborativeArrangementsCopromotionAgreementAgreementMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is CollaborativeArrangementCopromotionMember."
-],
-"CooperativeAdvertisingExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is CooperativeAdvertisingExpense."
-],
-"ContributionsFromNoncontrollingInterests": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ProceedsFromMinorityShareholders."
-],
-"FinancingReceivableTroubledDebtRestructuringsDomain": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is FinancingReceivableTroubledDebtRestructuringDomain."
-],
-"DebtInstrumentMaturityDateRangeStart": [
-"2012-01-31",
-"Element was deprecated because it has a dateStringItemType. Possible replacement is DebtInstrumentMaturityDateRangeStart1."
-],
-"FiniteLivedIntangibleAssetsAverageUsefulLife": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is FiniteLivedIntangibleAssetUsefulLife."
-],
-"AccrualForEnvironmentalLossContingenciesCaption": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AccrualForEnvironmentalLossContingencies and members of BalanceSheetLocationAxis."
-],
-"ScheduleOfEarningsPerShareReconciliationTableTextBlock": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ScheduleOfEarningsPerShareBasicAndDilutedTableTextBlock."
-],
-"OtherComprehensiveIncomeLossReclassificationAdjustmentForSaleOfSecuritiesIncludedInNetIncomeNetOfTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForSaleOfSecuritiesNetOfTax."
-],
-"FloorBrokerageMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is FloorBrokerage."
-],
-"MoreThanFiveYearsFromBalanceSheetDateAndThereafterMember": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept modeled as a dimension was replaced with line items. Possible replacements are line items within ScheduleOfLifeSettlementContractsFairValueMethodTextBlock and ScheduleOfLifeSettlementContractsInvestmentMethodTextBlock."
-],
-"NotionalAmountOfInterestRateDerivatives": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisGainLossIncludedInTradingRevenue": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisLiabilityGainLossIncludedInEarnings and members of IncomeStatementLocationAxis."
-],
-"CededPremiumsWrittenLife": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"SubsequentEventAmountLowerRange": [
-"2013-01-31",
-"Element was deprecated because it is an invalid concept."
-],
-"EquityIssuanceNumberOfEquitySecuritiesIssuedForNoncashConsiderations": [
-"2012-01-31",
-"Element was deprecated because it has an instant period type and a decimalItemType. Possible replacement is StockIssuedDuringPeriodSharesIssuedForNoncashConsideration."
-],
-"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInRollingAfterYearFive": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInRollingAfterYearFive."
-],
-"BalanceSheetLineItemAffectedByApplicationOfSFAS158Domain": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is BalanceSheetLocationDomain."
-],
-"CommunicationsAndDataProcessingMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is CommunicationsAndInformationTechnology."
-],
-"CashFlowHedgeGainReclassifiedToEarnings": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProfitLoss and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"MalpracticeInsuranceDeductible": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is MalpracticeInsuranceDeductible1."
-],
-"ProvedUndevelopedReserveBOE": [
-"2013-01-31",
-"Element was deprecated because it has a boeItemType attribute. Possible replacement is ProvedUndevelopedReserveBOE1."
-],
-"FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisGainLossIncludedInOtherIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisInstrumentsClassifiedInShareholdersEquityGainLossIncludedInEarnings and members of IncomeStatementLocationAxis."
-],
-"TypesOfCreditRiskDerivativesUsed": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are members of CreditDerivativesByContractTypeAxis."
-],
-"DevelopmentStageEnterpriseAdditionalInformationForIncomeStatementAbstract": [
-"2012-01-31",
-"This element has been deprecated because it children were deprecated."
-],
-"PublicUtilitiesPropertyPlantAndEquipmentEquipmentEstimatedUsefulLife": [
-"2013-01-31",
-"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentEquipmentUsefulLife."
-],
-"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationEstimatedAmountAmortizedYearTwo": [
-"2012-01-31",
-"Element was deprecated because it has a duration period type and a credit balance attribute. Possible replacement is IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationAmortizationExpenseYearTwo."
-],
-"AccountingStandardsUpdate201017Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"SubsequentEventDateEvaluated": [
-"2012-01-31",
-"Element was deprecated."
-],
-"AssetsHeldForSaleLongLivedAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"BusinessAcquisitionPurchasePriceAllocationRealEstateAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"CumulativeEffectAdjustmentApplicationOfFairValueOptionUnrealizedGainsUnrecognized": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"PriorPeriodReclassificationAdjustmentAbstract": [
-"2012-01-31",
-"This element has been deprecated because its children have been relocated."
-],
-"IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingLimitedPartnershipUnitDiluted": [
-"2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingLimitedPartnershipUnitDiluted1."
-],
-"CapitalizedExploratoryWellCostsThereafter": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CapitalizedExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
-],
-"CapitalizedExploratoryWellCostsGreaterThanOrEqualToTwoYearsAndLessThanThreeYears": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CapitalizedExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
-],
-"NonmonetaryNotionalAmountOfPriceRiskCashFlowHedgeDerivatives": [
-"2013-01-31",
-"Element was deprecated because the intended concept conveyed is the underlying. Possible replacements are UnderlyingDerivativeAsset, UnderlyingDerivativeLiability, UnderlyingDerivative and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis and DerivativeInstrumentRiskAxis."
-],
-"IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingLimitedPartnershipUnit": [
-"2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingLimitedPartnershipUnitBasic."
-],
-"MortgagesHeldForSaleFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
-],
-"ParticipatingSecuritiesDistributedAndUndistributedEarnings": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are ParticipatingSecuritiesDistributedAndUndistributedEarningsLossBasic or ParticipatingSecuritiesDistributedAndUndistributedEarningsLossDiluted."
-],
-"AdditionsToNoncurrentAssets": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Possible replacement is corresponding primary line items and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
-],
-"HeldToMaturitySecuritiesContinuousUnrealizedLossPositionLessThan12MonthsAggregateLosses": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is HeldToMaturitySecuritiesContinuousUnrealizedLossPositionLessThan12MonthsAggregateLoss."
-],
-"ShippingHandlingAndTransportationCostsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ShippingHandlingandTransportationCosts."
-],
-"MoreThanOneAndWithinTwoYearsFromBalanceSheetDateMember": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept modeled as a dimension was replaced with line items. Possible replacements are line items within ScheduleOfLifeSettlementContractsFairValueMethodTextBlock and ScheduleOfLifeSettlementContractsInvestmentMethodTextBlock."
-],
-"ScheduleOfTradingSecuritiesAndOtherTradingAssetsMajorTypesOfTradingSecuritiesAndAssetsAxis": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is MajorTypesOfDebtAndEquitySecuritiesAxis."
-],
-"PaymentsForPurchaseOfOtherAssets": [
-"2013-01-31",
-"Element was deprecated because it was being used for either operating or investing activities. Possible replacements are PaymentsForPurchaseOfOtherAssets1, PaymentsForProceedsFromOtherInvestingActivities or PaymentsToAcquireOtherProductiveAssets."
-],
-"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionPeriodInEffect": [
-"2012-01-31",
-"Element was deprecated because it has a dateStringItemType. Possible replacement is FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionPeriodInEffect1."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseReportedAndIncurredButNotReportedIBNRClaims": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilityForClaimsAndClaimsAdjustmentExpense."
-],
-"DefinedBenefitPlanRecognizedNetGainLossDueToSettlementsAndCurtailments": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is DefinedBenefitPlanRecognizedNetGainLossDueToSettlementsAndCurtailments1."
-],
-"TaxCreditCarryforwardExpirationDates": [
-"2012-01-31",
-"Element was deprecated because it has a stringItemType. Possible replacements are CashAvailableForDistributions or TaxCreditCarryforwardExpirationDate."
-],
-"AssumptionForFairValueAsOfBalanceSheetDateOfInterestsContinuedToBeHeldByTransferorServicingAssetsOrLiabilitiesAxis": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is FinancialInstrumentAxis."
-],
-"GainOnPurchaseOfBusinessMember": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"TaxesOtherThanIncomeAndExciseTaxesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is TaxesExcludingIncomeAndExciseTaxes."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisFederalHomeLoanBankBorrowingsValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
-],
-"LiabilitiesSubjectToCompromiseEndOfPeriod": [
-"2013-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is LiabilitiesSubjectToCompromise."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisObligationsValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
-],
-"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureDevelopmentCosts": [
-"2013-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesDevelopmentCosts."
-],
-"UnsolicitedTenderOfferExpensesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"CashFlowHedgeGainLossReclassifiedToEarningsNet": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProfitLoss and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"NetInvestmentIncomeInsuranceEntity": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is NetInvestmentIncome."
-],
-"AssetsHeldForSaleCapitalLeasedAssetsNet": [
-"2014-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"AverageTermOfCreditRiskDerivatives": [
-"2012-01-31",
-"Element was deprecated because it has a durationStringItemType. Possible replacement is AverageTermOfCreditRiskDerivatives1."
-],
-"OccupancyNetMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OccupancyNet."
-],
-"PartiesToContractualArrangementAxis": [
-"2014-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacement is LeaseArrangementTypeAxis."
-],
-"IncomeTaxExpenseBenefitContinuingOperationsDiscontinuedOperationsExtraordinaryItemsAbstract": [
-"2012-01-31",
-"This element has been deprecated because the children of this element have been relocated."
-],
-"FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInTradingRevenue": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
-],
-"GainLossOnDispositionOfAssetsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnDispositionOfAssets."
-],
-"TemporaryEquityCarryingAmount": [
-"2012-01-31",
-"Element was deprecated. Possible replacements are TemporaryEquityCarryingAmountAttributableToParent, TemporaryEquityCarryingAmountAttributableToNoncontrollingInterest or RedeemableNoncontrollingInterestEquityCarryingAmount."
-],
-"BusinessAcquisitionPurchasePriceAllocationLand": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LossOnReceivablesAxis": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"ProductRecallDomain": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"DerivativeFinancialInstrumentsLiabilitiesFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
-],
-"LossContingencyRelatedReceivableCarryingValueCurrent": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is LossContingencyReceivableCurrent."
-],
-"GainOnPurchaseOfBusiness": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is BusinessCombinationBargainPurchaseGainRecognizedAmount."
-],
-"DerivativeLiabilityFairValueNet1": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DerivativeFairValueOfDerivativeLiabilityAmountNotOffsetAgainstCollateral."
-],
-"OptionIndexedToIssuersEquityRedeemableStockRedemptionRequirements": [
-"2012-01-31",
-"Element was deprecated because it has a stringItemType. Possible replacement is OptionIndexedToIssuersEquityRedeemableStockRedemptionRequirementsAmount."
-],
-"DefinedBenefitPlanExpectedFutureBenefitPaymentsInYearFive": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is DefinedBenefitPlanExpectedFutureBenefitPaymentsYearFive."
-],
-"ShareBasedGoodsAndNonemployeeServicesTransactionCashFlowEffects": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is IssuanceOfStockAndWarrantsForServicesOrClaims."
-],
-"LineOfCreditFacilityAmountOutstanding": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LineofCredit."
-],
-"UnprovedOilAndGasPropertyOrMajorProjectDomain": [
-"2013-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is ProjectMember."
-],
-"FairValueAssetsMeasuredOnRecurringBasisLoansReceivableValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
-],
-"NetInvestmentIncomeInsuranceEntityFixedMaturities": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NetInvestmentIncome and members of InvestmentTypeAxis."
-],
-"FinancingReceivableTroubledDebtRestructuringsThatSubsequentlyDefaultedAxis": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is FinancingReceivableTroubledDebtRestructuringAxis."
-],
-"MergerAndAcquisitionCosts": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CashAndCashEquivalentsFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsMarketableSecurities": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"NotionalAmountOfDerivatives": [
-"2012-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DerivativeNotionalAmount."
-],
-"LiabilityForFuturePolicyBenefitByProductSegmentDomain": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ReinsurancePremiumsForInsuranceCompaniesByProductSegmentDomain."
-],
-"CashFlowHedgeGainReclassifiedToRevenue": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is Revenues and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"AssumptionForFairValueOnSecuritizationDateOfInterestsContinuedToBeHeldByTransferorServicingAssetsOrLiabilitiesWeightedAverageLife": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is FairValueAssumptionDateOfSecuritizationOrAssetBackedFinancingArrangementTransferorsContinuingInvolvementServicingAssetsOrLiabilitiesWeightedAverageLife."
-],
-"EntityWideRevenueMajorCustomerAmount": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Possible replacement is Revenues and members of MajorCustomersAxis."
-],
-"NotionalAmountOfInterestRateCashFlowHedgeDerivatives": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis and DerivativeInstrumentRiskAxis."
-],
-"DerivativeAverageExchangeRateFloor": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is DerivativeAverageExchangeRateFloor1."
-],
-"OtherTaxCarryforwardValuationAllowance": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TaxCreditCarryforwardValuationAllowance."
-],
-"CashFlowHedgeGainReclassifiedToOtherIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is OtherIncome and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"ChangeInTaxStatusDomain": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"AllowanceForFundsUsedDuringConstructionCapitalizedInterestMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is PublicUtilitiesAllowanceForFundsUsedDuringConstructionCapitalizedInterest."
-],
-"FairValueLiabilitiesMeasuredOnRecurringAndNonrecurringBasisValuationTechniquesAbstract": [
-"2012-01-31",
-"This element has been deprecated because its children were deprecated when the disclosure was dimensionalized."
-],
-"ScheduleOfInsuredFinancialObligationsWithCreditDeteriorationRemainingWeightedAverageContractPeriod": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is InsuredFinancialObligationsWithCreditDeteriorationRemainingWeightedAverageContractPeriod."
-],
-"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureNetCashFlows": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesNetCashFlows."
-],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsVestedInPeriodFairValue": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsVestedInPeriodFairValue1."
-],
-"OtherExpenseOfInsuranceEntities": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is OtherExpenses."
-],
-"ForeignCurrencyExchangeRateTranslation": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is ForeignCurrencyExchangeRateTranslation1."
-],
-"OtherComprehensiveIncomeDerivativesQualifyingAsHedgesNetOfTaxPeriodIncreaseDecrease": [
-"2012-01-31",
-"Element was deprecated because it has no balance attribute. Possible replacement is OtherComprehensiveIncomeLossDerivativesQualifyingAsHedgesNetOfTax."
-],
-"BusinessCombinationContingentConsiderationArrangementsChangeInAmountOfContingentConsiderationLiability": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is BusinessCombinationContingentConsiderationArrangementsChangeInAmountOfContingentConsiderationLiability1."
-],
-"MinorityInterestInNetIncomeLossOperatingPartnerships": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacement is NoncontrollingInterestInNetIncomeLossOperatingPartnershipsNonredeemable or NoncontrollingInterestInNetIncomeLossOperatingPartnershipsRedeemable."
-],
-"ExecutiveCompensationContractsMember": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"RealEstateAndAccumulatedDepreciationDateAcquired": [
-"2012-01-31",
-"Element was deprecated because it has a dateStringItemType. Possible replacement is RealEstateAndAccumulatedDepreciationDateAcquired1."
-],
-"StockOptionsMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is EmployeeStockOptionMember."
-],
-"DefinedBenefitPlanTargetAllocationPercentagesOfAssetsEquitySecuritiesAbstract": [
-"2012-01-31",
-"This element has been deprecated."
-],
-"ImpairedFinancingReceivableWithRelatedAllowanceAxis": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is FinancingReceivableRecordedInvestmentByClassOfFinancingReceivableAxis."
-],
-"AcquiredFiniteLivedIntangibleAssetsByMajorClassAxis": [
-"2012-01-31",
-"Element was deprecated due to redundancy. Possible replacement is FiniteLivedIntangibleAssetsByMajorClassAxis."
-],
-"DeferredTaxLiabilityNotRecognizedLineItems": [
-"2013-01-31",
-"Element was deprecated."
-],
-"StockRepurchaseProgramPeriodInForce": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is StockRepurchaseProgramPeriodInForce1."
-],
-"AmortizationPeriodOfDeferredGainLossOnDiscontinuationOfForeignCurrencyFairValueHedge": [
-"2012-01-31",
-"Element was deprecated because it has a durationStringItemType. Possible replacement is AmortizationPeriodOfDeferredGainLossOnDiscontinuationOfForeignCurrencyFairValueHedge1."
-],
-"DefinedBenefitPensionMember": [
-"2012-01-31",
-"Element was deprecated due to redundancy. Possible replacement is PensionPlansDefinedBenefitMember."
-],
-"SFAS141RElementsIncrementalToSFAS141Abstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"HeldtomaturitySecuritiesDebtMaturityDateRangeLow": [
-"2012-01-31",
-"Element was deprecated because it has a durationStringItemType. Possible replacements are HeldtomaturitySecuritiesDebtMaturitiesDate and RangeAxis (MinimumMember)."
-],
-"TypeOfDeferredCompensationDomain": [
-"2014-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacements are DeferredBonusAndProfitSharingArrangementIndividualContractTypeOfDeferredCompensationDomain, OtherPostretirementBenefitsIndividualContractsTypeOfDeferredCompensationDomain, or EquityBasedArrangementsIndividualContractsTypeOfDeferredCompensationDomain."
-],
-"LeveragedBuyoutRedemptionOfShareBasedAwards": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DefinedBenefitPlanTargetAllocationPercentageOfAssetsRealEstateRangeMinimum": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are DefinedBenefitPlanTargetPlanAssetAllocationsRangeMinimum and members of DefinedBenefitPlanByPlanAssetCategoriesAxis."
-],
-"GuaranteedBenefitLiabilityGross": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilitiesForGuaranteesOnLongDurationContractsGuaranteedBenefitLiabilityGross."
-],
-"CededCreditRiskClaimsLossAdjustmentExpenseIncurred": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisSecuritiesSoldNotYetPurchasedValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
-],
-"FairValueAssetsMeasuredOnRecurringBasisEquityMethodInvestmentsValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
-],
-"AvailableforsaleSecuritiesContinuousUnrealizedLossPositionLessThan12MonthsAggregateLosses2": [
-"2013-01-31",
-"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is AvailableForSaleSecuritiesContinuousUnrealizedLossPositionLessThan12MonthsAggregateLosses."
-],
-"LoansReceivableFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
-],
-"DebtInstrumentConvertibleEffectiveInterestRate": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DebtInstrumentInterestRateEffectivePercentage, DebtInstrumentInterestRateEffectivePercentageRateRangeMinimum, DebtInstrumentInterestRateEffectivePercentageRateRangeMaximum and members of LongtermDebtTypeAxis or ShortTermDebtTypeAxis."
-],
-"NetCreditLossesDuringPeriodOnLoansManagedOrSecuritized": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is NetCreditLossOnLoansManagedOrSecuritizedOrAssetbackedFinancingArrangement."
-],
-"BusinessAcquisitionPreacquisitionContingencyDescription": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisTradingLiabilitiesValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
-],
-"LoanPortfolioExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is LoanPortfolioExpense."
-],
-"OptionIndexedToIssuersEquitySettlementDates": [
-"2012-01-31",
-"Element was deprecated because it has a dateStringItemType. Possible replacement is OptionIndexedToIssuersEquitySettlementDateOrDates."
-],
-"FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisGainLossIncludedInInvestmentIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisInstrumentsClassifiedInShareholdersEquityGainLossIncludedInEarnings and members of IncomeStatementLocationAxis."
-],
-"DefinedBenefitPlanTargetAllocationPercentageOfAssetsEquitySecurities": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are DefinedBenefitPlanTargetPlanAssetAllocations and members of DefinedBenefitPlanByPlanAssetCategoriesAxis."
-],
-"OtherComprehensiveIncomeDefinedBenefitPlansAdjustmentNetOfTaxPeriodIncreaseDecrease": [
-"2012-01-31",
-"Element was deprecated because it has no balance attribute. Possible replacement is OtherComprehensiveIncomeLossPensionAndOtherPostretirementBenefitPlansAdjustmentNetOfTax."
-],
-"FairValueOtherLiabilitiesValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
-],
-"SecuritizedAssetsAndAnyOtherFinancialAssetsManagedTogetherAverageBalanceDuringPeriod": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisInvestmentContractsValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
-],
-"CumulativeEffectOfChangeInAccountingPrincipleTabularPresentationByFinancialStatementLineItemPreviouslyReportedAmount": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are NewAccountingPronouncementsOrChangeInAccountingPrincipleTable to model the financial reporting concept. Line items that can be used instead of this element include, but are not limited to, IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest, ProfitLoss, EarningsPerShareBasic, and EarningsPerShareDiluted."
-],
-"AssumedPremiumsWrittenPropertyAndCasualty": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"CashFlowHedgeGainLossReclassifiedToInvestmentIncomeNetAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"DefinedBenefitPlanTargetAllocationPercentagesOfAssetsDebtSecuritiesAbstract": [
-"2012-01-31",
-"This element has been deprecated."
-],
-"GainLossOnSaleOfTradeReceivablesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnSaleOfAccountsReceivable."
-],
-"CededPremiumsEarnedAccidentAndHealth": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"PremiumsWrittenNetPropertyAndCasualty": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PremiumsWrittenNet and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"OpenTaxYearsByMajorTaxJurisdiction": [
-"2012-01-31",
-"Element was deprecated because it has a stringItemType. Possible replacement is OpenTaxYear."
-],
-"RepurchaseOfEquityMember": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"DistributionMadeToMemberOrLimitedPartnerCashDistributionsPaid": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberCashDistributionsPaid or DistributionMadeToLimitedPartnerCashDistributionsPaid."
-],
-"CashFlowHedgeLossReclassifiedToInterestExpense": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is InterestExpense and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"AssetsOrLiabilitiesFromTransfersOfFinancialAssetsHavingNoReasonableEstimateOfFairValueLineItems": [
-"2012-01-31",
-"This element has been deprecated because the guidance from which this element is derived is no longer effective."
-],
-"SecuritizedAssetsAndAnyOtherFinancialAssetsManagedTogetherNetCreditLossesDuringPeriod": [
-"2012-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is AssetsThatContinueToBeRecognizedSecuritizedOrAssetBackedFinancingArrangementAssetsAndAnyOtherFinancialAssetsManagedTogetherNetCreditLossesDuringPeriod."
-],
-"AccountsNotesLoansAndFinancingReceivablesByProductAndServiceTypeAxis": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is ProductOrServiceAxis."
-],
-"FairValueAssetsMeasuredOnRecurringBasisGainLossIncludedInEarningsDescription": [
-"2012-01-31",
-"Element was deprecated due to redundancy. Possible replacement is FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisAssetGainLossIncludedInEarningsDescription."
-],
-"DiscussionOfCreditRiskDerivativeRiskManagementPolicy": [
-"2013-01-31",
-"Element was deprecated because it has a stringItemType attribute. Possible replacement is DerivativesPolicyTextBlock."
-],
-"SaleAxis": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"EffectOfChangeInReinvestmentRateOfReturnEstimate": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"DefinedBenefitPlanAmortizationOfNetGainsLosses": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is DefinedBenefitPlanFutureAmortizationOfGainLoss."
-],
-"BusinessCombinationConsiderationTransferredOther": [
-"2013-01-31",
-"Element was deprecated because it has debit balance and instant period type attributes.  Possible replacement is BusinessCombinationConsiderationTransferredOther1."
-],
-"PremiumsWrittenNetAccidentAndHealthAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"MortgageBackedSecuritiesAvailableForSaleFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
-],
-"LeveragedBuyoutProfessionalFeesAndOther": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"IncomeLossFromEquityRealEstatePartnershipsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is RealEstatePartnershipInvestmentSubsidiariesNetIncomeLossBeforeTax."
-],
-"EnvironmentalCostRecognizedCapitalizedInPeriod": [
-"2012-01-31",
-"Element was deprecated because it has an instant period type. Possible replacement is EnvironmentalCostsRecognizedCapitalizedInPeriod."
-],
-"PublicUtilitiesPropertyPlantAndEquipmentCommonEstimatedUsefulLife": [
-"2013-01-31",
-"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentCommonUsefulLife."
-],
-"FederalFundsSoldAndSecuritiesBorrowedOrPurchasedUnderAgreementsToResellFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
-],
-"OptionIndexedToIssuersEquityRedeemableStockRedemptionRequirementsAmount": [
-"2013-01-31",
-"Element was deprecated because it has debit balance and duration period type attributes. Possible replacement is OptionIndexedToIssuersEquityRedeemableStockRedemptionRequirementsAmount1."
-],
-"FinancingReceivableTroubledDebtRestructuringsAxis": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is FinancingReceivableTroubledDebtRestructuringAxis."
-],
-"DeferredTaxLiabilityNotRecognizedNameOfTemporaryDifferenceDomain": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept remodeled as primary concepts."
-],
-"CertainLoansAcquiredInTransferNotAccountedForAsDebtSecuritiesProvisionForLoanLosses": [
-"2012-01-31",
-"Element was deprecated because it has an instant period type. Possible replacement is CertainLoansAcquiredInTransferNotAccountedForAsDebtSecuritiesProvisionForLoanLosses1."
-],
-"BusinessAcquisitionCostOfAcquiredEntityPurchasePriceAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"ServicingLiabilityAtAmortizedValueIncreaseInObligation": [
-"2012-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is ServicingLiabilityAtAmortizedValueIncreaseInObligation1."
-],
-"FairValueAssetsMeasuredOnNonrecurringBasisValuationTechniquesGoodwill": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
-],
-"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureProductionCosts1": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesProductionCosts."
-],
-"DefinedBenefitPlanTargetAllocationPercentageOfAssetsRealEstateRangeMaximum": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are DefinedBenefitPlanTargetPlanAssetAllocationsRangeMaximum and members of DefinedBenefitPlanByPlanAssetCategoriesAxis."
-],
-"ReinsuranceEffectOnClaimsAndBenefitsIncurredPoliciesAcquiredInPeriod": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is PolicyholderBenefitsAndClaimsIncurredGross."
-],
-"DerivativeNonmonetaryNotionalAmountPricePerBarrel": [
-"2013-01-31",
-"Element was deprecated because the intended concept conveyed is the underlying. Possible replacement is UnderlyingDerivativeVolume."
-],
-"OtherComprehensiveIncomeReclassificationAdjustmentForWriteDownOfSecuritiesIncludedInNetIncomeNetOfTax": [
-"2012-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForWritedownOfSecuritiesNetOfTax."
-],
-"ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAmountCededToOtherCompanies": [
-"2013-01-31",
-"Element was deprecated. Possible replacement is CededPremiumsEarned."
-],
-"CashFlowHedgeGainLossReclassifiedToRevenueNet": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is Revenues and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"RetainedInterestFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
-],
-"DerivativeInstrumentsGainLossByIncomeStatementLocationAxis": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is IncomeStatementLocationAxis."
-],
-"PersonalLinesMember": [
-"2013-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is PropertyAndCasualtyPersonalInsuranceProductLineMember."
-],
-"DebtInstrumentCommitteeForUniformSecuritiesIdentificationProceduresCUSIP": [
-"2013-01-31",
-"Element was deprecated because it is has a stringItemType attribute. Possible replacement is CommitteeForUniformSecuritiesIdentificationProceduresCUSIP."
-],
-"RepaymentOfDebtMember": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"OtherTaxCarryforwardDeferredTaxAsset": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TaxCreditCarryforwardDeferredTaxAsset."
-],
-"PensionCostMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is PensionCostsMember."
-],
-"CollaborativeArrangementProductMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is CollaborativeArrangementProductAgreementMember."
-],
-"CumulativeEffectAdjustmentApplicationOfFairValueOptionUnrealizedLossesRecognized": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"EquityForwardAgreementsMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ForwardContractsMember."
-],
-"EnvironmentalCostRecognized": [
-"2012-01-31",
-"Element was deprecated because it has a stringItemType. Possible replacement is EnvironmentalCostsRecognizedCapitalized."
-],
-"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsAccumulatedOtherComprehensiveIncome": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AssumedPremiumsEarnedAccidentAndHealth": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"CashFlowHedgeGainLossReclassifiedToInvestmentIncomeNet": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is InvestmentIncomeNet and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"IncomeBeforeExtraordinaryItemsMember": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"GainLossOnSaleOfLoansReceivableMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"FairValueAssetsMeasuredOnNonrecurringBasisValuationTechniquesPropertyPlantAndEquipment": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
-],
-"LongLivedAssetsHeldForSaleGainLossOnSale": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is GainLossOnSaleOfPropertyPlantEquipment."
-],
-"SiteContingencyAccrualCaption": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AccrualForEnvironmentalLossContingencies and members of BalanceSheetLocationAxis."
-],
-"FairValueAssetsMeasuredOnRecurringBasisRetainedInterestValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationTangibleAssets": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LineOfCreditFacilityDateOfFirstRequiredPayment": [
-"2012-01-31",
-"Element was deprecated because it has a dateStringItemType. Possible replacement is LineOfCreditFacilityDateOfFirstRequiredPayment1."
-],
-"LoansPayableFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
-],
-"EquityFinancingForLeveragedBuyout": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CashFlowHedgeGainLossReclassifiedToRevenueNetAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardAwardRequisiteServicePeriod": [
-"2012-01-31",
-"Element was deprecated because it has a durationStringItemType. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardAwardRequisiteServicePeriod1."
-],
-"AssetsOrLiabilitiesFromTransfersOfFinancialAssetsHavingNoReasonableEstimateOfFairValueAxis": [
-"2012-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AccruedLiabilitiesFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
-],
-"TradingSecuritiesFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
-],
-"AdministrativeFeesAmountPaid": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is PaymentForAdministrativeFees."
-],
-"DeprecatedItems": [
-"",
-"This is a container item for US-GAAP concepts that have been deprecated."
-],
-"FinancingReceivableModificationsPostModificationRecordedInvestment1": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is FinancingReceivableModificationsPostModificationRecordedInvestment2."
-],
-"InvestmentInFederalHomeLoanBankStockFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
-],
-"LeveragedBuyoutTransactionDisclosureTextBlock": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"ScheduleOfLifeSettlementContractsInvestmentMethodFiveYearDisclosureAxis": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept modeled as a dimension was replaced with line items. Possible replacement is line items within ScheduleOfLifeSettlementContractsInvestmentMethodTextBlock."
-],
-"FiniteLivedCoalSupplyAgreementGross": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FiniteLivedIntangibleAssetsGross and members of FiniteLivedIntangibleAssetsByMajorClassAxis."
-],
-"NotionalAmountOfPriceRiskDerivatives": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis."
-],
-"DebtInstrumentConvertibleLatestDate": [
-"2012-01-31",
-"Element was deprecated because it has a dateStringItemType. Possible replacement is DebtInstrumentConvertibleLatestDate1."
-],
-"InvestmentsInForeignSubsidiariesAndForeignCorporateJointVenturesThatAreEssentiallyPermanentInDurationMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are UndistributedEarningsOfForeignSubsidiaries,  DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferenceUndistributedEarningsOfForeignSubsidiaries, DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxableUndistributedEarningsOfForeignSubsidiaries, DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityUndistributedEarningsOfForeignSubsidiaries, DeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticableUndistributedEarningsOfForeignSubsidiaries."
-],
-"MaximumLengthOfTimeHedgedInInterestRateCashFlowHedge": [
-"2012-01-31",
-"Element was deprecated because it has a durationStringItemType. Possible replacement is MaximumLengthOfTimeHedgedInInterestRateCashFlowHedge1."
-],
-"LongLivedAssetsHeldForSaleImpairmentCharge": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is ImpairmentOfLongLivedAssetsToBeDisposedOf."
-],
-"ScheduleOfPurchasePriceAllocationTableTextBlock": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"StockholdersEquityNotAllowableForNetCapital": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is StockholdersEquityAttributableToParentNotAllowableForNetCapital."
-],
-"CashFlowHedgeLossReclassifiedToInvestmentIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is InvestmentIncomeNet and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"CumulativeEffectOfChangeInAccountingPrincipleTabularPresentationByFinancialStatementLineItemRestatedAmountAbstract": [
-"2012-01-31",
-"This element was deprecated because the children of this abstract were deprecated."
-],
-"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInRollingYearFive": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInRollingYearFive."
-],
-"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareLiquidatingInvestmentRemainingPeriodHighEstimate": [
-"2012-01-31",
-"Element was deprecated because it has an instant period type. Possible replacement is FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareLiquidatingInvestmentRemainingPeriod1."
-],
-"TradingSecuritiesEquityCurrent": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TradingSecuritiesEquity."
-],
-"HeldToMaturitySecuritiesFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationPropertyPlantAndEquipment": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AverageBalanceDuringPeriodOfLoansHeldInPortfolio": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"ChangeInTaxStatusAxis": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsIntangibleAsset": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"StockholdersEquityIncludingPortionAttributableToNoncontrollingInterestAdjustedBalance": [
-"2013-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is StockholdersEquityIncludingPortionAttributableToNoncontrollingInterestAdjustedBalance1."
-],
-"LeveragedBuyoutCostOfTransactionChargedToExpenseAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"AllowanceForLoanAndLeaseLossesRecoveriesOfBadDebts": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is AllowanceForLoanAndLeaseLossRecoveryOfBadDebts."
-],
-"DebtInstrumentFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationProjectedBenefitObligationAsset": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AvailableforsaleSecuritiesContinuousUnrealizedLossPosition12MonthsOrLongerAggregateLosses1": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is AvailableforsaleSecuritiesContinuousUnrealizedLossPosition12MonthsOrLongerAggregateLosses."
-],
-"MortgageLoansOnRealEstateRenewedAndExtendedAmount": [
-"2013-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is MortgageLoansOnRealEstateRenewedAndExtendedAmount1."
-],
-"CategoriesOfInvestmentsCostMethodInvestmentsMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is CostmethodInvestmentsMember."
-],
-"CashFlowHedgeGainLossReclassifiedToCostOfSalesNet": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CostOfGoodsSold and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisDerivativeFinancialInstrumentsLiabilitiesValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
-],
-"FiniteLivedMediaContentGross": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FiniteLivedIntangibleAssetsGross and members of FiniteLivedIntangibleAssetsByMajorClassAxis."
-],
-"OtherComprehensiveIncomeForeignCurrencyTranslationAdjustmentTax": [
-"2012-01-31",
-"Element was deprecated because it has no balance attribute. Possible replacement is OtherComprehensiveIncomeLossForeignCurrencyTranslationAdjustmentTax."
-],
-"IncomeStatementAndOtherComprehensiveIncomeLocationDomain": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is IncomeStatementLocationDomain."
-],
-"DirectPremiumsWrittenAccidentAndHealth": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsWritten and members ofReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"IndefiniteLivedTradeDress": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are IndefiniteLivedIntangibleAssetsExcludingGoodwill and members of IndefiniteLivedIntangibleAssetsByMajorClassAxis."
-],
-"GeographicalIntersegmentEliminationsMember": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Possible replacements are members of ConsolidationItemsAxis."
-],
-"LeveragedBuyoutContinuingOwnershipInterestByContinuingStockholders": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"MinimumNetCapitalRequired": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is MinimumNetCapitalRequired1."
-],
-"ForeignReinsuranceUnderOpenYearMethodPremiumsClaimsAndExpense": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
 ],
 "AccountingStandardsUpdate200908Member": [
 "2014-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"InvestmentInFederalHomeLoanBankStockFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
-],
-"CumulativeEffectOfChangeInAccountingPrincipleTabularPresentationByFinancialStatementLineItemRestatedAmount": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are NewAccountingPronouncementsOrChangeInAccountingPrincipleTable to model the financial reporting concept. Line items that can be used instead of this element include, but are not limited to, IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest, ProfitLoss, EarningsPerShareBasic, and EarningsPerShareDiluted."
-],
-"NotesPayableFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
-],
-"OtherComprehensiveIncomeLossReclassificationAdjustmentForWritedownOfSecuritiesIncludedInNetIncomeBeforeTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForWritedownOfSecuritiesBeforeTax."
-],
-"AllowanceForLoanAndLeaseLossesProvisionForLossGross": [
-"2013-01-31",
-"Element was deprecated because it is an invalid concept. Possible replacement is ProvisionForLoanAndLeaseLosses."
-],
-"ImpairedFinancingReceivableWithNoRelatedAllowanceAxis": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is FinancingReceivableRecordedInvestmentByClassOfFinancingReceivableAxis."
-],
-"DerivativeHedgeDesignation": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
-],
-"GainsLossesOnSalesOfAssetsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnDispositionOfAssets1."
-],
-"SalesRevenueGoodsNetPercentage": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ConcentrationRiskPercentage1 and members of ConcentrationRiskByBenchmarkAxis."
-],
-"CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesOtherThanTemporaryImpairmentCharges": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesOtherthanTemporaryImpairmentChargesCreditLoss."
-],
-"AcquiredFiniteLivedIntangibleAssetWeightedAverageUsefulLife": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is AcquiredFiniteLivedIntangibleAssetsWeightedAverageUsefulLife."
-],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsForfeitedInPeriodWeightedAverageGrantDateFairValue": [
-"2012-01-31",
-"Element was deprecated because it has an instant period type. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsForfeituresWeightedAverageGrantDateFairValue."
-],
-"GainLossOnSaleOfSubsidiarysStockMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"MinorityInterestInNetIncomeLossOtherMinorityInterests": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacement is NoncontrollingInterestInNetIncomeLossOtherNoncontrollingInterestsNonredeemable or NoncontrollingInterestInNetIncomeLossOtherNoncontrollingInterestsRedeemable."
-],
-"TradingSecuritiesCurrentAbstract": [
+"AccountingStandardsUpdate200910Member": [
 "2014-01-31",
-"Element was deprecated."
-],
-"SharesSubjectToMandatoryRedemptionSettlementTermsForwardPriceOrOptionStrikePrice": [
-"2014-01-31",
-"Element was deprecated because it has a perUnitItemType attribute, it represents multiple distinct concepts and the financial reporting concept can be conveyed dimensionally. Possible replacements are OptionIndexedToIssuersEquityStrikePrice1 or ForwardContractIndexedToIssuersEquityForwardRate and members of ScheduleOfSharesSubjectToMandatoryRedemptionBySettlementTermsAxis."
-],
-"FiveYearScheduleOfMaturitiesOfParentCompanyRepaymentsOfPrincipleInYearTwo": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInYearTwo."
-],
-"CashFlowHedgeGainLossReclassifiedToEarningsNetAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"DerivativeNonmonetaryNotionalAmountPricePerGallon": [
-"2013-01-31",
-"Element was deprecated because the intended concept conveyed is the underlying. Possible replacement is UnderlyingDerivativeVolume."
-],
-"DebtInstrumentInterestRateAtPeriodEnd": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DebtInstrumentInterestRateEffectivePercentage."
-],
-"SaleOfStockSubsidiary": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is SubsidiariesMember."
-],
-"AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionIncomeStatementClassificationOfGainLossOnDisposal": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionGainLossOnDisposition1 and members of IncomeStatementLocationAxis."
-],
-"ForeignCurrencyDerivativesAtFairValueNet": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeFairValueOfDerivativeNet and ForeignExchangeContractMember."
-],
-"NetInvestmentIncomeInsuranceEntityShortTermInvestments": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NetInvestmentIncome and members of InvestmentTypeAxis."
-],
-"DerivativeInstrumentsGainRecognizedInIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeGainOnDerivative and members of HedgingDesignationAxis."
-],
-"DerivativeForwardExchangeRate": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is DerivativeForwardExchangeRate1."
-],
-"RetainedInterestFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
-],
-"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInRollingYearTwo": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInRollingYearTwo."
-],
-"LossContingencyRelatedReceivableCarryingValueNoncurrent": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is LossContingencyReceivableNoncurrent."
-],
-"MinimumNetCapitalRequiredForBrokerDealerSubsidiary": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is MinimumNetCapitalRequiredForBrokerDealerSubsidiary1."
-],
-"HeldtomaturitySecuritiesInUnrealizedLossPositionsQualitativeDisclosureOtherThirdPartyGuaranteesDescription": [
-"2013-01-31",
-"Element was deprecated."
-],
-"PremiumsWrittenNetOtherInsurance": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PremiumsWrittenNet and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"DefinedBenefitPlanTargetAllocationPercentageOfAssetsDebtSecuritiesRangeMaximum": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are DefinedBenefitPlanTargetPlanAssetAllocationsRangeMaximum and members of DefinedBenefitPlanByPlanAssetCategoriesAxis."
-],
-"IndefiniteLivedIntangibleAssetsAcquiredDuringPeriod": [
-"2013-01-31",
-"Element was deprecated because it was incorrectly defined.  Possible replacement element is IndefiniteLivedIntangibleAssetsAcquired."
-],
-"BusinessAcquisitionPurchasePriceAllocationStatus": [
-"2013-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"BusinessAcquisitionPreacquisitionContingencyAmount": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareLiquidatingInvestmentRemainingPeriodDate": [
-"2012-01-31",
-"Element was deprecated due to redundancy. Possible replacement is FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareLiquidatingInvestmentRemainingPeriod1."
-],
-"PremiumsWrittenNetFinancialGuaranteeInsuranceContractsAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"PublicUtilitiesPropertyPlantAndEquipmentAmountOfAcquisitionAdjustmentsRelatedAccumulatedDepreciation": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentAmountOfAcquisitionAdjustmentsRelatedAccumulatedDepreciation1."
-],
-"ProceedsFromLoanAndLeaseOriginationsAndPrincipalCollections": [
-"2012-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is ProceedsFromLoanAndLeaseOriginationsAndPrincipalCollections1."
-],
-"DirectPremiumsWrittenOtherInsurance": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"NotionalAmountOfOtherDerivativesNotDesignatedAsHedgingInstruments": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of HedgingDesignationAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsReceivables": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FairValueLevel2ToLevel1TransfersAmount": [
-"2012-01-31",
-"Element was deprecated. Possible replacements are FairValueAssetsLevel2ToLevel1TransfersAmount, FairValueLiabilitiesLevel2ToLevel1TransfersAmount, or FairValueEquityLevel2ToLevel1TransfersAmount."
-],
-"DefinedContributionPlanMaximumAnnualContributionPerEmployeeAmount": [
-"2013-01-31",
-"Element was deprecated because it was incorrectly defined. Possible replacement is DefinedContributionPlanMaximumAnnualContributionsPerEmployeeAmount."
-],
-"PrescriptionDrugSubsidyReceiptsYearTwo": [
-"2012-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is PrescriptionDrugSubsidyReceiptsYearTwo1."
-],
-"HealthCareOrganizationAmountOfWriteOffsOfAllowanceForDoubtfulAccounts": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AllowanceForDoubtfulAccountsReceivableWriteOffs."
-],
-"BusinessAcquisitionCostOfAcquiredEntityPlannedRestructuringActivities": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FairValueByBalanceSheetGroupingMethodologyAbstract": [
-"2012-01-31",
-"This element was removed because its children were deprecated after the disclosure was dimensionalized."
-],
-"NetInvestmentIncomeInsuranceEntityInvestmentRealEstate": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NetInvestmentIncome and members of InvestmentTypeAxis."
-],
-"OtherTaxCarryforwardNameDomain": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TaxCreditCarryforwardNameDomain."
-],
-"FairValueAssetsMeasuredOnRecurringBasisReceivablesValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
-],
-"RevenueFromAdministrativeServicesAffiliated": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AdministrativeServicesRevenue and members of LegalEntityAxis."
-],
-"DefinedBenefitPlanTargetAllocationPercentageOfAssetsOtherRangeMinimum": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are DefinedBenefitPlanTargetPlanAssetAllocationsRangeMinimum and members of DefinedBenefitPlanByPlanAssetCategoriesAxis."
-],
-"DefinedBenefitPlanExpectedFutureBenefitPaymentsInYearThree": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is DefinedBenefitPlanExpectedFutureBenefitPaymentsYearThree."
-],
-"NewContractAxis": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"ScheduleOfDistributionsMadeToMembersOrLimitedPartnersByDistributionTextBlock": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacement is  DistributionsMadeToLimitedLiabilityCompanyLlcMemberByDistributionTableTextBlock or DistributionsMadeToLimitedPartnerByDistributionTableTextBlock."
-],
-"DefinedBenefitPlanTargetAllocationPercentageOfAssetsDebtSecurities": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are DefinedBenefitPlanTargetPlanAssetAllocations and members of DefinedBenefitPlanByPlanAssetCategoriesAxis."
-],
-"AssetsOfDisposalGroupIncludingDiscontinuedOperationNoncurrent": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DisposalGroupIncludingDiscontinuedOperationLongLivedAssetsNoncurrent, DisposalGroupIncludingDiscontinuedOperationLongLivedAssetsCurrent or DisposalGroupIncludingDiscontinuedOperationLongLivedAssets."
-],
-"OtherComprehensiveIncomeLossBeforeTaxPeriodIncreaseDecrease": [
-"2012-01-31",
-"Element was deprecated because it has no balance attribute. Possible replacement is OtherComprehensiveIncomeLossBeforeTax."
-],
-"RevolvingLoanFacilityToFinanceLeveragedBuyout": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CommitmentsFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
-],
-"FiveYearScheduleOfMaturitiesOfParentCompanyRepaymentsOfPrincipleInYearFour": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInYearFour."
-],
-"CollaborativeArrangementProductAggregatedDisclosureMember": [
-"2013-01-31",
-"Element was deprecated because of unnecessary level of disaggregation in a parent-child relationship."
-],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardFairValueAssumptionsExpectedTermMinimum": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacements are SharebasedCompensationArrangementBySharebasedPaymentAwardFairValueAssumptionsExpectedTerm1 and RangeAxis (MinimumMember)."
-],
-"ExplanationDifferencesBetweenBookAndTaxBasis": [
-"2013-01-31",
-"Element was deprecated because it is an invalid concept."
-],
-"MortgageLoansOnRealEstatePriorLiens": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is MortgageLoansOnRealEstatePriorLiens1."
-],
-"BusinessAcquisitionContingentConsiderationPotentialCashPayment": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"IncomeLossFromDiscontinuedOperationsNetOfTaxPerOutstandingLimitedPartnershipUnit": [
-"2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromDiscontinuedOperationsNetOfTaxPerOutstandingLimitedPartnershipUnitBasic."
-],
-"RestructuringAndRelatedCostCostIncurredToDate": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is RestructuringAndRelatedCostCostIncurredToDate1."
-],
-"AvailableforsaleSecuritiesDebtMaturityDateRangeLow": [
-"2012-01-31",
-"Element was deprecated because it has a durationStringItemType. Possible replacements are AvailableforsaleSecuritiesDebtMaturitiesDate and RangeAxis (MinimumMember)."
-],
-"IncreaseDecreaseInCarryingValueOfAssetsReceivedAsConsiderationInDisposalOfBusiness": [
-"2013-01-31",
-"Element was deprecated."
-],
-"OtherComprehensiveIncomeForeignCurrencyTransactionAndTranslationReclassificationAdjustmentRealizedUponSaleOrLiquidationBeforeTax": [
-"2012-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossForeignCurrencyTransactionAndTranslationReclassificationAdjustmentFromAOCIRealizedUponSaleOrLiquidationBeforeTax."
-],
-"HeldToMaturitySecuritiesUnrecognizedHoldingLoss": [
-"2013-01-31",
-"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is HeldToMaturitySecuritiesUnrecognizedHoldingLosses."
-],
-"OriginationAndPurchasesOfMortgageBankingAssets": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is PaymentsForOriginationAndPurchasesOfLoansHeldForSale."
-],
-"DisposalGroupIncludingDiscontinuedOperationIntangibleAssetsNet": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DisposalGroupIncludingDiscontinuedOperationIntangibleAssetsNoncurrent, DisposalGroupIncludingDiscontinuedOperationIntangibleAssetsCurrent or DisposalGroupIncludingDiscontinuedOperationIntangibleAssets."
-],
-"FinancingReceivable": [
-"2012-01-31",
-"Element was deprecated due to redundancy. Possible replacement is NotesReceivableNet."
-],
-"BusinessAcquisitionPurchasePriceAllocationNoncontrollingInterest": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"SiteContingencyAccrualUndiscountedAmount": [
-"2013-01-31",
-"Element was deprecated due to redundancy.  Possible replacement is AccrualForEnvironmentalLossContingenciesGross."
-],
-"TradingLiabilitiesFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
-],
-"ValuationAllowanceAmount": [
-"2013-01-31",
-"Element was deprecated due to redundancy.  Possible replacement is DeferredTaxAssetsValuationAllowance."
-],
-"DebtInstrumentBasisSpreadOnVariableRate": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is DebtInstrumentBasisSpreadOnVariableRate1."
-],
-"OtherComprehensiveIncomeReclassificationOfDefinedBenefitPlanNetTransitionAssetObligationRecognizedInNetPeriodicBenefitCostNetOfTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetTransitionAssetObligationNetOfTax."
-],
-"CausesOfIncreaseDecreaseInLiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAxis": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilityForCatastropheClaimsByCatastrophicEventAxis."
-],
-"FinancingReceivableAllowanceDomain": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is FinancingReceivableRecordedInvestmentClassOfFinancingReceivableDomain."
-],
-"EntityWideDisclosureOnGeographicAreasRevenueFromExternalCustomersAttributedToForeignCountries": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Possible replacement is Revenues and members of StatementGeographicalAxis."
-],
-"AverageBalanceDuringPeriodOfLoansHeldInPortfolioAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"OtherAmortizationMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OtherAmortizationOfDeferredCharges."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisFederalFundsPurchasedAndSecuritiesSoldUnderAgreementsToRepurchaseValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
-],
-"OtherAssetsHeldForSaleCurrent": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DisposalGroupIncludingDiscontinuedOperationOtherCurrentAssets."
-],
-"ClosedBlockDividendObligation": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ClosedBlockLiabilitiesPolicyholderDividendObligation."
-],
-"LossContingencyAccrualCarryingValueProvision": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is LossContingencyAccrualProvision."
-],
-"PremiumsWrittenAssumedCededAndEarnedAndIndustryRatiosAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"PremiumsEarnedNetOtherInsuranceAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardAwardVestingPeriodMinimum": [
-"2012-01-31",
-"Element was deprecated because it has a dateStringItemType. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardAwardVestingPeriod1, which has been modeled as a dimension."
-],
-"NotionalAmountOfForeignCurrencyFairValueHedgeDerivatives": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis and DerivativeInstrumentRiskAxis."
-],
-"FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisAssetGainLossIncludedInOtherComprehensiveIncome": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisAssetGainLossIncludedInOtherComprehensiveIncomeLoss."
-],
-"MortgageBackedSecuritiesHeldToMaturityFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
-],
-"PremiumIncomeSubjectToParticipationThroughReinsurancePercentage": [
-"2013-01-31",
-"Element was deprecated."
-],
-"PremiumsWrittenNetAccidentAndHealth": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PremiumsWrittenNet and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionFlag": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionFlag1."
-],
-"NoninterestExpenseTransferAgentAndCustodianFeesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpenseTransferAgentandCustodianFees."
-],
-"IndefiniteLivedIntangibleAssetsImpairmentLosses": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is ImpairmentOfIntangibleAssetsIndefinitelivedExcludingGoodwill."
-],
-"FederalHomeLoanBankAdvancesGeneralDebtObligationsDisclosuresCollateralPledged": [
-"2012-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is FederalHomeLoanBankAdvancesGeneralDebtObligationsDisclosuresCollateralPledged1."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAdjustmentOfOpeningBalanceAxis": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacements are AdjustmentsForChangeInAccountingPrincipleAxis and ErrorCorrectionsAndPriorPeriodAdjustmentsRestatementByRestatementPeriodAndAmountAxis."
-],
-"MinorityInterestInNetIncomeLossPreferredUnitHolders": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacement is NoncontrollingInterestInNetIncomeLossPreferredUnitHoldersRedeemable or NoncontrollingInterestInNetIncomeLossPreferredUnitHoldersNonredeemable."
-],
-"OtherComprehensiveIncomeAvailableForSaleSecuritiesTax": [
-"2012-01-31",
-"Element was deprecated because it has no balance attribute. Possible replacement is OtherComprehensiveIncomeLossAvailableForSaleSecuritiesTax."
 ],
 "AccountingStandardsUpdate200912Member": [
 "2014-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"OtherComprehensiveIncomeLossTaxPortionAttributableToParent": [
-"2012-01-31",
-"Element was deprecated because it has no balance attribute. Possible replacement is OtherComprehensiveIncomeLossTaxPortionAttributableToParent1."
+"AccountingStandardsUpdate200913Member": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"BusinessAcquisitionPurchasePriceAllocationIntangibleAssetsDescription": [
-"2013-01-31",
+"AccountingStandardsUpdate200914Member": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"AccountingStandardsUpdate200915Member": [
+"2014-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
 "AccountingStandardsUpdate200917Member": [
 "2014-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"FinancingReceivableByCreditQualityIndicatorDomain": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are CreditRatingAMBestDomain, InternalCreditAssessmentDomain, ExternalCreditRatingFitchMember, ExternalCreditRatingStandardPoorsMember, ExternalCreditRatingMoodysMember, ExternalCreditRatingByGroupingDomain."
-],
-"RevenueFromAdministrativeServices": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AdministrativeServicesRevenue and members of LegalEntityAxis."
-],
-"CumulativeEffectOnRetainedEarningsBeforeTax": [
-"2012-01-31",
-"Element was deprecated because it has an instant period type. Possible replacement is CumulativeEffectOnRetainedEarningsBeforeTax1."
-],
-"ImpairedIntangibleAssetNameDomain": [
-"2012-01-31",
-"Element was deprecated. Possible replacements are IndefiniteLivedIntangibleAssetsMajorClassNameDomain and/or FiniteLivedIntangibleAssetsMajorClassNameDomain."
-],
-"OtherAssetsHeldForSale": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DisposalGroupIncludingDiscontinuedOperationOtherAssets."
-],
-"UnusualOrInfrequentItemGross1": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacement for a gain is UnusualOrInfrequentItemGainGross, or UnusualOrInfrequentItemLossGross to represent a loss."
-],
-"DeferredTaxLiabilityNotRecognizedTable": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"ImpairmentOfGoodwillMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GoodwillImpairmentLoss."
-],
-"ProceedsFromSaleOfOtherAssets": [
-"2013-01-31",
-"Element was deprecated because it was being used for either operating or investing activities. Possible replacements are ProceedsFromSaleOfOtherAssets1 and ProceedsFromSaleOfOtherAssetsInvestingActivities."
-],
-"CumulativeEffectAdjustmentBifurcationOfHybridsGrossGains": [
+"AccountingStandardsUpdate201001Member": [
 "2014-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"PresentValueOfFutureInsuranceProfitsInterestAccrued": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsInterestAccrued1."
-],
-"DeferredCompensationArrangementWithIndividualRequisiteServicePeriod": [
-"2014-01-31",
-"Element was deprecated because it has a stringItemType attribute. Possible replacement is DeferredCompensationArrangementWithIndividualRequisiteServicePeriod1."
-],
-"MoreThanTwoAndWithinThreeYearsFromBalanceSheetDateMember": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept modeled as a dimension was replaced with line items. Possible replacements are line items within ScheduleOfLifeSettlementContractsFairValueMethodTextBlock and ScheduleOfLifeSettlementContractsInvestmentMethodTextBlock."
-],
-"DefinedBenefitPlanExpectedFutureBenefitPaymentsInYearFour": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is DefinedBenefitPlanExpectedFutureBenefitPaymentsYearFour."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentLiabilitiesAccountsPayable": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxable": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxableUndistributedEarningsOfForeignSubsidiaries, DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxableUndistributedEarningsOfDomesticSubsidiaries, DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxableBadDebtReserveForTaxPurposesOfQualifiedLender,  and DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxablePolicyholdersSurplus."
-],
-"CapitalizedExploratoryWellCostsGreaterThanOrEqualToOneYearAndLessThanTwoYears": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CapitalizedExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
-],
-"DirectPremiumsEarnedLife": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"SubsequentEventDateFinancialStatementsAvailableForIssuance": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"IncomeTaxExpenseBenefitAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseReportedAndIncurredButNotReportedIBNRClaimsCommentary": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilityForClaimsAndClaimsAdjustmentExpenseMethodologiesAndAssumptions."
-],
-"OperatingLeaseExpenseOtherExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is LeaseAndRentalExpense."
-],
-"SaleLeasebackTransactionNetProceeds": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are SaleLeasebackTransactionNetProceedsInvestingActivities or SaleLeasebackTransactionNetProceedsFinancingActivities."
-],
-"GainLossOnCreditRiskHedgeIneffectiveness": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeNetHedgeIneffectivenessGainLoss and members of CreditDerivativesByContractTypeAxis."
-],
-"AssumptionForFairValueOnSecuritizationDateOfInterestsContinuedToBeHeldByTransferorServicingAssetsOrLiabilitiesAxis": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is FinancialInstrumentAxis."
-],
-"IncreaseDecreaseInBorrowedSecurities": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is IncreaseDecreaseInSecuritiesBorrowed."
-],
-"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionRangeOfRestrictionPeriodHighEnd": [
-"2012-01-31",
-"Element was deprecated because it has an instant period type. Possible replacement is FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionPeriod and members of RangeAxis."
-],
-"FiniteLivedIntangibleAssetsAcquired": [
-"2013-01-31",
-"Element was deprecated because it was incorrectly defined.  Possible replacement element is FiniteLivedIntangibleAssetsAcquired1."
-],
-"MinorityInterestIncreaseFromStockIssuance": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacement is NoncontrollingInterestIncreaseFromSubsidiaryEquityIssuance or NoncontrollingInterestIncreaseFromSaleOfParentEquityInterest."
-],
-"CostMethodInvestmentsAggregateCarryingAmount": [
-"2013-01-31",
-"Element deprecated due to redundancy. Possible replacement is CostMethodInvestments."
-],
-"ForeignReinsuranceUnderOpenYearMethodPremiumsInUnderwritingAccount": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ForeignReinsuranceUnderOpenYearMethodPremiums."
-],
-"LiabilityForUnpaidClaimsAdjustmentExpenseByExpenseTypeTextBlock": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ScheduleOfLiabilityForUnpaidClaimsAndClaimsAdjustmentExpense."
-],
-"DefinedBenefitPlanEstimatedFutureEmployerContributionsInCurrentFiscalYear": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is DefinedBenefitPlansEstimatedFutureEmployerContributionsInCurrentFiscalYear."
-],
-"FinancialInstrumentsOwnedAndPledgedAsCollateralAssociatedLiabilitiesCaption": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is SecurityOwnedAndPledgedAsCollateralAssociatedLiabilitiesFairValue and members of BalanceSheetLocationAxis."
-],
-"CancellationOfContractDomain": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"LoansHeldForSaleFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
-],
-"PaymentsForRepurchaseOfCommonStockForEmployeeTaxWithholdingObligations": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is PaymentsRelatedToTaxWithholdingForShareBasedCompensation."
-],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardAwardExpirationDating": [
-"2012-01-31",
-"Element was deprecated because it has a dateStringItemType. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardExpirationDate."
-],
-"RestructuringReserveSettledWithoutCash": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is RestructuringReserveSettledWithoutCash1."
-],
-"LineOfCreditFacilityRevolvingCreditDescription": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are LineOfCreditFacilityDescription and members of CreditFacilityAxis."
-],
-"DefinedBenefitPlanRealEstate": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are DefinedBenefitPlanWeightedAverageAssetAllocations and members of DefinedBenefitPlanByPlanAssetCategoriesAxis."
-],
-"FiniteLivedIntangibleAssetsAbstract": [
-"2012-01-31",
-"This element has been deprecated."
-],
-"UnrealizedGainLossOrWriteDownMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is MarketableSecuritiesUnrealizedGainLoss."
-],
-"IncrementalEffectsOnBalanceSheetApplicationOfSFAS158RecognitionProvisionsBalanceSheetLineItemAxis": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is BalanceSheetLocationAxis."
-],
-"EffectsOfChangesInPrepaymentEstimateAssumptionsForCMOsAndREMICsAffectedItemDomain": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"GainOrLossFromSaleOfFinancialAssetsInSecuritizations": [
-"2012-01-31",
-"Element was deprecated because it has a stringItemType. Possible replacement is SecuritizationFinancialAssetForWhichTransferIsAccountedAsSaleGainLossOnSale."
-],
-"DefinedBenefitPlanTargetAllocationPercentageOfAssetsOther": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are DefinedBenefitPlanTargetPlanAssetAllocations and members of DefinedBenefitPlanByPlanAssetCategoriesAxis."
-],
-"NotionalAmountOfForeignCurrencyCashFlowHedgeDerivatives": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
-],
-"SettlementOfLitigationMember": [
-"2012-01-31",
-"Element was deprecated because the dimension of the financial reporting concept was remodeled. Possible replacements are LitigationStatusAxis and other elements/members as needed."
-],
-"ScheduleOfEquityIssuedSinceInceptionTextBlock": [
-"2012-01-31",
-"Element was deprecated because the disclosure is required in the statement of stockholders' equity."
-],
-"BusinessAcquisitionPurchasePriceAllocationProperty": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"RealizedLossesOnSaleOfInvestmentsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is MarketableSecuritiesRealizedGainLoss."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInOtherIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueLiabilitiesMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
-],
-"PrepaidReinsurancePremiumsAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"PublicUtilitiesPropertyPlantAndEquipmentDescriptionOfAmortizationOfPresentValueOfRegulatedAssetForPlantAbandonment": [
-"2012-01-31",
-"Element was deprecated because it has a stringItemType. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentAmortizationOfPresentValueOfRegulatedAssetForPlantAbandonment."
-],
-"SiteContingencyAccrualDiscountAmount": [
-"2013-01-31",
-"Element was deprecated due to redundancy.  Possible replacement is AccrualForEnvironmentalLossContingenciesDiscount."
-],
-"OperatingLossCarryforwardsExpirationDates": [
-"2013-01-31",
-"Element was deprecated because it has a stringItemtype attribute. Possible replacement is OperatingLossCarryforwardsExpirationDate."
-],
-"RemainingRecoveryPeriodOfRegulatoryAssetsForWhichNoReturnOnInvestmentDuringRecoveryPeriodIsProvided": [
-"2012-01-31",
-"Element was deprecated because it has a durationStringItemType. Possible replacement is RemainingRecoveryPeriodOfRegulatoryAssetsForWhichNoReturnOnInvestmentDuringRecoveryPeriodIsProvided1."
-],
-"FairValueLevel1ToLevel2TransfersDescription": [
-"2012-01-31",
-"Element was deprecated. Possible replacements are FairValueAssetsLevel1ToLevel2TransfersAmount, FairValueLiabilitiesLevel1ToLevel2TransfersAmount, or FairValueEquityLevel1ToLevel2TransfersAmount."
-],
-"BusinessAcquisitionDateOfAcquisitionAgreement": [
-"2012-01-31",
-"Element was deprecated because it has a dateStringItemType. Possible replacement is BusinessAcquisitionDateOfAcquisitionAgreement1."
-],
-"SiteContingencyAccrualDiscountRate": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AccrualForEnvironmentalLossContingenciesDiscountRate."
-],
-"ServicingLiabilityAtAmortizedCostAmount": [
-"2012-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ServicingLiabilityAtAmortizedValueBalance."
-],
-"IncomeTaxPenaltiesAndInterestAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"ExperienceRatedRefundsPayable": [
-"2013-01-31",
-"Element was deprecated due to remodeling of reinsurance topic area."
-],
-"CancellationOfContractAxis": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"AvailableForSaleSecuritiesFairValueDisclosure": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AvailableForSaleSecurities."
-],
-"OtherComprehensiveIncomeMinimumPensionLiabilityNetAdjustmentNetOfTax": [
-"2012-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"SegmentReportingInformationRevenue": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Possible replacement is Revenues and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
-],
-"CashSurrenderValueFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
-],
-"GuaranteedBenefitsPaid": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilitiesForGuaranteesOnLongDurationContractsBenefitsPaid."
-],
-"GasAndOilAcreageUndevelopedGross": [
-"2012-01-31",
-"Element was deprecated because it has an integerItemType. Possible replacement is GasAndOilAreaUndevelopedGross."
-],
-"DeferredPolicyAcquisitionCostsNet": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DeferredPolicyAcquisitionCosts."
-],
-"DefinedBenefitPlanTargetAllocationPercentageOfAssetsEquitySecuritiesRangeMinimum": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are DefinedBenefitPlanTargetPlanAssetAllocationsRangeMaximum and members of DefinedBenefitPlanByPlanAssetCategoriesAxis."
-],
-"LiabilitiesRelatedToInvestmentContractsFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
-],
-"EscrowDepositDisbursementsRelatedToPropertyAcquisition": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is EscrowDepositDisbursementsRelatedToPropertyAcquisition1."
-],
-"OtherComprehensiveIncomeLossReclassificationAdjustmentForWriteDownOfSecuritiesIncludedInNetIncomeTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForWritedownOfSecuritiesTax."
-],
-"SharesSubjectToMandatoryRedemptionSettlementTermsImpactOfChangesInFairValueOfSharesOnNumberOfShares": [
-"2012-01-31",
-"Element was deprecated because it has an integerItemType. Possible replacement is FinancialInstrumentsSubjectToMandatoryRedemptionSettlementTermsImpactOfChangesInFairValueOfSharesOnNumberOfShares."
-],
-"EffectOfIllegalActsOnFinancialStatementsDisclosureMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"EnvironmentalCostRecognizedRecoveryCreditedToExpense": [
-"2012-01-31",
-"Element was deprecated because it has an instant period type. Possible replacement is EnvironmentalCostsRecognizedRecoveryCreditedToExpense."
-],
-"OtherComprehensiveIncomeLossReclassificationAdjustmentOnDerivativesIncludedInNetIncomeBeforeTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIOnDerivativesBeforeTax."
-],
-"CashFlowHedgeGainReclassifiedToCostOfSales": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CostOfGoodsSold and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"AgingOfCapitalizedExploratoryWellCostAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"PremiumsReceivableFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
-],
-"OtherComprehensiveIncomeReclassificationAdjustmentOnDerivativesIncludedInNetIncomeBeforeTax": [
-"2012-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIOnDerivativesBeforeTax."
-],
-"ScheduleOfLifeSettlementContractsInvestmentMethodTable": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept modeled as a dimension was replaced with line items. Possible replacement is line items within ScheduleOfLifeSettlementContractsInvestmentMethodTextBlock."
-],
-"HeldToMaturitySecuritiesContinuousUnrealizedLossPosition12MonthsOrLongerAggregateLosses": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is HeldToMaturitySecuritiesContinuousUnrealizedLossPosition12MonthsOrLongerAggregateLoss."
-],
-"BusinessAcquisitionPurchasePriceAllocationOtherNoncurrentAssets": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"ProductionAndDistributionCostsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ProductionAndDistributionCosts."
-],
-"InterestAndDividendIncomeMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is InvestmentIncomeInterestAndDividend."
-],
-"DefinedBenefitPlanTargetAllocationPercentageOfAssetsDebtSecuritiesRangeMinimum": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are DefinedBenefitPlanTargetPlanAssetAllocationsRangeMinimum and members of DefinedBenefitPlanByPlanAssetCategoriesAxis."
-],
-"DistributionMadeToMemberOrLimitedPartnerDistributionsDeclaredPerUnit": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberDistributionsDeclaredPerUnit or DistributionMadeToLimitedPartnerDistributionsDeclaredPerUnit."
-],
-"DerivativeFinancialInstrumentsAssetsFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
-],
-"DescriptionOfChangeInAverageTrancheLifeEstimate": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"AssetsDesignatedToClosedBlockOtherClosedBlockAssets": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area. Possible replacement is AssetsDesignatedToClosedBlockOtherClosedBlockAssets1."
-],
-"OtherComprehensiveIncomeReclassificationOfDefinedBenefitPlansNetGainLossRecognizedInNetPeriodicBenefitCostBeforeTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetGainLossBeforeTax."
-],
-"TradingSecuritiesFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
-],
-"GainLossOnInvestmentsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnInvestments."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsPrepaidExpenseAndOtherAssets": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"IndefiniteLivedTradeSecrets": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are IndefiniteLivedIntangibleAssetsExcludingGoodwill and members of IndefiniteLivedIntangibleAssetsByMajorClassAxis."
-],
-"FiveYearScheduleOfMaturitiesOfParentCompanyRepaymentsOfPrincipleInYearFive": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInYearFive."
-],
-"LeveragedBuyoutCostOfTransactionChargedToExpense": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareLiquidatingInvestmentRemainingPeriodLowEstimate": [
-"2012-01-31",
-"Element was deprecated because it has an instant period type. Possible replacement is FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareLiquidatingInvestmentRemainingPeriod1."
-],
-"BusinessAcquisitionPurchasePriceAllocationNetTangibleAssets": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DefinedBenefitPlanFairValueOfPlanAssetsByMeasurementAxis": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is FairValueByFairValueHierarchyLevelAxis."
-],
-"CashFlowHedgeLossReclassifiedToRevenue": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is Revenues and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"DescriptionOfCreditRiskDerivativeActivities": [
-"2013-01-31",
-"Element was deprecated because it has a stringItemType attribute. Possible replacement is DisclosureOfCreditDerivativesTextBlock."
-],
-"SubsequentEventDateEvaluationEnded": [
-"2012-01-31",
-"Element was deprecated."
-],
-"InvestmentsFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
-],
-"CapitalLeasesFutureMinimumPaymentsNetMinimumPayments": [
-"2012-01-31",
-"Element was deprecated due to redundancy. Possible replacement is CapitalLeasesFutureMinimumPaymentsPresentValueOfNetMinimumPayments."
-],
-"GainLossOnSaleOfLeasedAssetsNetOperatingLeasesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"EnvironmentalCostsOfPropertyForSaleDisposalOrAbandonmentAnticipatedExitCosts": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is EnvironmentalExitCostsAnticipatedCost."
-],
-"EnvironmentalCostsOfPropertyForSaleDisposalOrAbandonmentDisclosures": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is EnvironmentalExitCostsNatureOfCosts."
-],
-"AlternativeNetCapitalRequirement": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is AlternativeNetCapitalRequirement1."
-],
-"RealEstateAndAccumulatedDepreciationCarryingAmountOfLandAndBuildingsAndImprovements": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is RealEstateGrossAtCarryingValue."
-],
-"HeldToMaturitySecuritiesFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
-],
-"DefinedBenefitPlanTargetAllocationPercentagesOfAssetsRealEstateAbstract": [
-"2012-01-31",
-"This element has been deprecated."
-],
-"SettlementOfDebtMember": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"AssetsHeldForSaleAtCarryingValue": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AssetsOfDisposalGroupIncludingDiscontinuedOperation."
-],
-"LeveragedBuyoutOwnershipInterestOfNewInvestors": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"OtherComprehensiveIncomeLossReclassificationPensionAndOtherPostretirementBenefitPlansNetGainLossRecognizedInNetPeriodicBenefitCostTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetGainLossTax."
-],
-"UndistributedEarningsAllocatedToParticipatingSecurities": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are UndistributedEarningsLossAllocatedToParticipatingSecuritiesBasic or UndistributedEarningsLossAllocatedToParticipatingSecuritiesDiluted."
-],
-"OtherComprehensiveIncomeReclassificationAdjustmentForWriteDownOfSecuritiesIncludedInNetIncomeBeforeTax": [
-"2012-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForWritedownOfSecuritiesBeforeTax."
-],
-"CashFlowHedgeGainLossReclassifiedToOtherIncomeNetAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"TradingLiabilitiesFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
-],
-"CumulativeEffectAdjustmentApplicationOfFairValueOptionUnrealizedGainsRecognized": [
+"AccountingStandardsUpdate201002Member": [
 "2014-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"CumulativeEffectAdjustmentApplicationOfFairValueOptionGrossLossesAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"OtherComprehensiveIncomeAvailableForSaleSecuritiesAdjustmentBeforeTaxPeriodIncreaseDecrease": [
-"2012-01-31",
-"Element was deprecated because it has no balance attribute. Possible replacement is OtherComprehensiveIncomeLossAvailableForSaleSecuritiesAdjustmentBeforeTax."
-],
-"EffectsOfUnrealizedHoldingGainLossOnPresentValueOfFutureInsuranceProfits": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is EffectsOfUnrealizedHoldingGainLossOnPresentValueOfFutureInsuranceProfits1."
-],
-"FiveYearScheduleOfMaturitiesOfParentCompanyRepaymentsOfPrincipleWithinOneYear": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInNextTwelveMonths."
-],
-"MoreThanFourAndWithinFiveYearsFromBalanceSheetDateMember": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept modeled as a dimension was replaced with line items. Possible replacements are line items within ScheduleOfLifeSettlementContractsFairValueMethodTextBlock and ScheduleOfLifeSettlementContractsInvestmentMethodTextBlock."
-],
-"EntityWideDisclosureOnGeographicAreasLongLivedAssetsInEntitysCountryOfDomicile": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Possible replacement is NoncurrentAssets and members of StatementGeographicalAxis."
-],
-"ScheduleOfShareBasedCompensationArrangementByShareBasedPaymentAwardAwardTypeAndPlanNameAxis": [
-"2012-01-31",
-"Element was deprecated because the dimension of the financial reporting concept was remodeled. Possible replacements are PlanNameAxis and/or AwardTypeAxis."
-],
-"ComponentOfOtherExpenseNonoperatingNameDomain": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"BusinessAcquisitionPurchasePriceAllocationIntangibleAssetsOtherThanGoodwill": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAdjustmentOfOpeningBalanceTypeDomain": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacements are ChangeInAccountingPrincipleMember and AdjustmentsForErrorCorrectionDomain."
-],
-"AcquiredIndefiniteLivedIntangibleAssetAmount": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is IndefinitelivedIntangibleAssetsAcquired."
-],
-"DisposalDate": [
-"2012-01-31",
-"Element was deprecated because it has a dateStringItemType. Possible replacement is DisposalDate1."
-],
-"GainLossOnCreditRiskDerivativesNet": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeGainLossOnDerivativeNet and members of CreditDerivativesByContractTypeAxis."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseIncurredClaimsPriorYears": [
-"2014-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is SupplementalInformationForPropertyCasualtyInsuranceUnderwritersPriorYearClaimsAndClaimsAdjustmentExpense."
-],
-"BusinessCombinationStepAcquisitionEquityInterestInAcquireeFairValue": [
-"2013-01-31",
-"Element was deprecated because it has debit balance and instant period type attributes. Possible replacement is BusinessCombinationStepAcquisitionEquityInterestInAcquireeFairValue1."
-],
-"RefundsReceivedRelatedToRevenueFromDifferentYearMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"FutureAmortizationExpenseRemainderOfFiscalYear": [
-"2012-01-31",
-"Element was deprecated because it has a duration period type. Possible replacement is FiniteLivedIntangibleAssetsAmortizationExpenseRemainderOfFiscalYear."
-],
-"EquitySecuritiesOtherMember": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"RealEstateInsuranceMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is RealEstateInsurance."
-],
-"AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionSegmentClassification": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionGainLossOnDisposition1 and members of StatementBusinessSegmentsAxis."
-],
-"GainLossOnSettlementOfDerivativeInstrumentMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnSaleOfDerivatives."
-],
-"ProjectsWithExploratoryWellCostsCapitalizedForMoreThanOneYearByProjectAxis": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is CapitalizedCostsOfUnprovedPropertiesExcludedFromAmortizationByPropertyOrProjectAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsAssetHeldForSale": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AssetsHeldForSaleAtCarryingValueAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"ClassOfFinancingReceivableMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is FinancingReceivableRecordedInvestmentClassOfFinancingReceivableDomain."
-],
-"FairValueByBalanceSheetGroupingSignificantAssumptionsAbstract": [
-"2012-01-31",
-"This element was removed because its children were deprecated after the disclosure was dimensionalized."
-],
-"RealEstateAndAccumulatedDepreciationAccumulatedDepreciation": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is RealEstateAccumulatedDepreciation."
-],
-"PrescriptionDrugSubsidyReceiptsYearFive": [
-"2012-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is PrescriptionDrugSubsidyReceiptsYearFive1."
-],
-"DebtInstrumentConvertibleInterestExpense": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is InterestExpenseDebt and members of LongtermDebtTypeAxis or ShortTermDebtTypeAxis."
-],
-"ReinsuranceEffectOnClaimsAndBenefitsIncurredNetAmountAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"DistributionMadeToMemberOrLimitedPartnerDeclarationDate": [
-"2012-01-31",
-"Element was deprecated because it has a dateStringItemType. If you have used this element in the past, consider replacing it with DistributionMadeToLimitedLiabilityCompanyLLCMemberDeclarationDate or DistributionMadeToLimitedPartnerDeclarationDate."
-],
-"DirectPremiumsEarnedOtherInsurance": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"DevelopmentStageEnterpriseAdditionalInformationForStatementOfCashFlowsAbstract": [
-"2012-01-31",
-"This element has been deprecated because it children were deprecated."
-],
-"CashForLeveragedBuyout": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"BusinessAcquisitionPurchasePriceAllocationWarrantyLiability": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"ScheduleOfClosedBlockSummarizedFinancialData": [
-"2013-01-31",
-"Element was deprecated."
-],
-"ComponentOfOtherOperatingCostAndExpenseNameDomain": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"AvailableForSaleSecuritiesGrossUnrealizedLosses1": [
-"2013-01-31",
-"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is AvailableForSaleSecuritiesGrossUnrealizedLoss."
-],
-"CededCreditRiskAmount": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ReinsuranceRecoverables with CededCreditRiskConcentratedCreditRiskMember."
-],
-"DefinedBenefitPlanTargetAllocationPercentageOfAssetsRealEstate": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are DefinedBenefitPlanTargetPlanAssetAllocations and members of DefinedBenefitPlanByPlanAssetCategoriesAxis."
-],
-"DepositLiabilitiesReclassifiedAsLoansReceivable": [
-"2012-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is DepositLiabilitiesReclassifiedAsLoansReceivable1."
-],
-"SubsidiaryOrEquityMethodInvesteePricePerShare": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is SaleOfStockPricePerShare."
-],
-"ConvertibleDebtFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
-],
-"PrescriptionDrugSubsidyReceiptsYearFour": [
-"2012-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is PrescriptionDrugSubsidyReceiptsYearFour1."
-],
-"CumulativeEffectAdjustmentGrossLosses": [
+"AccountingStandardsUpdate201003Member": [
 "2014-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"SegmentReportingInformationInvestments": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Possible replacement is corresponding primary line items and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
-],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsPeriodIncreaseDecreaseIntrinsicValue": [
-"2013-01-31",
-"Element was deprecated due to rationalization."
-],
-"FairValueEstimateNotPracticableRetainedInterest": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"EffectOfIllegalActsOnFinancialStatementsAmountMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"OutstandingStockAwardsMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is StockCompensationPlanMember."
-],
-"CompensatingBalancesCashAndCashEquivalentsMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is RestrictedCashAndCashEquivalentsCashAndCashEquivalentsMember."
-],
-"ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAmountAssumedFromOtherCompanies": [
-"2013-01-31",
-"Element was deprecated. Possible replacement is AssumedPremiumsEarned."
-],
-"ChangeInUnrealizedGainLossOnFairValueHedgingInstruments": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is ChangeInUnrealizedGainLossOnFairValueHedgingInstruments1."
-],
-"BusinessAcquisitionCostOfAcquiredEntityOtherNoncashConsideration": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AssetsHeldForSaleCurrent": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AssetsOfDisposalGroupIncludingDiscontinuedOperationCurrent."
-],
-"OtherThanTemporaryImpairmentLossesInvestmentsHeldtomaturitySecuritiesPortionRecognizedInEarningsNetQualitativeDisclosuresThirdPartyGuaranteesDescription": [
-"2013-01-31",
-"Element was deprecated."
-],
-"SourcesAndUsesOfCashForLeveragedBuyoutAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureIncomeTaxExpense1": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesIncomeTaxExpense."
-],
-"InternalCreditRatingMember": [
-"2013-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is InternalCreditAssessmentDomain."
-],
-"CapitalizedExploratoryWellCostsGreaterThanOrEqualToThreeYearsAndLessThanFourYearsNumberOfProjects": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProjectsThatHaveExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
-],
-"FederalHomeLoanBankAdvancesMaturitiesSummaryByInterestRateTypeUnderOneYear": [
-"2012-01-31",
-"Element was deprecated due to redundancy. Possible replacement is FederalHomeLoanBankAdvancesMaturitiesSummaryDueWithinOneYearOfBalanceSheetDate."
-],
-"BusinessCombinationContingentConsiderationArrangementsChangeInAmountOfContingentConsiderationAsset": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is BusinessCombinationContingentConsiderationArrangementsChangeInAmountOfContingentConsiderationAsset1."
-],
-"PremiumsWrittenNetLifeAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"PresentValueOfFutureInsuranceProfitsImpairmentWriteDown": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsImpairmentWriteDown1."
-],
-"NewContractDomain": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInRemainderOfFiscalYear": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalRemainderOfFiscalYear."
-],
-"PremiumIncomeSubjectToParticipationThroughReinsuranceValue": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AssumedPremiumsEarned."
-],
-"FairValueOffBalanceSheetRisksByFinancialInstrumentAxis": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is FinancialInstrumentAxis."
-],
-"AccountsPayableFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
-],
-"FinancialGuaranteeInsuranceContractsPremiumsReceivableNewBusinessWritten": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is FinancialGuaranteeInsuranceContractsPremiumReceivableNewBusinessWritten."
-],
-"LifeSettlementContractsInvestmentMethodDisclosureItemsLineItems": [
-"2012-01-31",
-"This element has been deprecated as the maturity schedule has been remodeled using line items instead of dimensions. If you have used this element in the past, use the line items found as children of ScheduleOfLifeSettlementContractsInvestmentMethodTextBlock."
-],
-"DefinedBenefitPlanTargetAllocationPercentageOfAssetsOtherRangeMaximum": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are DefinedBenefitPlanTargetPlanAssetAllocationsRangeMaximum and members of DefinedBenefitPlanByPlanAssetCategoriesAxis."
-],
-"NotesReceivableFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
-],
-"AssetsHeldForSalePropertyPlantAndEquipment": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacement are DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipmentNoncurrent, DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipmentCurrent or DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipment."
-],
-"LeveragedBuyoutConsiderationPaidForOutstandingShares": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CededCreditRiskPremiumsEarned": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"OtherExpenseCapitalizationToDeferredAcquisitionCostDAC": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is DeferredPolicyAcquisitionCostsAdditions."
-],
-"EarningsPerShareBasicMember": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"FederalHomeLoanBankBorrowingsFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
-],
-"FairValueAssetsMeasuredOnNonrecurringBasisValuationTechniquesInvestmentInPhysicalCommodities": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
-],
-"ReinsurerOtherAssetsAndLiabilitiesAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"AmortizationPeriodOfDeferredGainLossOnDiscontinuationOfFairValueHedge": [
-"2012-01-31",
-"Element was deprecated because it has a durationStringItemType. Possible replacement is AmortizationPeriodOfDeferredGainLossOnDiscontinuationOfFairValueHedge1."
-],
-"MalpracticeLossContingencyAccrualAdjustment": [
+"AccountingStandardsUpdate201008Member": [
 "2014-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"AmortizationOfAcquiredIntangibleAssets": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AmortizationOfIntangibleAssets."
-],
-"AvailableForSaleSecuritiesInUnrealizedLossPositionsQualitativeDisclosureNumberOfPositions": [
-"2013-01-31",
-"Element was deprecated because it was a decimalItemType attribute. Possible replacement is AvailableForSaleSecuritiesInUnrealizedLossPositionsQualitativeDisclosureNumberOfPositions1."
-],
-"ScheduleofLevelThreeDefinedBenefitPlanAssetsRollForwardTableTextBlock": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ScheduleOfEffectOfSignificantUnobservableInputsChangesInPlanAssetsTableTextBlock."
-],
-"DistributionMadeToMemberOrLimitedPartnerDeclarationDate1": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberDeclarationDate or DistributionMadeToLimitedPartnerDeclarationDate."
-],
-"CallOptionsWrittenMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CallOptionMember with ShortMember."
-],
-"SiteContingencyAccrualPresentValue": [
-"2013-01-31",
-"Element was deprecated due to redundancy.  Possible replacement is AccrualForEnvironmentalLossContingencies."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseReportedAndIncurredButNotReportedIBNRClaimsAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentLiabilitiesLongTermDebt": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DiscussionOfMethodOfMeasuringFairValueOfCreditRiskDerivatives": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are members of ValuationTechniqueAxis."
-],
-"ImpairmentInValueOfAssetMember": [
-"2012-01-31",
-"Element was deprecated because the dimension of the financial reporting concept was remodeled."
-],
-"FairValueAssetsMeasuredOnNonrecurringBasisValuationTechniquesGasPurchaseContract": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
-],
-"FinancingReceivableModificationsDeterminationOfAllowanceForCreditLosses": [
-"2012-01-31",
-"Element was deprecated. Possible replacements are FinancingReceivableModificationsDeterminationOfAllowanceForCreditLosses1 and FinancingReceivableModificationsSubsequentDefaultDeterminationOfAllowanceForCreditLosses."
-],
-"ValuationAllowanceForImpairmentOfRecognizedServicingAssetsByTypeOfFinancialInstrumentAxis": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is FinancialInstrumentAxis."
-],
-"AvailableforsaleSecuritiesContinuousUnrealizedLossPositionAggregateLosses1": [
-"2012-01-31",
-"Element was deprecated because it has an instant type period type attribute. Possible replacement is AvailableForSaleSecuritiesContinuousUnrealizedLossPositionAggregateLosses."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsCashAndCashEquivalents": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LiabilitiesOfAssetsHeldForSale": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilitiesOfDisposalGroupIncludingDiscontinuedOperation."
-],
-"ForeignReinsuranceTransactionsAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"AmountAvailableForDividendDistributionWithApprovalFromRegulatoryAgencies": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is StatutoryAccountingPracticesStatutoryAmountAvailableForDividendPaymentsWithRegulatoryApproval."
-],
-"FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisAssetAndLiabilityGainLossIncludedInOtherComprehensiveIncomeLoss": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisGainLossIncludedInOtherComprehensiveIncomeLoss."
-],
-"DefinedBenefitPlanWeightedAverageAssetAllocationsAbstract": [
-"2012-01-31",
-"This element was removed because the dimensionalizing of Defined Benefit Plan, Actual Plan Asset Allocations resulted in one child element to this [Abstract] element."
-],
-"RestructuringReserveSettledWithCash": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is PaymentsForRestructuring."
-],
-"DirectPremiumsLifeInsuranceInForce": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is LifeInsuranceInForceGross."
-],
-"FairValueAssetsMeasuredOnNonrecurringBasisValuationTechniquesCapitalLeasedAssetsNoncurrent": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
-],
-"OtherComprehensiveIncomeReclassificationOfDefinedBenefitPlanNetTransitionAssetObligationRecognizedInNetPeriodicBenefitCostBeforeTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetTransitionAssetObligationBeforeTax."
-],
-"OtherComprehensiveIncomeDefinedBenefitPlansAdjustmentBeforeTaxPeriodIncreaseDecrease": [
-"2012-01-31",
-"Element was deprecated because it has no balance attribute. Possible replacement is OtherComprehensiveIncomeLossPensionAndOtherPostretirementBenefitPlansAdjustmentBeforeTax."
-],
-"PartiesToContractualArrangementMember": [
-"2014-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacement is LeaseArrangementTypeDomain."
-],
-"AssumedPremiumsWrittenAccidentAndHealth": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"LineItemForCreditRiskDerivativesOnBalanceSheet": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are members of BalanceSheetLocationAxis."
-],
-"InvestmentsInAndAdvancesToAffiliatesBalanceContracts": [
-"2013-01-31",
-"Element was deprecated because it has a decimalItemType attribute. Possible replacement is InvestmentsInAndAdvancesToAffiliatesBalanceContracts1."
-],
-"BusinessAcquisitionCostOfAcquiredEntityAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"TradingSecuritiesFairValueDisclosure": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TradingSecurities."
-],
-"BusinessAcquisitionPurchasePriceAllocationGoodwillAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"DefinedBenefitPlanTargetAllocationPercentageOfAssetsEquitySecuritiesRangeMaximum": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are DefinedBenefitPlanTargetPlanAssetAllocationsRangeMaximum and members of DefinedBenefitPlanByPlanAssetCategoriesAxis."
-],
-"DirectPremiumsEarnedAccidentAndHealth": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"AllowanceForDoubtfulAccountsReceivableChargeOffs": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is AllowanceForDoubtfulAccountsReceivableWriteOffs."
-],
-"OtherComprehensiveIncomeLossReclassificationPensionAndOtherPostretirementBenefitPlansNetTransitionAssetObligationRecognizedInNetPeriodicBenefitCostTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetTransitionAssetObligationTax."
-],
-"WarrantsMember": [
-"2012-01-31",
-"Element was deprecated due to redundancy. Possible replacement is WarrantMember."
-],
-"InvestmentsFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
-],
-"BusinessAcquisitionContingentConsiderationAccountingTreatment": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AcquiredFiniteLivedIntangibleAssetsWeightedAveragePeriodPriorToRenewalOrExtension": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is AcquiredFiniteLivedIntangibleAssetWeightedAveragePeriodBeforeRenewalOrExtension."
-],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityConvertedInPeriod": [
-"2012-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardSharesIssuedInPeriod."
-],
-"FairValueAssetsMeasuredOnRecurringBasisDerivativeFinancialInstrumentsAssetsValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
-],
-"CancellationOfContractMember": [
-"2012-01-31",
-"Element was deprecated because the dimension of the financial reporting concept was remodeled."
-],
-"MaturityOfForeignCurrencyDerivatives": [
-"2012-01-31",
-"Element was deprecated because it has a durationStringItemType. Possible replacement is MaturityOfForeignCurrencyDerivatives1."
-],
-"NotionalAmountOfInterestRateFairValueHedgeDerivatives": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
-],
-"FiniteLivedComputerSoftwareGross": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is CapitalizedComputerSoftwareGross."
-],
-"ContingentlyIssuableSharesMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is StockCompensationPlanMember."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseGross": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilityForClaimsAndClaimsAdjustmentExpense."
-],
-"RealEstateOwnedValuationAllowanceProvision": [
-"2014-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is RealEstateOwnedValuationAllowanceProvision1."
-],
-"SubsequentEventProFormaImpact": [
-"2012-01-31",
-"Element was deprecated because the dimension of the financial reporting concept was remodeled. Possible replacements are ProformaMember and other elements/members as needed."
-],
-"MarketingAndAdvertisingExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is MarketingAndAdvertisingExpense."
-],
-"FairValueAssetsMeasuredOnRecurringBasisInvestmentsValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
-],
-"DistributionMadeToMemberOrLimitedPartnerDistributionsPaidPerUnit": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberDistributionsPaidPerUnit or DistributionMadeToLimitedPartnerDistributionsPaidPerUnit."
-],
-"SecuritiesSoldNotYetPurchasedFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
-],
-"RealEstateOwnedAmountOfLossAtAcquisition": [
-"2013-01-31",
-"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is RealEstateOwnedAmountOfLossAtAcquisition1."
-],
-"ReportableSegmentsMember": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Create member element to identify specific segment."
-],
-"EnvironmentalExitCostsReasonablyPossibleAdditionalLosses": [
-"2012-01-31",
-"Element was deprecated because it has a stringItemType. Possible replacement is EnvironmentalExitCostsReasonablyPossibleAdditionalLoss."
-],
-"MultiemployerPlanWithdrawalObligation": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is MultiemployerPlansWithdrawalObligation."
-],
-"SalesOfEquityToFinanceLeveragedBuyout": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"SegmentReportingMeasurement": [
-"2012-01-31",
-"Element was deprecated. Possible replacements are DescriptionOfBasisOfAccountingForTransactionsBetweenReportableSegments, DescriptionOfNatureOfDifferencesBetweenMeasurementsOfReportableSegmentsProfitsOrLossesAndEntitysProfitOrLossBeforeIncomeTaxExpenseOrIncomeAndDiscontinuedOperations, DescriptionOfNatureOfDifferencesBetweenMeasurementsOfReportableSegmentsAssetsAndEntitysAssets, DescriptionOfNatureOfChangesFromPriorPeriodsInMeasurementMethodsUsedToDetermineReportedSegmentProfitOrLossAndEffectOfThoseChangesOnMeasureOfSegmentProfitOrLoss, or DescriptionOfNatureAndEffectOfAnyAsymmetricalAllocationsToReportableSegments."
-],
-"AssetsHeldForSaleOtherNoncurrent": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DisposalGroupIncludingDiscontinuedOperationOtherNoncurrentAssets."
-],
-"SwaptionsMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is SwaptionMember."
-],
-"SecuritiesSoldNotYetPurchasedFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
-],
-"LongLivedAssetsHeldForSaleProceedsFromSale": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is ProceedsFromSaleOfPropertyPlantAndEquipment."
-],
-"BankruptcyOfCustomerMember": [
-"2012-01-31",
-"Element was deprecated because the dimension of the financial reporting concept was remodeled."
-],
-"PrescriptionDrugSubsidyReceiptsFiveFiscalYearsThereafter": [
-"2012-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is PrescriptionDrugSubsidyReceiptsafterYearFive."
-],
-"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareLiquidatingInvestmentRemainingPeriod": [
-"2012-01-31",
-"Element was deprecated because it has an instant period type. Possible replacement is FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareLiquidatingInvestmentRemainingPeriod1."
-],
-"IncomeTaxExaminationYearSUnderExamination": [
-"2012-01-31",
-"Element was deprecated because it has a stringItemType. Possible replacement is IncomeTaxExaminationYearUnderExamination."
-],
-"OtherComprehensiveIncomeAmortizationOfDefinedBenefitPlanNetPriorServiceCostRecognizedInNetPeriodicPensionCostNetOfTax": [
-"2012-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossAmortizationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetPriorServiceCostCreditNetOfTax."
-],
-"AssetOrLiabilityFromTransfersOfFinancialAssetsHavingNoReasonableEstimateOfFairValueDescriptionOfItems": [
-"2012-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"MultiemployerPlansCollectiveBargainingArrangementDescription": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is MultiemployerPlansCollectiveBargainingArrangementExpirationDateDescription."
-],
-"ReceivablesFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseIncurredClaims": [
-"2014-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseIncurredClaims1."
-],
-"AccountingStandardsUpdate200914Member": [
+"AccountingStandardsUpdate201017Member": [
 "2014-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
@@ -5535,491 +55,727 @@
 "2014-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"PresentValueOfFutureInsuranceProfitsUnrealizedInvestmentLosses": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsUnrealizedInvestmentLosses1."
+"AccountsNotesLoansAndFinancingReceivablesByProductAndServiceTypeAxis": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is ProductOrServiceAxis."
 ],
-"PurchasedPutOptionMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PutOptionMember with LongMember."
+"AccountsPayableFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
 ],
-"BusinessAcquisitionPurchasePriceAllocationUnmarketableSecurities": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+"AccountsPayableFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
 ],
-"CallOptionsPurchasedMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CallOptionMember with LongMember."
+"AccountsReceivableFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
 ],
-"MinorityInterestInNetIncomeLossLimitedPartnerships": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacement is NoncontrollingInterestInNetIncomeLossLimitedPartnershipsNonredeemable or NoncontrollingInterestInNetIncomeLossLimitedPartnershipsRedeemable."
+"AccountsReceivableFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
 ],
-"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsMaterialGainLossNotRecognizedInCurrentFiscalYear": [
+"AccretionExpenseMember": [
 "2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is AccretionExpenseIncludingAssetRetirementObligations."
+],
+"AccrualForEnvironmentalLossContingenciesCaption": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AccrualForEnvironmentalLossContingencies and members of BalanceSheetLocationAxis."
+],
+"AccrualForEnvironmentalLossContingenciesNet": [
+"2013-01-31",
+"Element was deprecated due to redundancy.  Possible replacement is AccrualForEnvironmentalLossContingencies."
+],
+"AccrualForEnvironmentalLossContingenciesNetAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"AccrualForEnvironmentalLossContingenciesNetRollingMaturityAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"AccruedLiabilitiesFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
+],
+"AccruedLiabilitiesFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
+],
+"AccumulatedDepreciationDepletionAndAmortizationWritedownOfPropertyPlantAndEquipment": [
+"2013-01-31",
+"Element was deprecated because it has credit balance attribute. Possible replacement is ImpairmentOfLongLivedAssetsHeldForUse."
+],
+"AcquiredFiniteLivedIntangibleAssetAmount": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is FinitelivedIntangibleAssetsAcquired1."
+],
+"AcquiredFiniteLivedIntangibleAssetWeightedAverageUsefulLife": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is AcquiredFiniteLivedIntangibleAssetsWeightedAverageUsefulLife."
+],
+"AcquiredFiniteLivedIntangibleAssetsByMajorClassAxis": [
+"2012-01-31",
+"Element was deprecated due to redundancy. Possible replacement is FiniteLivedIntangibleAssetsByMajorClassAxis."
+],
+"AcquiredFiniteLivedIntangibleAssetsWeightedAveragePeriodPriorToRenewalOrExtension": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is AcquiredFiniteLivedIntangibleAssetWeightedAveragePeriodBeforeRenewalOrExtension."
+],
+"AcquiredIndefiniteLivedIntangibleAssetAmount": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is IndefinitelivedIntangibleAssetsAcquired."
 ],
 "AcquisitionMember": [
 "2012-01-31",
 "Element was deprecated. Possible replacements are SeriesOfIndividuallyImmaterialBusinessAcquisitionsMember and other elements/members as needed."
 ],
-"OtherSellingAndMarketingExpenseMember": [
+"AdditionsToNoncurrentAssets": [
 "2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OtherSellingAndMarketingExpense."
+"Element was deprecated due to remodeling of Segment area. Possible replacement is corresponding primary line items and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
 ],
-"OtherComprehensiveIncomeReclassificationAdjustmentForSaleOfSecuritiesIncludedInNetIncomeTax": [
+"AdjustmentsToAdditionalPaidInCapitalReallocationOfMinorityInterest": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is NoncontrollingInterestIncreaseFromSubsidiaryEquityIssuance."
+],
+"AdjustmentsToAdditionalPaidInCapitalShareBasedCompensationNonvestedSharesRequisiteServicePeriodRecognition": [
+"2013-01-31",
+"Element was deprecated due to redundancy."
+],
+"AdministrativeFeesAmountPaid": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is PaymentForAdministrativeFees."
+],
+"AdvancePaymentsByBorrowersForTaxesAndInsuranceRelatedText": [
 "2012-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForSaleOfSecuritiesTax."
+"Element was deprecated due to redundancy. Possible replacement is AdvancePaymentsByBorrowersForTaxesAndInsuranceSummary."
 ],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsInventory": [
+"AdvertisingExpenseMember": [
 "2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is AdvertisingExpense."
 ],
-"IssuanceOfEquityMember": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"ProductionAndPropertyTaxExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ProductionTaxExpense or RealEstateTaxExpense."
-],
-"ProductRecallMember": [
-"2012-01-31",
-"Element was deprecated because the dimension of the financial reporting concept was remodeled."
-],
-"OtherComprehensiveIncomeLossReclassificationAdjustmentForSaleOfSecuritiesIncludedInNetIncomeTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForSaleOfSecuritiesTax."
-],
-"FederalHomeLoanBankAdvancesMaturitiesSummaryByInterestRateTypeAfterFiveYears": [
-"2012-01-31",
-"Element was deprecated due to redundancy. Possible replacement is FederalHomeLoanBankAdvancesMaturitiesSummaryDueAfterFiveYearsOfBalanceSheetDate."
-],
-"TradingSecuritiesRestrictedCurrent": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TradingSecuritiesRestricted."
-],
-"ImpairmentOrDisposalOfLongLivedIntangibleAssetsAssetsToBeSoldPolicy": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is ImpairmentOrDisposalOfLongLivedAssetsIncludingIntangibleAssetsPolicyPolicyTextBlock."
-],
-"OtherComprehensiveIncomeReclassificationOfDefinedBenefitPlantNetTransitionAssetObligationRecognizedInNetPeriodicBenefitCostTax": [
-"2012-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetTransitionAssetObligationTax."
-],
-"VariableInterestEntityQualitativeOrQuantitativeInformationDateInvolvementBegan": [
-"2012-01-31",
-"Element was deprecated because it has a dateStringItemType. Possible replacement is VariableInterestEntityQualitativeOrQuantitativeInformationDateInvolvementBegan1."
-],
-"RepurchaseAgreementCounterpartyAxis": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is CountepartyNameAxis."
-],
-"ForeignEarningsRepatriatedUnderAmericanJobsCreationActOf2004Description": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"NoninterestExpenseDirectorsFeesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpenseDirectorsFees."
-],
-"DescriptionOfMultiemployerPlan": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is MultiemployerPlansPlanBenefitsDescription."
-],
-"LiabilityForTitleClaimsAndClaimsAdjustmentExpenseAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"PublicUtilitiesPropertyPlantAndEquipmentTransmissionAndDistributionEstimatedUsefulLife": [
-"2013-01-31",
-"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentTransmissionAndDistributionUsefulLife."
-],
-"RetailLandSalesReceivablesRangeOfStatedInterestRates": [
-"2012-01-31",
-"Element was deprecated because it has an integerItemType and redundant. Possible replacements are RetailLandSalesReceivablesLowEndOfRangeOfStatedInterestRates or RetailLandSalesReceivablesHighEndOfRangeOfStatedInterestRates."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisGainLossIncludedInInvestmentIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisLiabilityGainLossIncludedInEarnings and members of IncomeStatementLocationAxis."
-],
-"FDICPremiumExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is FederalDepositInsuranceCorporationPremiumExpense."
-],
-"FederalFundsPurchasedFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
-],
-"SubsequentEventDateEvaluationEnded1": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"NotionalAmountOfNetInvestmentHedgingInstrumentsTotalAbstract": [
+"AgingOfCapitalizedExploratoryWellCostAbstract": [
 "2013-01-31",
 "Element was deprecated."
 ],
-"NotesReceivableFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
-],
-"TimeSharingTransactionsAdditionsToAllowanceForCurrentPeriodSalesOnReceivablesSoldWithRecourse": [
+"AgingOfCapitalizedExploratoryWellCostsNumberOfProjectsAbstract": [
 "2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is TimeSharingTransactionsAdditionsToAllowanceForCurrentPeriodSalesOnReceivablesSoldWithRecourse1."
+"Element was deprecated."
 ],
-"ImpairedFinancingReceivableWithNoRelatedAllowanceMember": [
-"2012-01-31",
-"Element was deprecated because the concept was modeled as primary concepts. Possible replacement is FinancingReceivableRecordedInvestmentClassOfFinancingReceivableDomain."
-],
-"ProceedsFromLoanOriginations": [
-"2012-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is ProceedsFromLoanOriginations1."
-],
-"DerivativeHigherRemainingMaturityRange": [
-"2012-01-31",
-"Element was deprecated because it has a durationStringItemType. Possible replacement is DerivativeHigherRemainingMaturityRange1."
-],
-"IncreaseDecreaseInDeferredRentReceivables": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is StraightLineRent."
-],
-"LiabilityForFuturePolicyBenefitsLiabilitiesAssumed": [
+"AllowanceForCostOfEquityFundsUsedDuringConstructionMember": [
 "2013-01-31",
-"Element was deprecated because it has credit balance attribute. Possible replacement is LiabilityForFuturePolicyBenefitsPeriodExpense."
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is PublicUtilitiesAllowanceForFundsUsedDuringConstructionCapitalizedInterest."
 ],
-"ClosedBlockAssetsAndLiabilitiesTableTextBlock": [
+"AllowanceForDoubtfulAccountsReceivableChargeOffs": [
 "2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ScheduleOfClosedBlockAssetsAndLiabilities."
+"Element was deprecated because it has a credit balance attribute. Possible replacement is AllowanceForDoubtfulAccountsReceivableWriteOffs."
 ],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsOtherShareIncreaseDecreaseInPeriodWeightedAverageExercisePrice": [
-"2012-01-31",
-"Element was deprecated because it has an instant period type. Possible replacement is ShareBasedCompensationArrangementsByShareBasedPaymentAwardOptionsOtherShareIncreaseDecreaseInPeriodWeightedAverageExercisePrice."
-],
-"NonmonetaryNotionalAmountOfPriceRiskFairValueHedgeDerivatives": [
+"AllowanceForFundsUsedDuringConstructionCapitalizedInterestMember": [
 "2013-01-31",
-"Element was deprecated because the intended concept conveyed is the underlying. Possible replacements are UnderlyingDerivativeAsset, UnderlyingDerivativeLiability, UnderlyingDerivative and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis and DerivativeInstrumentRiskAxis."
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is PublicUtilitiesAllowanceForFundsUsedDuringConstructionCapitalizedInterest."
 ],
-"MinimumNetCapitalRequiredForEntity": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is MinimumNetCapitalRequiredForEntity1."
-],
-"BusinessAcquisitionPurchasePriceAllocationNoncurrentLiabilitiesLongTermDebt": [
+"AllowanceForLoanAndLeaseLossesProvisionForLossGross": [
 "2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+"Element was deprecated because it is an invalid concept. Possible replacement is ProvisionForLoanAndLeaseLosses."
 ],
-"FinancingMember": [
-"2012-01-31",
-"Element was deprecated because the dimension of the financial reporting concept was remodeled."
-],
-"DistributionMadeToMemberOrLimitedPartnerShareDistributionDilutionPerShare": [
+"AllowanceForLoanAndLeaseLossesProvisionForLossNet": [
 "2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberUnitDistributionDilutionPerUnit or DistributionMadeToLimitedPartnerUnitDistributionDilutionPerUnit."
-],
-"FinancingReceivableAllowanceForCreditLossesRecoveries": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is FinancingReceivableAllowanceForCreditLossesRecovery."
-],
-"MaximumLengthOfTimeHedgedInCashFlowHedge": [
-"2012-01-31",
-"Element was deprecated because it has a durationStringItemType. Possible replacement is MaximumLengthOfTimeHedgedInCashFlowHedge1."
-],
-"FairValueLinesOfCreditValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
-],
-"MinorityInterestAndEarningsLossesEquityInvestmentsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is IncomeLossFromEquityMethodInvestments."
-],
-"DividendPaymentRestrictionsScheduleAmountsPaid": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is PaymentsOfDividends."
-],
-"BusinessAcquisitionPurchasePriceAllocationGoodwillExpectedTaxDeductibleAmountDescription": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FinancialGuaranteeInsuranceContractsPremiumReceivedOverContractPeriodPremiumReceivableWeightedAverageCollectionPeriod": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is FinancialGuaranteeInsuranceContractsPremiumReceivedOverContractPeriodPremiumReceivableWeightedAverageCollectionPeriod1."
-],
-"OtherComprehensiveIncomeMinimumPensionLiabilityNetAdjustmentBeforeTax": [
-"2012-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"OptionIndexedToIssuersEquitySettlementAlternativesAtFairValue": [
-"2012-01-31",
-"Element was deprecated because it has a stringItemType. Possible replacements are OptionIndexedToIssuersEquitySettlementAlternativesCashAtFairValue or OptionIndexedToIssuersEquitySettlementAlternativesSharesAtFairValue."
-],
-"FairValueLoansPayableValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
-],
-"LineOfCreditFacilityInitiationDate": [
-"2012-01-31",
-"Element was deprecated because it has a dateStringItemType. Possible replacement is LineOfCreditFacilityInitiationDate1."
-],
-"OtherComprehensiveIncomeLossAmortizationPensionAndOtherPostretirementBenefitPlansNetPriorServiceCostRecognizedInNetPeriodicBenefitCostBeforeTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossAmortizationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetPriorServiceCostCreditBeforeTax."
-],
-"LeveragedBuyoutPredecessorBasisAdjustment": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AvailableForSaleSecuritiesFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
-],
-"DebtInstrumentConvertibleConversionRatio": [
-"2013-01-31",
-"Element was deprecated because it has a decimalItemType attribute. Possible replacement is DebtInstrumentConvertibleConversionRatio1."
-],
-"AssumptionForFairValueOfInterestsContinuedToBeHeldByTransferorServicingAssetsOrLiabilitiesWeightedAverageLife": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is AssumptionForFairValueOfAssetsOrLiabilitiesThatRelateToTransferorsContinuingInvolvementWeightedAverageLife1."
-],
-"CommitmentsFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsAssetToBeDisposedOf": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"OtherComprehensiveIncomeReclassificationAdjustmentOnDerivativesIncludedInNetIncomeTax": [
-"2012-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIOnDerivativesTax."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisCommitmentsValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
-],
-"TargetOrTrackingStockClassDomain": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is ClassOfStockDomain."
-],
-"SuppliesAndPostageExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is SuppliesAndPostageExpense."
+"Element was deprecated because it is an invalid concept. Possible replacement is ProvisionForLoanAndLeaseLosses."
 ],
 "AllowanceForLoanAndLeaseLossesProvisionForLossNetAbstract": [
 "2013-01-31",
 "Element was deprecated."
 ],
-"PresentValueOfFutureInsuranceProfits": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ValueOfBusinessAcquiredVOBA."
-],
-"BusinessAcquisitionPurchasePriceAllocationMineralRights": [
+"AllowanceForLoanAndLeaseLossesRecoveriesOfBadDebts": [
 "2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is AllowanceForLoanAndLeaseLossRecoveryOfBadDebts."
+],
+"AllowanceForNotesReceivable": [
+"2012-01-31",
+"Element was deprecated due to redundancy. Possible replacement is FinancingReceivableAllowanceForCreditLosses."
+],
+"AlternativeInvestmentsFairValueDisclosureInputs": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
+],
+"AlternativeInvestmentsFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
+],
+"AlternativeNetCapitalRequirement": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is AlternativeNetCapitalRequirement1."
+],
+"AmortizationOfAcquiredIntangibleAssets": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is AmortizationOfIntangibleAssets."
+],
+"AmortizationOfDeferredSalesCommissionsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"AmortizationOfIntangiblesNonproductionMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is AmortizationOfIntangibleAssets."
+],
+"AmortizationOfRegulatoryAssetMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is AmortizationOfRegulatoryAsset."
+],
+"AmortizationPeriodOfDeferredGainLossOnDiscontinuationOfFairValueHedge": [
+"2012-01-31",
+"Element was deprecated because it has a durationStringItemType. Possible replacement is AmortizationPeriodOfDeferredGainLossOnDiscontinuationOfFairValueHedge1."
+],
+"AmortizationPeriodOfDeferredGainLossOnDiscontinuationOfForeignCurrencyFairValueHedge": [
+"2012-01-31",
+"Element was deprecated because it has a durationStringItemType. Possible replacement is AmortizationPeriodOfDeferredGainLossOnDiscontinuationOfForeignCurrencyFairValueHedge1."
+],
+"AmortizationPeriodOfDeferredGainLossOnDiscontinuationOfInterestRateFairValueHedge": [
+"2012-01-31",
+"Element was deprecated because it has a durationStringItemType. Possible replacement is AmortizationPeriodOfDeferredGainLossOnDiscontinuationOfInterestRateFairValueHedge1."
+],
+"AmortizationPeriodOfDeferredGainLossOnDiscontinuationOfPriceRiskFairValueHedge": [
+"2012-01-31",
+"Element was deprecated because it has a durationStringItemType. Possible replacement is AmortizationPeriodOfDeferredGainLossOnDiscontinuationOfPriceRiskFairValueHedge1."
+],
+"AmountAvailableForDividendDistributionWithApprovalFromRegulatoryAgencies": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is StatutoryAccountingPracticesStatutoryAmountAvailableForDividendPaymentsWithRegulatoryApproval."
+],
+"AmountAvailableForDividendDistributionWithoutPriorApprovalFromRegulatoryAgency": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is StatutoryAccountingPracticesStatutoryAmountAvailableForDividendPaymentsWithoutRegulatoryApproval."
+],
+"AmountOfRegulatoryAssistanceReceived": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is AmountOfRegulatoryAssistanceReceived1."
+],
+"AssetManagementFees": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacement is AssetManagementFees1 or InvestmentAdvisoryManagementAndAdministrativeFees."
+],
+"AssetManagementMember": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions."
+],
+"AssetOrLiabilityFromTransfersOfFinancialAssetsHavingNoReasonableEstimateOfFairValueAtCarryingValue": [
+"2012-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"FairValueAssetsMeasuredOnRecurringBasisServicingRightsValuationTechniques": [
+"AssetOrLiabilityFromTransfersOfFinancialAssetsHavingNoReasonableEstimateOfFairValueDescriptionOfItems": [
 "2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"PropertyPlantAndEquipmentUsefulLifeAverage": [
+"AssetOrLiabilityFromTransfersOfFinancialAssetsHavingNoReasonableEstimateOfFairValueNameDomain": [
 "2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is PropertyPlantAndEquipmentUsefulLife."
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"ReinsuranceLossOnUncollectibleAccountsInPeriodDescription": [
-"2013-01-31",
-"Element was deprecated due to remodeling of reinsurance topic area."
-],
-"PremiumsWrittenNetOtherInsuranceAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"FinancingAxis": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"CashFlowHedgeGainLossReclassifiedToInterestExpenseNetAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"DerivativeAverageRemainingMaturity": [
+"AssetOrLiabilityFromTransfersOfFinancialAssetsHavingNoReasonableEstimateOfFairValueReasonWhyNotEstimated": [
 "2012-01-31",
-"Element was deprecated because it has a durationStringItemType. Possible replacement is DerivativeAverageRemainingMaturity1."
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"DeferredIncomeTaxExpenseBenefitAbstract": [
+"AssetsDesignatedToClosedBlockOtherClosedBlockAssets": [
 "2013-01-31",
-"Element was deprecated."
+"Element was deprecated due to remodeling of topic area. Possible replacement is AssetsDesignatedToClosedBlockOtherClosedBlockAssets1."
 ],
-"MalpracticeLossContingencySettlementOfClaims": [
+"AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionGainLossOnDisposition": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionGainLossOnDisposition1."
+],
+"AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionIncomeStatementClassificationOfGainLossOnDisposal": [
 "2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is MalpracticeLossContingencyPeriodCost."
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionGainLossOnDisposition1 and members of IncomeStatementLocationAxis."
 ],
-"DerivativeFairValueGrossAmountNotOffsetAgainstCollateralNetAbstract": [
+"AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionSegmentClassification": [
 "2013-01-31",
-"Element was deprecated."
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionGainLossOnDisposition1 and members of StatementBusinessSegmentsAxis."
 ],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAdjustmentOfOpeningBalanceTable": [
+"AssetsHeldForSaleAtCarryingValue": [
 "2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is AssetsOfDisposalGroupIncludingDiscontinuedOperation."
+],
+"AssetsHeldForSaleAtCarryingValueAbstract": [
+"2014-01-31",
+"Element was deprecated."
+],
+"AssetsHeldForSaleCapitalLeasedAssetsNet": [
+"2014-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"AssetsHeldForSaleCurrent": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is AssetsOfDisposalGroupIncludingDiscontinuedOperationCurrent."
+],
+"AssetsHeldForSaleCurrentAbstract": [
+"2014-01-31",
+"Element was deprecated."
+],
+"AssetsHeldForSaleLongLived": [
+"2014-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DisposalGroupIncludingDiscontinuedOperationLongLivedAssetsNoncurrent, DisposalGroupIncludingDiscontinuedOperationLongLivedAssetsCurrent or DisposalGroupIncludingDiscontinuedOperationLongLivedAssets."
+],
+"AssetsHeldForSaleLongLivedAbstract": [
+"2014-01-31",
+"Element was deprecated."
+],
+"AssetsHeldForSaleOtherNoncurrent": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DisposalGroupIncludingDiscontinuedOperationOtherNoncurrentAssets."
+],
+"AssetsHeldForSalePropertyPlantAndEquipment": [
+"2014-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacement are DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipmentNoncurrent, DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipmentCurrent or DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipment."
+],
+"AssetsOfDisposalGroupIncludingDiscontinuedOperationNoncurrent": [
+"2014-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DisposalGroupIncludingDiscontinuedOperationLongLivedAssetsNoncurrent, DisposalGroupIncludingDiscontinuedOperationLongLivedAssetsCurrent or DisposalGroupIncludingDiscontinuedOperationLongLivedAssets."
+],
+"AssetsOrLiabilitiesFromTransfersOfFinancialAssetsHavingNoReasonableEstimateOfFairValueAxis": [
+"2012-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"AssetsOrLiabilitiesFromTransfersOfFinancialAssetsHavingNoReasonableEstimateOfFairValueLineItems": [
+"2012-01-31",
+"This element has been deprecated because the guidance from which this element is derived is no longer effective."
+],
+"AssetsOrLiabilitiesFromTransfersOfFinancialAssetsHavingNoReasonableEstimateOfFairValueTable": [
+"2012-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"AssumedPremiumsEarnedAccidentAndHealth": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"AssumedPremiumsEarnedFinancialGuaranteeInsuranceContracts": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"AssumedPremiumsEarnedLife": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"AssumedPremiumsEarnedOtherInsurance": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"AssumedPremiumsEarnedPropertyAndCasualty": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"AssumedPremiumsLifeInsuranceInForce": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is LifeInsuranceInForceAssumed."
+],
+"AssumedPremiumsWrittenAccidentAndHealth": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"AssumedPremiumsWrittenFinancialGuaranteeInsuranceContracts": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"AssumedPremiumsWrittenLife": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"AssumedPremiumsWrittenOtherInsurance": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"AssumedPremiumsWrittenPropertyAndCasualty": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"AssumptionForFairValueAsOfBalanceSheetDateOfInterestsContinuedToBeHeldByTransferorServicingAssetsOrLiabilitiesAxis": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is FinancialInstrumentAxis."
+],
+"AssumptionForFairValueOfInterestsContinuedToBeHeldByTransferorServicingAssetsOrLiabilitiesWeightedAverageLife": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is AssumptionForFairValueOfAssetsOrLiabilitiesThatRelateToTransferorsContinuingInvolvementWeightedAverageLife1."
+],
+"AssumptionForFairValueOnSecuritizationDateOfInterestsContinuedToBeHeldByTransferorServicingAssetsOrLiabilitiesAxis": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is FinancialInstrumentAxis."
+],
+"AssumptionForFairValueOnSecuritizationDateOfInterestsContinuedToBeHeldByTransferorServicingAssetsOrLiabilitiesWeightedAverageLife": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is FairValueAssumptionDateOfSecuritizationOrAssetBackedFinancingArrangementTransferorsContinuingInvolvementServicingAssetsOrLiabilitiesWeightedAverageLife."
+],
+"AuctionMarketPreferredSecuritiesStockSeriesRateSettingInterval": [
+"2012-01-31",
+"Element was deprecated because it has an integerItemType. Possible replacement is AuctionMarketPreferredSecuritiesStockSeriesRateSettingInterval1."
+],
+"AvailableForSaleSecuritiesDebtMaturitiesAmortizedCost": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is AvailableForSaleDebtSecuritiesAmortizedCostBasis."
+],
+"AvailableForSaleSecuritiesFairValueDisclosure": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is AvailableForSaleSecurities."
+],
+"AvailableForSaleSecuritiesFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
+],
+"AvailableForSaleSecuritiesFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
+],
+"AvailableForSaleSecuritiesGrossUnrealizedGainLoss": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is AvailableForSaleSecuritiesGrossUnrealizedGainLoss1."
+],
+"AvailableForSaleSecuritiesGrossUnrealizedLosses1": [
+"2013-01-31",
+"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is AvailableForSaleSecuritiesGrossUnrealizedLoss."
+],
+"AvailableForSaleSecuritiesInUnrealizedLossPositionsQualitativeDisclosureNumberOfPositions": [
+"2013-01-31",
+"Element was deprecated because it was a decimalItemType attribute. Possible replacement is AvailableForSaleSecuritiesInUnrealizedLossPositionsQualitativeDisclosureNumberOfPositions1."
+],
+"AvailableforsaleSecuritiesContinuousUnrealizedLossPosition12MonthsOrLongerAggregateLosses1": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is AvailableforsaleSecuritiesContinuousUnrealizedLossPosition12MonthsOrLongerAggregateLosses."
+],
+"AvailableforsaleSecuritiesContinuousUnrealizedLossPosition12MonthsOrLongerAggregateLosses2": [
+"2013-01-31",
+"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is AvailableForSaleSecuritiesContinuousUnrealizedLossPosition12MonthsOrLongerAggregateLosses."
+],
+"AvailableforsaleSecuritiesContinuousUnrealizedLossPositionAggregateLosses1": [
+"2012-01-31",
+"Element was deprecated because it has an instant type period type attribute. Possible replacement is AvailableForSaleSecuritiesContinuousUnrealizedLossPositionAggregateLosses."
+],
+"AvailableforsaleSecuritiesContinuousUnrealizedLossPositionAggregateLosses2": [
+"2013-01-31",
+"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is AvailableForSaleSecuritiesContinuousUnrealizedLossPositionAggregateLosses."
+],
+"AvailableforsaleSecuritiesContinuousUnrealizedLossPositionLessThan12MonthsAggregateLosses1": [
+"2012-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is AvailableForSaleSecuritiesContinuousUnrealizedLossPositionLessThan12MonthsAggregateLosses."
+],
+"AvailableforsaleSecuritiesContinuousUnrealizedLossPositionLessThan12MonthsAggregateLosses2": [
+"2013-01-31",
+"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is AvailableForSaleSecuritiesContinuousUnrealizedLossPositionLessThan12MonthsAggregateLosses."
+],
+"AvailableforsaleSecuritiesDebtMaturityDateRangeHigh": [
+"2012-01-31",
+"Element was deprecated because it has a durationStringItemType. Possible replacements are AvailableforsaleSecuritiesDebtMaturitiesDate and RangeAxis (MaximumMember)."
+],
+"AvailableforsaleSecuritiesDebtMaturityDateRangeLow": [
+"2012-01-31",
+"Element was deprecated because it has a durationStringItemType. Possible replacements are AvailableforsaleSecuritiesDebtMaturitiesDate and RangeAxis (MinimumMember)."
+],
+"AvailableforsaleSecuritiesGrossUnrealizedGain": [
+"2013-01-31",
+"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is AvailableForSaleSecuritiesGrossUnrealizedGains."
+],
+"AverageBalanceDuringPeriodOfLoansHeldForSaleOrSecuritization": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"AverageBalanceDuringPeriodOfLoansHeldInPortfolio": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"AverageBalanceDuringPeriodOfLoansHeldInPortfolioAbstract": [
+"2014-01-31",
+"Element was deprecated."
+],
+"AverageBalanceDuringPeriodOfLoansManagedAndSecuritized": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"AverageBalanceDuringPeriodOfLoansSecuritized": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"AverageRemainingMaturityOfForeignCurrencyDerivatives": [
+"2012-01-31",
+"Element was deprecated because it has a durationStringItemType. Possible replacement is AverageRemainingMaturityOfForeignCurrencyDerivatives1."
+],
+"AverageTermOfCreditRiskDerivatives": [
+"2012-01-31",
+"Element was deprecated because it has a durationStringItemType. Possible replacement is AverageTermOfCreditRiskDerivatives1."
+],
+"BadDebtReserveForTaxPurposesOfUSSavingsAndLoanAssociationsOrOtherQualifiedThriftLenderMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are BadDebtReserveForTaxPurposesOfQualifiedLender, DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferenceBadDebtReserveForTaxPurposesOfQualifiedLender, DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxableBadDebtReserveForTaxPurposesOfQualifiedLender, DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityBadDebtReserveForTaxPurposesOfQualifiedLender,  and DeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticableBadDebtReserveForTaxPurposesOfQualifiedLender."
+],
+"BalanceSheetLineItemAffectedByApplicationOfSFAS158Domain": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is BalanceSheetLocationDomain."
+],
+"BankruptcyDomain": [
+"2013-01-31",
 "Element was deprecated due to remodeling of topic area."
 ],
-"DeferredTaxLiabilityNotRecognizedCumulativeAmountOfTemporaryDifference": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are\nUndistributedEarningsOfForeignSubsidiaries, UndistributedEarningsOfDomesticSubsidiaries, BadDebtReserveForTaxPurposesOfQualifiedLender, and PolicyholdersSurplus."
-],
-"CashFlowHedgeLossReclassifiedToCostOfSales": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CostOfGoodsSold and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"PropertyPlantAndEquipmentUsefulLifeMinimum": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType and the financial reporting concept was modeled as a dimension. Possible replacements are PropertyPlantAndEquipmentUsefulLife and Range Axis (MinimumMember)."
-],
-"LossOnReceivablesMember": [
+"BankruptcyOfCustomerMember": [
 "2012-01-31",
 "Element was deprecated because the dimension of the financial reporting concept was remodeled."
-],
-"FairValueAssetsMeasuredOnNonrecurringBasisValuationTechniquesFiniteLivedIntangibleAssets": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
-],
-"DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipmentNet": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipmentNoncurrent, DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipmentCurrent or DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipment."
-],
-"BusinessAcquisitionPurchasePriceAllocationAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationEstimatedAmountAmortizedYearFour": [
-"2012-01-31",
-"Element was deprecated because it has a duration period type and a credit balance attribute. Possible replacement is IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationAmortizationExpenseYearFour."
 ],
 "BankruptcyOfPartyAxis": [
 "2013-01-31",
 "Element was deprecated due to remodeling of topic area."
 ],
-"BusinessAcquisitionPurchasePriceAllocationDeferredTaxLiabilitiesNoncurrent": [
+"BelowMarketLeasesMember": [
 "2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"PublicUtilitiesPropertyPlantAndEquipmentFuelEstimatedUsefulLife": [
-"2013-01-31",
-"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentFuelUsefulLife."
-],
-"RetrospectiveEffectOfChangeInAccountingPrincipleTabularPresentationByFinancialStatementLineItemAmountBeforeApplication": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are NewAccountingPronouncementsOrChangeInAccountingPrincipleTable. Line items that can be used instead of this element include, but are not limited to, IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest, ProfitLoss, EarningsPerShareBasic, and EarningsPerShareDiluted."
-],
-"ComponentOfOtherExpenseNonoperatingTable": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"CapitalizedExploratoryWellCostsThereafterNumberOfProjects": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProjectsThatHaveExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
-],
-"BusinessCombinationContingentConsiderationArrangementsAndIndemnificationAssetsAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"MultiemployerPlanSignificantChangesImpactingComparability": [
-"2012-01-31",
-"Element was deprecated. Possible replacements are MultiemployerPlansBusinessCombinationOrDivestitureDescription, MultiemployerPlansContributionRateIncreaseDecreaseDescription, and MultiemployerPlansEmployeesIncreaseDecreaseDescription."
-],
-"DateFounded": [
-"2012-01-31",
-"Element was deprecated because it has a dateStringItemType. Possible replacement is YearFounded."
+"Element was deprecated because it is an invalid concept. Possible replacements are elements under BelowMarketLeaseAbstract."
 ],
 "BoardMemberCompensationContractsMember": [
 "2013-01-31",
 "Element was deprecated due to remodeling of topic area."
 ],
-"ImpairedIntangibleAssetsByDescriptionAxis": [
-"2012-01-31",
-"Element was deprecated. Possible replacements are IndefiniteLivedIntangibleAssetsByMajorClassAxis and/or FiniteLivedIntangibleAssetsByMajorClassAxis."
-],
-"ReservesProportionalInterestOfNetProvedReserveQuantitiesOfProportionatelyConsolidatedInvestees": [
-"2012-01-31",
-"Element was deprecated because it has an integerItemType. Possible replacement is ReservesProportionalInterestOfNetProvedReserveQuantitiesOfProportionatelyConsolidatedInvestees1."
-],
-"EquityMethodInvestmentsFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisGainLossIncludedInOtherIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisLiabilityGainLossIncludedInEarnings and members of IncomeStatementLocationAxis."
-],
-"RestructuringAndRelatedCostExpectedCost": [
+"BorrowedFunds": [
 "2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is RestructuringAndRelatedCostExpectedCost1."
+"Element was deprecated due to redundancy. Possible replacement is DebtAndCapitalLeaseObligations."
 ],
-"DerecognizedAssetsSecuritizedOrAssetbackedFinancingArrangementAssetsAndAnyOtherFinancialAssetsManagedTogetherAverageBalanceDuringPeriod": [
+"BorrowingsToFinanceLeveragedBuyout": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BorrowingsToFinanceLeveragedBuyoutAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionContingentConsiderationAccountingTreatment": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionContingentConsiderationAtFairValue": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionContingentConsiderationAtFairValueCurrent": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionContingentConsiderationAtFairValueNoncurrent": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionContingentConsiderationPotentialCashPayment": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionContingentConsiderationSharesIssuable": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionContingentConsiderationSharesIssuableDescription": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionCostOfAcquiredEntityAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionCostOfAcquiredEntityCashPaid": [
+"2013-01-31",
+"Element was deprecated because it has debit balance and instant period type attributes. Possible replacement is PaymentsToAcquireBusinessesGross."
+],
+"BusinessAcquisitionCostOfAcquiredEntityDescriptionOfPurchasePriceComponents": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionCostOfAcquiredEntityEquityInterestsIssuedAndIssuable": [
+"2013-01-31",
+"Element deprecated because it has a debit balance attribute and instant period type. Possible replacement is BusinessCombinationConsiderationTransferredEquityInterestsIssuedAndIssuable."
+],
+"BusinessAcquisitionCostOfAcquiredEntityLiabilitiesIncurred": [
+"2013-01-31",
+"Element was deprecated because it has debit balance and instant period type attributes.  Possible replacement is BusinessCombinationConsiderationTransferredLiabilitiesIncurred."
+],
+"BusinessAcquisitionCostOfAcquiredEntityOtherNoncashConsideration": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionCostOfAcquiredEntityPlannedRestructuringActivities": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionCostOfAcquiredEntityPurchasePrice": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionCostOfAcquiredEntityPurchasePriceAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionDateOfAcquisitionAgreement": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. Possible replacement is BusinessAcquisitionDateOfAcquisitionAgreement1."
+],
+"BusinessAcquisitionEffectiveDateOfAcquisition": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. Possible replacement is BusinessAcquisitionEffectiveDateOfAcquisition1."
+],
+"BusinessAcquisitionEntityAcquiredAndReasonForAcquisitionAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionPeriodResultsIncludedInCombinedEntity": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. Possible replacement is BusinessAcquisitionPeriodResultsIncludedInCombinedEntity1."
+],
+"BusinessAcquisitionPreacquisitionContingencyAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionPreacquisitionContingencyAmount": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPreacquisitionContingencyDescription": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPreacquisitionContingencyDescriptionOfSettlement": [
 "2014-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"FairValueOptionQualitativeDisclosuresRelatedToElectionByEligibleItemOrGroupAxis": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is EligibleItemOrGroupForFairValueOptionAxis."
-],
-"DepositAssetsOrLiabilitiesPresentValueOfExpectedRecoveries": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacement is DepositAssetsPresentValueOfExpectedRecoveries."
-],
-"GainLossOnDerivativesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is UnrealizedGainLossOnDerivatives."
-],
-"PremiumsNetLifeInsuranceInForceAbstract": [
+"BusinessAcquisitionPreexistingRelationshipAbstract": [
 "2014-01-31",
 "Element was deprecated."
 ],
-"FederalFundsSoldAndSecuritiesBorrowedOrPurchasedUnderAgreementsToResellFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
+"BusinessAcquisitionPreexistingRelationshipDescription": [
+"2014-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is BusinessCombinationSeparatelyRecognizedTransactionsDescription and members of BusinessCombinationSeparatelyRecognizedTransactionsAxis."
 ],
-"FairValueAssetsMeasuredOnNonrecurringBasisValuationTechniquesInventoryNoncurrent": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+"BusinessAcquisitionPreexistingRelationshipGainLossRecognized": [
+"2014-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is BusinessCombinationSeparatelyRecognizedTransactionsNetGainsAndLosses and members of BusinessCombinationSeparatelyRecognizedTransactionsAxis."
 ],
-"ImpairedFinancingReceivableWithRelatedAllowanceMember": [
-"2012-01-31",
-"Element was deprecated because the concept was modeled as primary concepts. Possible replacement is FinancingReceivableRecordedInvestmentClassOfFinancingReceivableDomain."
+"BusinessAcquisitionPurchasePriceAllocationAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionPurchasePriceAllocationAmortizableIntangibleAssets": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationAssetsAcquired": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationAssetsAcquiredLiabilitiesAssumedNet": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationAssetsAcquiredLiabilitiesAssumedNetAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionPurchasePriceAllocationBuildings": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCapitalLeaseObligationAccrual": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
 "BusinessAcquisitionPurchasePriceAllocationCurrentAssets": [
 "2013-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"ScheduleOfIndefiniteLivedIntangibleAssetsByMajorClassTable": [
-"2012-01-31",
-"Element was deprecated because the dimension of the financial reporting concept was remodeled. Possible replacements are ScheduleOfIndefiniteLivedIntangibleAssetsTable and members of IndefiniteLivedIntangibleAssetsByMajorClassAxis."
-],
-"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareInvestmentRedemptionNoticePeriod": [
-"2014-01-31",
-"Element was deprecated because it has a stringItemType attribute. Possible replacement is FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareInvestmentRedemptionNoticePeriod1."
-],
-"FutureAmortizationExpenseYearThree": [
-"2012-01-31",
-"Element was deprecated because it has a duration period type. Possible replacement is FiniteLivedIntangibleAssetsAmortizationExpenseYearThree."
-],
-"DerivativeFinancialInstrumentsLiabilitiesFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
-],
-"WeightedAverageNumberOfSharesOutstandingBasicAndDiluted": [
-"2012-01-31",
-"Element was deprecated because it has an instant period type. Possible replacement is WeightedAverageNumberOfShareOutstandingBasicAndDiluted."
-],
-"DefinedBenefitPlanExpectedFutureBenefitPaymentsInFiveFiscalYearsThereafter": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is DefinedBenefitPlanExpectedFutureBenefitPaymentsFiveFiscalYearsThereafter."
-],
-"DepositAssetsOrLiabilitiesEffectOfChangeInInterestAccrualAssumptionOnExpectedRecoveryAmounts": [
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsAbstract": [
 "2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DepositAssetsEffectOfIncreaseDecreaseInInterestAccrualAssumptionOnExpectedRecoveryAmounts and DepositLiabilitiesEffectOfIncreaseDecreaseInInterestAccrualAssumptionOnExpectedRecoveryAmounts."
+"Element was deprecated."
 ],
-"CompensatedAbsencesLiabilityVacationAndHoliday": [
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsAssetHeldForSale": [
 "2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AccruedVacationCurrentAndNoncurrent."
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsAmountsRecognizedInBalanceSheet": [
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsAssetNotToBeUsed": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsAssetNotToBeUsedAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsAssetToBeDisposedOf": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsCashAndCashEquivalents": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsDescription": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsFinishedGoods": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsInventory": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsInventoryAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsMarketableSecurities": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsMerchandise": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsPrepaidExpenseAndOtherAssets": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsRawMaterials": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsReceivables": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsWorkInProgress": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentLiabilities": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentLiabilitiesAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentLiabilitiesAccountsPayable": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentLiabilitiesAccruedLiabilities": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentLiabilitiesDeferredRevenue": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentLiabilitiesDescription": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentLiabilitiesLongTermDebt": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentLiabilitiesOtherLiabilities": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationDeferredIncomeTaxesAssetLiabilityNet": [
 "2013-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
@@ -6027,267 +783,3807 @@
 "2013-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"FiniteLivedIntangibleAssetsUsefulLifeMinimum": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacements are FiniteLivedIntangibleAssetUsefulLife and RangeAxis (MinimumMember)."
-],
-"FairValueAssetsMeasuredOnRecurringBasisCashSurrenderValueValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
-],
-"DefinedContributionPensionMember": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is PensionPlansDefinedBenefitMember."
-],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardFairValueAssumptionsExpectedTermMaximum": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacements are SharebasedCompensationArrangementBySharebasedPaymentAwardFairValueAssumptionsExpectedTerm1 dimensionalized by RangeAxis (MaximumMember)."
-],
-"DividendIncomeMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is InvestmentIncomeDividend."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentLiabilitiesAccruedLiabilities": [
+"BusinessAcquisitionPurchasePriceAllocationDeferredTaxLiabilitiesNoncurrent": [
 "2013-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsWeightedAverageGrantDateFairValuePeriodIncreaseDecrease": [
-"2013-01-31",
-"Element was deprecated due to rationalization."
-],
-"CausesOfIncreaseDecreaseInLiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseCauseDomain": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is CatastrophicEventDomain."
-],
-"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationEstimatedAmountAmortizedYearFive": [
-"2012-01-31",
-"Element was deprecated because it has a duration period type and a credit balance attribute. Possible replacement is IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationAmortizationExpenseYearFive."
-],
-"PolicyholdersSurplusOfLifeInsuranceEntityMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are PolicyHoldersSurplus, DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferencePolicyHoldersSurplus, DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxablePolicyHoldersSurplus, DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityPolicyHoldersSurplus, and DeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticablePolicyHoldersSurplus."
-],
-"MaximumRemainingMaturityOfForeignCurrencyDerivatives": [
-"2012-01-31",
-"Element was deprecated because it has a durationStringItemType. Possible replacement is MaximumRemainingMaturityOfForeignCurrencyDerivatives1."
-],
-"ScheduleOfEffectsOfChangesInPrepaymentEstimateAssumptionsForCollateralizedMortgageObligationsAndRealEstateMortgageInvestmentConduitsTextBlock": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"LiabilityForFuturePolicyBenefitByProductSegmentAxis": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"ScheduleOfLifeSettlementContractsFairValueMethodTable": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept modeled as a dimension was replaced with line items. Possible replacement is line items within ScheduleOfLifeSettlementContractsFairValueMethodTextBlock."
-],
-"ProductionBarrelsOfOilEquivalents": [
-"2013-01-31",
-"Element was deprecated because it has a boeItemType attribute. Possible replacement is ProductionBarrelsOfOilEquivalents1."
-],
-"FairValueOffBalanceSheetRisksFinancialInstrumentsDomain": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is TransfersAndServicingOfFinancialInstrumentsTypesOfFinancialInstrumentsDomain."
-],
-"DerivativeDescriptionOfVariableRateBasis": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeVariableInterestRate and members of VariableRateAxis."
-],
-"AssumedPremiumsWrittenLife": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"FederalHomeLoanBankAdvancesMaturitiesSummary": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AdvancesFromFederalHomeLoanBanks."
-],
-"DefinedBenefitPlanAmortizationOfNetPriorServiceCostCredit": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is DefinedBenefitPlanFutureAmortizationOfPriorServiceCostCredit."
-],
-"AvailableforsaleSecuritiesGrossUnrealizedGain": [
-"2013-01-31",
-"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is AvailableForSaleSecuritiesGrossUnrealizedGains."
-],
-"OtherDeferredCostAmortizationExpense": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is OtherAmortizationOfDeferredCharges."
-],
-"ProvedDevelopedReservesBOE": [
-"2013-01-31",
-"Element was deprecated because it has a boeItemType attribute. Possible replacement is ProvedDevelopedReservesBOE1."
-],
-"PreOpeningCostsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is PreOpeningCosts."
-],
-"PublicUtilitiesPropertyPlantAndEquipmentDistributionEstimatedUsefulLife": [
-"2013-01-31",
-"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentDistributionUsefulLife."
-],
-"OtherComprehensiveIncomeAvailableForSaleSecuritiesAdjustmentNetOfTaxPeriodIncreaseDecrease": [
-"2012-01-31",
-"Element was deprecated because it has no balance attribute. Possible replacement is OtherComprehensiveIncomeLossAvailableForSaleSecuritiesAdjustmentNetOfTax."
-],
-"CapitalizedExploratoryWellCostsGreaterThanOrEqualToOneYearAndLessThanTwoYearsNumberOfProjects": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProjectsThatHaveExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
-],
-"RegulatoryCapitalDisclosuresForBusinessCombinations": [
+"BusinessAcquisitionPurchasePriceAllocationEquipment": [
 "2013-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"SegmentGeographicalGroupsOfCountriesGroupOneMember": [
-"2013-01-31",
-"Element deprecated because it was inappropriately modeled."
-],
-"FinancingReceivableInformationByCreditQualityIndicatorAxis": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are CreditRatingAMBestAxis, CreditRatingMoodysAxis, CreditRatingStandardPoorsAxis, CreditRatingFitchAxis, ExternalCreditRatingByGroupingAxis, InternalCreditAssessmentAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationPreacquisitionContingencyAccrual": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsTotalShareBasedLiabilitiesPaid": [
-"2014-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsShareBasedLiabilitiesPaid."
-],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsForfeituresInPeriodWeightedAverageExercisePrice": [
-"2012-01-31",
-"Element was deprecated because it has an instant period type. Possible replacement is ShareBasedCompensationArrangementsByShareBasedPaymentAwardOptionsForfeituresInPeriodWeightedAverageExercisePrice."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsAssetNotToBeUsed": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DebtInstrumentDateOfFirstRequiredPayment": [
-"2012-01-31",
-"Element was deprecated because it has a dateStringItemType. Possible replacement is DebtInstrumentDateOfFirstRequiredPayment1."
-],
-"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsPrepaidBenefitCost": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CededPremiumsWrittenPropertyAndCasualty": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"GainLossOnOilAndGasHedgingActivityMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"NetAmountAtRiskByProductAndGuaranteeWeightedAverageAttainedAge": [
-"2012-01-31",
-"Element was deprecated because it has an integerItemType. Possible replacement is NetAmountAtRiskByProductAndGuaranteeWeightedAverageAttainedAge1."
-],
-"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureIncomeTaxExpense": [
-"2013-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesIncomeTaxExpense."
-],
-"TemporaryEquityRedemptionValue": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TemporaryEquityCarryingAmountIncludingPortionAttributableToNoncontrollingInterests."
-],
-"IndefiniteLivedIntangibleAssetsBySegmentLineItems": [
-"2012-01-31",
-"This element has been deprecated."
-],
-"CreditRatingDomain": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are CreditRatingAMBestDomain, InternalCreditAssessmentDomain, ExternalCreditRatingFitchMember, ExternalCreditRatingStandardPoorsMember, ExternalCreditRatingMoodysMember, ExternalCreditRatingByGroupingDomain."
-],
-"SubsequentEventTermOfContract": [
-"2013-01-31",
-"Element deprecated because it was inappropriately modeled.  Possible replacements are LesseeLeasingArrangementsOperatingLeasesTermOfContract, LessorLeasingArrangementsOperatingLeasesTermOfContract or DerivativeTermOfContract."
-],
-"FairValueAdjustmentsOnHedgesAndDerivativeContractsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is UnrealizedGainLossOnDerivatives."
-],
-"OtherNoninterestExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OtherNoninterestExpense."
-],
-"ExpenseRelatedToDistributionOrServicingAndUnderwritingFeesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ExpenseRelatedtoDistributionorServicingandUnderwritingFees."
-],
-"FiniteLivedIntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationGross": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FiniteLivedIntangibleAssetsGross and members of FiniteLivedIntangibleAssetsByMajorClassAxis."
-],
-"RetrospectiveEffectOfChangeInAccountingPrincipleTabularPresentationByFinancialStatementLineItemAmountOfApplicationAdjustment": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept has been modeled as a dimension. Possible replacements are NewAccountingPronouncementsOrChangeInAccountingPrincipleTable. Line items that can be used instead of this element include, but are not limited to, IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest, ProfitLoss, EarningsPerShareBasic, and EarningsPerShareDiluted."
-],
-"NotionalAmountOfFairValueHedgeInstruments": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
-],
-"ForeignCurrencyContractsFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
-],
-"CashFlowHedgeGainReclassifiedToInvestmentIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is InvestmentIncomeNet and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"CostMethodInvestmentsFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationMethodology": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"ServicingAssetAtAmortizedValueAmortization": [
-"2012-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is ServicingAssetAtAmortizedValueAmortization1."
-],
-"AccountingStandardsUpdate201008Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AssumedPremiumsEarnedFinancialGuaranteeInsuranceContracts": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"OtherComprehensiveIncomeAmortizationOfDefinedBenefitPlanNetPriorServiceCostCreditRecognizedInNetPeriodicBenefitCostBeforeTax": [
-"2012-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossAmortizationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetPriorServiceCostCreditBeforeTax."
-],
-"SecuritiesLoanedOrSoldUnderAgreementsToRepurchaseFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
-],
-"AccrualForEnvironmentalLossContingenciesNetAbstract": [
+"BusinessAcquisitionPurchasePriceAllocationGoodwillAbstract": [
 "2013-01-31",
 "Element was deprecated."
-],
-"BorrowingsToFinanceLeveragedBuyout": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AssumedPremiumsLifeInsuranceInForce": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is LifeInsuranceInForceAssumed."
-],
-"GainLossOnSaleOfOilAndGasPropertiesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnSaleOfProperty."
-],
-"OtherComprehensiveIncomeForeignCurrencyTranslationReclassificationAdjustmentRealizedUponSaleOrLiquidationTax": [
-"2012-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossForeignCurrencyTransactionAndTranslationReclassificationAdjustmentFromAOCIRealizedUponSaleOrLiquidationTax."
 ],
 "BusinessAcquisitionPurchasePriceAllocationGoodwillAmount": [
 "2013-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
+"BusinessAcquisitionPurchasePriceAllocationGoodwillExpectedTaxDeductibleAmountDescription": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationIntangibleAssetsDescription": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationIntangibleAssetsNotAmortizable": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationIntangibleAssetsOtherThanGoodwill": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationLand": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationLiabilitiesAssumed": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationMethodology": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationMineralRights": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationNaturalResources": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationNegativeGoodwillDescription": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationNetTangibleAssets": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationNoncontrollingInterest": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationNoncurrentAssets": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationNoncurrentAssetsAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionPurchasePriceAllocationNoncurrentAssetsDescription": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationNoncurrentLiabilities": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationNoncurrentLiabilitiesAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionPurchasePriceAllocationNoncurrentLiabilitiesDescription": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationNoncurrentLiabilitiesLongTermDebt": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationNoncurrentLiabilitiesRestructuringCostAccrual": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationNotesPayableAndLongTermDebt": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationOtherAssets": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationOtherLiabilities": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationOtherNoncurrentAssets": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationOtherNoncurrentLiabilities": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationPlant": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationPreacquisitionContingencyAccrual": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationProjectedBenefitObligationAsset": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationProperty": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationPropertyPlantAndEquipment": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationPropertyPlantAndEquipmentAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionPurchasePriceAllocationRealEstateAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionPurchasePriceAllocationStatus": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationTangibleAssets": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationTangibleAssetsAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionPurchasePriceAllocationUnclassifiedAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionPurchasePriceAllocationUnfavorableContractAccrual": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationUnmarketableSecurities": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationWarrantyLiability": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessCombinationConsiderationTransferred": [
+"2013-01-31",
+"Element was deprecated because it has debit balance and instant period type attributes.  Possible replacement is BusinessCombinationConsiderationTransferred1."
+],
+"BusinessCombinationConsiderationTransferredIncludingEquityInterestInAcquireeHeldPriorToCombination": [
+"2013-01-31",
+"Element was deprecated because it has debit balance and instant period type attributes. Possible replacement is BusinessCombinationConsiderationTransferredIncludingEquityInterestInAcquireeHeldPriorToCombination1."
+],
+"BusinessCombinationConsiderationTransferredOther": [
+"2013-01-31",
+"Element was deprecated because it has debit balance and instant period type attributes.  Possible replacement is BusinessCombinationConsiderationTransferredOther1."
+],
+"BusinessCombinationContingentConsiderationArrangementsAndIndemnificationAssetsAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessCombinationContingentConsiderationArrangementsChangeInAmountOfContingentConsiderationAsset": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is BusinessCombinationContingentConsiderationArrangementsChangeInAmountOfContingentConsiderationAsset1."
+],
+"BusinessCombinationContingentConsiderationArrangementsChangeInAmountOfContingentConsiderationLiability": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is BusinessCombinationContingentConsiderationArrangementsChangeInAmountOfContingentConsiderationLiability1."
+],
+"BusinessCombinationGoodwillRecognizedSegmentAllocation": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is Goodwill and members of StatementBusinessSegmentsAxis."
+],
+"BusinessCombinationMember": [
+"2012-01-31",
+"Element was deprecated because the dimension of the financial reporting concept was remodeled. Possible replacements are BusinessAcquisitionAxis and other elements/members as needed."
+],
+"BusinessCombinationProFormaInformationAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessCombinationStepAcquisitionEquityInterestInAcquireeFairValue": [
+"2013-01-31",
+"Element was deprecated because it has debit balance and instant period type attributes. Possible replacement is BusinessCombinationStepAcquisitionEquityInterestInAcquireeFairValue1."
+],
+"BusinessDevelopmentMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is BusinessDevelopment."
+],
+"BusinessExitCosts": [
+"2013-01-31",
+"Element was deprecated. Possible replacement is BusinessExitCosts1."
+],
+"BusinessInterruptionInsuranceRecoveryStatementOfIncomeLineItems": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is GainOnBusinessInterruptionInsuranceRecovery and members of IncomeStatementLocationAxis."
+],
+"BusinessIntersegmentEliminationsMember": [
+"2012-01-31",
+"Element was deprecated due to redundancy. Possible replacement is IntersegmentEliminationMember."
+],
+"CallOptionsPurchasedMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CallOptionMember with LongMember."
+],
+"CallOptionsWrittenMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CallOptionMember with ShortMember."
+],
+"CancellationOfContractAxis": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"CancellationOfContractDomain": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"CancellationOfContractMember": [
+"2012-01-31",
+"Element was deprecated because the dimension of the financial reporting concept was remodeled."
+],
+"CapitalLeaseExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is CapitalLeasesIncomeStatementInterestExpense."
+],
+"CapitalLeasesFutureMinimumPaymentsNetMinimumPayments": [
+"2012-01-31",
+"Element was deprecated due to redundancy. Possible replacement is CapitalLeasesFutureMinimumPaymentsPresentValueOfNetMinimumPayments."
+],
+"CapitalizedExploratoryWellCostGreaterThanOrEqualToTwoYearsAndLessThanThreeYearsNumberOfProjects": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProjectsThatHaveExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
+],
+"CapitalizedExploratoryWellCostsGreaterThanOrEqualToFourYearsAndLessThanFiveYears": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CapitalizedExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
+],
+"CapitalizedExploratoryWellCostsGreaterThanOrEqualToFourYearsAndLessThanFiveYearsNumberOfProjects": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProjectsThatHaveExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
+],
+"CapitalizedExploratoryWellCostsGreaterThanOrEqualToOneYearAndLessThanTwoYears": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CapitalizedExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
+],
+"CapitalizedExploratoryWellCostsGreaterThanOrEqualToOneYearAndLessThanTwoYearsNumberOfProjects": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProjectsThatHaveExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
+],
+"CapitalizedExploratoryWellCostsGreaterThanOrEqualToThreeYearsAndLessThanFourYears": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CapitalizedExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
+],
+"CapitalizedExploratoryWellCostsGreaterThanOrEqualToThreeYearsAndLessThanFourYearsNumberOfProjects": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProjectsThatHaveExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
+],
+"CapitalizedExploratoryWellCostsGreaterThanOrEqualToTwoYearsAndLessThanThreeYears": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CapitalizedExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
+],
+"CapitalizedExploratoryWellCostsThereafter": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CapitalizedExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
+],
+"CapitalizedExploratoryWellCostsThereafterNumberOfProjects": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProjectsThatHaveExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
+],
+"CapitalizedInterestCostsMember": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"CashAndCashEquivalentsFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
+],
+"CashAndCashEquivalentsFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
+],
+"CashFlowHedgeGainLossReclassifiedToCostOfSalesNet": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CostOfGoodsSold and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeGainLossReclassifiedToCostOfSalesNetAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"CashFlowHedgeGainLossReclassifiedToEarningsNet": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProfitLoss and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeGainLossReclassifiedToEarningsNetAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"CashFlowHedgeGainLossReclassifiedToInterestExpenseNet": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is InterestExpense and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeGainLossReclassifiedToInterestExpenseNetAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"CashFlowHedgeGainLossReclassifiedToInvestmentIncomeNet": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is InvestmentIncomeNet and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeGainLossReclassifiedToInvestmentIncomeNetAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"CashFlowHedgeGainLossReclassifiedToOtherExpenseNet": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is OtherCostAndExpenseOperating and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeGainLossReclassifiedToOtherExpenseNetAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"CashFlowHedgeGainLossReclassifiedToOtherIncomeNet": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is OtherIncome and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeGainLossReclassifiedToOtherIncomeNetAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"CashFlowHedgeGainLossReclassifiedToRevenueNet": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is Revenues and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeGainLossReclassifiedToRevenueNetAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"CashFlowHedgeGainReclassifiedToCostOfSales": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CostOfGoodsSold and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeGainReclassifiedToEarnings": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProfitLoss and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeGainReclassifiedToInterestExpense": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is InterestExpense and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeGainReclassifiedToInvestmentIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is InvestmentIncomeNet and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeGainReclassifiedToOtherExpense": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is OtherCostAndExpenseOperating and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeGainReclassifiedToOtherIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is OtherIncome and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeGainReclassifiedToRevenue": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is Revenues and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeLossReclassifiedToCostOfSales": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CostOfGoodsSold and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeLossReclassifiedToEarnings": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProfitLoss and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeLossReclassifiedToInterestExpense": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is InterestExpense and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeLossReclassifiedToInvestmentIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is InvestmentIncomeNet and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeLossReclassifiedToOtherExpense": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is OtherCostAndExpenseOperating and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeLossReclassifiedToOtherIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is OtherIncome and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeLossReclassifiedToRevenue": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is Revenues and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashForLeveragedBuyout": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"CashForLeveragedBuyoutBySourceAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"CashOrStockAvailableForDistributionsDescription": [
+"2012-01-31",
+"Element was deprecated because it has a stringItemType. Possible replacements are CashAvailableForDistributions or StockOrUnitsAvailableForDistributions."
+],
+"CashSurrenderValueFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
+],
+"CashSurrenderValueFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
+],
+"CategoriesOfInvestmentsCostMethodInvestmentsMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is CostmethodInvestmentsMember."
+],
+"CategoriesOfInvestmentsMarketableSecuritiesAvailableForSaleSecuritiesMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is AvailableforsaleSecuritiesMember."
+],
+"CategoriesOfInvestmentsMarketableSecuritiesHeldToMaturitySecuritiesMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is HeldtomaturitySecuritiesMember."
+],
+"CategoriesOfInvestmentsMarketableSecuritiesTradingSecuritiesMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TradingAccountAssetsMember."
+],
+"CausesOfIncreaseDecreaseInLiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAmount": [
+"2014-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is SupplementalInformationForPropertyCasualtyInsuranceUnderwritersPriorYearClaimsAndClaimsAdjustmentExpense."
+],
+"CausesOfIncreaseDecreaseInLiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAxis": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LiabilityForCatastropheClaimsByCatastrophicEventAxis."
+],
+"CausesOfIncreaseDecreaseInLiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseCauseDomain": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is CatastrophicEventDomain."
+],
+"CededCreditRiskAmount": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ReinsuranceRecoverables with CededCreditRiskConcentratedCreditRiskMember."
+],
+"CededCreditRiskAmountAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"CededCreditRiskClaimsLossAdjustmentExpenseIncurred": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"CededCreditRiskClaimsReceivable": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"CededCreditRiskOtherRisks": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"CededCreditRiskPremiumsEarned": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"CededPremiumsEarnedAccidentAndHealth": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"CededPremiumsEarnedFinancialGuaranteeInsuranceContracts": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"CededPremiumsEarnedLife": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"CededPremiumsEarnedOtherInsurance": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"CededPremiumsEarnedPropertyAndCasualty": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"CededPremiumsLifeInsuranceInForce": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is LifeInsuranceInForceCeded."
+],
+"CededPremiumsWrittenAccidentAndHealth": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"CededPremiumsWrittenFinancialGuaranteeInsuranceContracts": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"CededPremiumsWrittenLife": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"CededPremiumsWrittenOtherInsurance": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"CededPremiumsWrittenPropertyAndCasualty": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"CertainLoansAcquiredInTransferAccountedForAsAvailableForSaleDebtSecuritiesOtherThanTemporaryImpairmentCharges": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsAvailableforsaleDebtSecuritiesOtherthanTemporaryImpairmentChargesCreditLoss."
+],
+"CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesOtherThanTemporaryImpairmentCharges": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesOtherthanTemporaryImpairmentChargesCreditLoss."
+],
+"CertainLoansAcquiredInTransferAccountedForAsHeldToMaturityDebtSecuritiesOtherThanTemporaryImpairmentCharges": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsHeldtomaturityDebtSecuritiesOtherthanTemporaryImpairmentChargesCreditLoss."
+],
+"CertainLoansAcquiredInTransferNotAccountedForAsDebtSecuritiesAllowanceForLoanLossesDecreases": [
+"2012-01-31",
+"Element was deprecated because it has an instant period type. Possible replacement is CertainLoansAcquiredInTransferNotAccountedForAsDebtSecuritiesAllowanceForLoanLossesDecreases1."
+],
+"CertainLoansAcquiredInTransferNotAccountedForAsDebtSecuritiesProvisionForLoanLosses": [
+"2012-01-31",
+"Element was deprecated because it has an instant period type. Possible replacement is CertainLoansAcquiredInTransferNotAccountedForAsDebtSecuritiesProvisionForLoanLosses1."
+],
+"ChangeInHistoricalClaimsRateExperienceMember": [
+"2014-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"ChangeInMeasurementDateSFAS158Abstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"ChangeInTaxStatusAxis": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"ChangeInTaxStatusDomain": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"ChangeInTaxStatusMember": [
+"2012-01-31",
+"Element was deprecated because the dimension of the financial reporting concept was remodeled."
+],
+"ChangeInUnrealizedGainLossOnFairValueHedgingInstruments": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is ChangeInUnrealizedGainLossOnFairValueHedgingInstruments1."
+],
+"ChangeInUnrealizedGainLossOnForeignCurrencyFairValueHedgingInstruments": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is ChangeInUnrealizedGainLossOnForeignCurrencyFairValueHedgingInstruments1."
+],
+"ChangeInUnrealizedGainLossOnHedgedItemInFairValueHedge": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is ChangeInUnrealizedGainLossOnHedgedItemInFairValueHedge1."
+],
+"ChangeInUnrealizedGainLossOnHedgedItemInForeignCurrencyFairValueHedge": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is ChangeInUnrealizedGainLossOnHedgedItemInForeignCurrencyFairValueHedge1."
+],
+"CharityCareOtherMeasurementBasisDescription": [
+"2012-01-31",
+"Element was deprecated due to redundancy. Possible replacement is CharityCareMethodology."
+],
+"ClassOfFinancingReceivableMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is FinancingReceivableRecordedInvestmentClassOfFinancingReceivableDomain."
+],
+"ClassOfTreasuryStockDomain": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is ClassOfStockDomain."
+],
+"ClassOfWarrantOrRightExercisePriceOfWarrantsOrRights": [
+"2014-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is ClassOfWarrantOrRightExercisePriceOfWarrantsOrRights1."
+],
+"ClearanceFeesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ClearanceFees."
+],
+"ClosedBlockAssetsAndLiabilities": [
+"2012-01-31",
+"Element was deprecated because it has a stringItemType. Possible replacement is ScheduleOfClosedBlockAssetsAndLiabilities."
+],
+"ClosedBlockAssetsAndLiabilitiesTableTextBlock": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ScheduleOfClosedBlockAssetsAndLiabilities."
+],
+"ClosedBlockDividendObligation": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ClosedBlockLiabilitiesPolicyholderDividendObligation."
+],
+"ClosedBlockOperationsChangeInPolicyholderDividendObligation": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ClosedBlockDividendObligationPeriodIncreaseDecrease."
+],
+"CollaborativeArrangementProductAggregatedDisclosureMember": [
+"2013-01-31",
+"Element was deprecated because of unnecessary level of disaggregation in a parent-child relationship."
+],
+"CollaborativeArrangementProductMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is CollaborativeArrangementProductAgreementMember."
+],
+"CollaborativeArrangementsAndNoncollaborativeArrangementTransactionsAxis": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TypeOfArrangementAxis."
+],
+"CollaborativeArrangementsAndNoncollaborativeArrangementTransactionsMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ArrangementsAndNonarrangementTransactionsMember."
+],
+"CollaborativeArrangementsCopromotionAgreementAggregatedDisclosureMember": [
+"2013-01-31",
+"Element was deprecated because of unnecessary level of disaggregation in a parent-child relationship."
+],
+"CollaborativeArrangementsCopromotionAgreementAgreementMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is CollaborativeArrangementCopromotionMember."
+],
+"CommercialLinesMember": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is PropertyAndCasualtyCommercialInsuranceProductLineMember."
+],
+"CommitmentsFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
+],
+"CommitmentsFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
+],
+"CommonStockIncludingAdditionalPaidInCapital": [
+"2013-01-31",
+"Element was deprecated due to ambiguous definition. Possible replacement is CommonStocksIncludingAdditionalPaidInCapital."
+],
+"CommonStockIncludingAdditionalPaidInCapitalNetOfDiscount": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is CommonStocksIncludingAdditionalPaidInCapitalNetOfDiscount."
+],
+"CommonStockholdersEquity": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is StockholdersEquity."
+],
+"CommunicationsAndDataProcessingMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is CommunicationsAndInformationTechnology."
+],
+"CommunicationsDataProcessingAndOccupancyMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is CommunicationsInformationTechnologyAndOccupancy."
+],
+"CompensatedAbsencesLiabilityVacationAndHoliday": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is AccruedVacationCurrentAndNoncurrent."
+],
+"CompensatingBalancesCashAndCashEquivalentsAxis": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is CashAndCashEquivalentsAxis."
+],
+"CompensatingBalancesCashAndCashEquivalentsMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is RestrictedCashAndCashEquivalentsCashAndCashEquivalentsMember."
+],
+"CompetitiveTransitionChargeMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is StrandedCostsMember."
+],
+"ComponentOfOtherExpenseNonoperatingAxis": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"ComponentOfOtherExpenseNonoperatingNameDomain": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"ComponentOfOtherExpenseNonoperatingTable": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"ComponentOfOtherIncomeNonoperatingAxis": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"ComponentOfOtherIncomeNonoperatingNameDomain": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"ComponentOfOtherIncomeNonoperatingTable": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"ComponentOfOtherOperatingCostAndExpenseGeneralAxis": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"ComponentOfOtherOperatingCostAndExpenseNameDomain": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"ComponentOfOtherOperatingCostAndExpenseTable": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"ConcentrationOfCededCreditRisk": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ConcentrationRiskCreditRiskReinsurance."
+],
+"ConcentrationRiskPercentage": [
+"2012-01-31",
+"This element has been deprecated as it has a period type of instant. If you have used it in the past, use ConcentrationRiskPercentage1."
+],
+"ConsumerCreditScoreMember": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is InternalCreditAssessmentDomain."
+],
+"ContingentlyIssuableSharesMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is StockCompensationPlanMember."
+],
+"ContractHolderReceivables": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is PremiumsReceivableGross."
+],
+"ContractsInForceSubjectToParticipationThroughReinsuranceValue": [
+"2013-01-31",
+"Element was deprecated."
+],
+"ContractsReceivable": [
+"2012-01-31",
+"Element was deprecated due to redundancy. Possible replacement is AccountsReceivableBilledForLongTermContractsOrPrograms."
+],
+"ContributionsFromNoncontrollingInterests": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ProceedsFromMinorityShareholders."
+],
+"ConvertibleDebtFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
+],
+"ConvertibleDebtFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
+],
+"CooperativeAdvertisingExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is CooperativeAdvertisingExpense."
+],
+"CorporateCreditQualityIndicatorMember": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is InternalCreditAssessmentDomain."
+],
+"CorporateEliminationMember": [
+"2012-01-31",
+"Element was deprecated due to redundancy. Possible replacement is IntersegmentEliminationMember."
+],
+"CostMethodInvestmentsAggregateCarryingAmount": [
+"2013-01-31",
+"Element deprecated due to redundancy. Possible replacement is CostMethodInvestments."
+],
+"CostMethodInvestmentsFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
+],
+"CostMethodInvestmentsFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
+],
+"CreditDerivativeCurrentFairValue": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is CreditRiskDerivativeLiabilitiesAtFairValue."
+],
+"CreditDerivativeOriginAndPurpose": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DiscussionOfObjectivesForUsingCreditRiskDerivativeInstruments."
+],
+"CreditDerivativeTerm": [
+"2013-01-31",
+"Element was deprecated because it is has a stringItemType attribute. Possible replacement is CreditDerivativeTerm1."
+],
+"CreditDerivativesByUnderlyingAssetClassAxis": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is UnderlyingAssetClassAxis."
+],
+"CreditRatingDomain": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are CreditRatingAMBestDomain, InternalCreditAssessmentDomain, ExternalCreditRatingFitchMember, ExternalCreditRatingStandardPoorsMember, ExternalCreditRatingMoodysMember, ExternalCreditRatingByGroupingDomain."
+],
+"CreditRiskDerivativesAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"CumulativeEffectAdjustmentAbstract": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"CumulativeEffectAdjustmentApplicationOfFairValueOptionGrossGains": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"CumulativeEffectAdjustmentApplicationOfFairValueOptionGrossGainsAbstract": [
+"2014-01-31",
+"Element was deprecated."
+],
+"CumulativeEffectAdjustmentApplicationOfFairValueOptionGrossLosses": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"CumulativeEffectAdjustmentApplicationOfFairValueOptionGrossLossesAbstract": [
+"2014-01-31",
+"Element was deprecated."
+],
+"CumulativeEffectAdjustmentApplicationOfFairValueOptionUnrealizedGainsRecognized": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"CumulativeEffectAdjustmentApplicationOfFairValueOptionUnrealizedGainsUnrecognized": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"CumulativeEffectAdjustmentApplicationOfFairValueOptionUnrealizedLossesRecognized": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"CumulativeEffectAdjustmentApplicationOfFairValueOptionUnrealizedLossesUnrecognized": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"CumulativeEffectAdjustmentBifurcationOfHybridsGrossGains": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"CumulativeEffectAdjustmentBifurcationOfHybridsGrossLosses": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"CumulativeEffectAdjustmentGrossGains": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"CumulativeEffectAdjustmentGrossLosses": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"CumulativeEffectOfChangeInAccountingPrincipleTabularPresentationByFinancialStatementLineItemAdjustmentAmount": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are NewAccountingPronouncementsOrChangeInAccountingPrincipleTable to model the financial reporting concept. Line items that can be used instead of this element include, but are not limited to, IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest, ProfitLoss, EarningsPerShareBasic, and EarningsPerShareDiluted."
+],
+"CumulativeEffectOfChangeInAccountingPrincipleTabularPresentationByFinancialStatementLineItemPreviouslyReportedAmount": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are NewAccountingPronouncementsOrChangeInAccountingPrincipleTable to model the financial reporting concept. Line items that can be used instead of this element include, but are not limited to, IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest, ProfitLoss, EarningsPerShareBasic, and EarningsPerShareDiluted."
+],
+"CumulativeEffectOfChangeInAccountingPrincipleTabularPresentationByFinancialStatementLineItemRestatedAmount": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are NewAccountingPronouncementsOrChangeInAccountingPrincipleTable to model the financial reporting concept. Line items that can be used instead of this element include, but are not limited to, IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest, ProfitLoss, EarningsPerShareBasic, and EarningsPerShareDiluted."
+],
+"CumulativeEffectOfChangeInAccountingPrincipleTabularPresentationByFinancialStatementLineItemRestatedAmountAbstract": [
+"2012-01-31",
+"This element was deprecated because the children of this abstract were deprecated."
+],
+"CumulativeEffectOnRetainedEarningsBeforeTax": [
+"2012-01-31",
+"Element was deprecated because it has an instant period type. Possible replacement is CumulativeEffectOnRetainedEarningsBeforeTax1."
+],
+"CumulativeEffectOnRetainedEarningsNetOfTax": [
+"2012-01-31",
+"Element was deprecated because it has an instant period type. Possible replacement is CumulativeEffectOnRetainedEarningsNetOfTax1."
+],
+"CumulativeEffectOnRetainedEarningsTax": [
+"2012-01-31",
+"Element was deprecated because it has an instant period type. Possible replacement is CumulativeEffectOnRetainedEarningsTax1."
+],
+"CurrentIncomeTaxExpenseBenefitAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"DateFounded": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. Possible replacement is YearFounded."
+],
+"DebtInstrumentBasisSpreadOnVariableRate": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is DebtInstrumentBasisSpreadOnVariableRate1."
+],
+"DebtInstrumentCollateralFees": [
+"2012-01-31",
+"Element was deprecated because it has a stringItemType. Possible replacement is DebtInstrumentCollateralFee."
+],
+"DebtInstrumentCommitteeForUniformSecuritiesIdentificationProceduresCUSIP": [
+"2013-01-31",
+"Element was deprecated because it is has a stringItemType attribute. Possible replacement is CommitteeForUniformSecuritiesIdentificationProceduresCUSIP."
+],
+"DebtInstrumentConvertibleConversionRatio": [
+"2013-01-31",
+"Element was deprecated because it has a decimalItemType attribute. Possible replacement is DebtInstrumentConvertibleConversionRatio1."
+],
+"DebtInstrumentConvertibleEarliestDate": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. Possible replacement is DebtInstrumentConvertibleEarliestDate1."
+],
+"DebtInstrumentConvertibleEffectiveInterestRate": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DebtInstrumentInterestRateEffectivePercentage, DebtInstrumentInterestRateEffectivePercentageRateRangeMinimum, DebtInstrumentInterestRateEffectivePercentageRateRangeMaximum and members of LongtermDebtTypeAxis or ShortTermDebtTypeAxis."
+],
+"DebtInstrumentConvertibleInterestExpense": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is InterestExpenseDebt and members of LongtermDebtTypeAxis or ShortTermDebtTypeAxis."
+],
+"DebtInstrumentConvertibleLatestDate": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. Possible replacement is DebtInstrumentConvertibleLatestDate1."
+],
+"DebtInstrumentConvertibleRemainingDiscountAmortizationPeriod": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is DebtInstrumentConvertibleRemainingDiscountAmortizationPeriod1."
+],
+"DebtInstrumentDateOfFirstRequiredPayment": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. Possible replacement is DebtInstrumentDateOfFirstRequiredPayment1."
+],
+"DebtInstrumentDecreaseRepayments": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replace is RepaymentsOfDebt."
+],
+"DebtInstrumentFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
+],
+"DebtInstrumentFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
+],
+"DebtInstrumentIncreaseAdditionalBorrowings": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute.  Possible replacement is ProceedsFromIssuanceOfDebt."
+],
+"DebtInstrumentInterestRateAtPeriodEnd": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DebtInstrumentInterestRateEffectivePercentage."
+],
+"DebtInstrumentInterestRateIncrease": [
+"2013-01-31",
+"Element was deprecated because it has a pureItemType attribute. Possible replacement is DebtInstrumentInterestRateIncreaseDecrease."
+],
+"DebtInstrumentIssuanceDate": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. Possible replacement is DebtInstrumentIssuanceDate1."
+],
+"DebtInstrumentMaturityDateRangeEnd": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. Possible replacement is DebtInstrumentMaturityDateRangeEnd1."
+],
+"DebtInstrumentMaturityDateRangeStart": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. Possible replacement is DebtInstrumentMaturityDateRangeStart1."
+],
+"DebtInstrumentOfferingDate": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. Possible replacement is DebtInstrumentOfferingDate1."
+],
+"DebtInstrumentSinkingFundAmount": [
+"2012-01-31",
+"Element was deprecated. Possible replacements are DebtInstrumentSinkingFundPayment or DebtInstrumentCumulativeSinkingFundPayments."
+],
+"DebtorReorganizationItemsGainLossOnAssetSalesNet": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is DebtorReorganizationItemsGainLossOnAssetSalesNet1."
+],
+"DebtorReorganizationItemsGainLossOnSettlementOfOtherClaimsNet": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is DebtorReorganizationItemsGainLossOnSettlementOfOtherClaimsNet1."
+],
+"DebtorReorganizationItemsInterestIncomeOnAccumulatedCash": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is DebtorReorganizationItemsInterestIncomeOnAccumulatedCash1."
+],
+"DebtorReorganizationItemsNetGainLossOnRejectionOfLeasesAndOtherExecutoryContracts": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is DebtorReorganizationItemsNetGainLossOnRejectionOfLeasesAndOtherExecutoryContracts1."
+],
+"DeferredCompensationArrangementWithIndividualCashAwardsGrantedAmount": [
+"2013-01-31",
+"Element was deprecated because it has debit balance and duration period type attributes. Possible replacement is DeferredCompensationArrangementWithIndividualCashAwardGrantedAmount."
+],
+"DeferredCompensationArrangementWithIndividualExcludingShareBasedPaymentsAndPostretirementBenefitsByTitleOfIndividualAxis": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is TitleofIndividualAxis."
+],
+"DeferredCompensationArrangementWithIndividualMaximumContractualTerm": [
+"2014-01-31",
+"Element was deprecated because it has a stringItemType attribute. Possible replacement is DeferredCompensationArrangementWithIndividualMaximumContractualTerm1."
+],
+"DeferredCompensationArrangementWithIndividualPostretirementBenefitsByTitleOfIndividualAxis": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is TitleofIndividualAxis."
+],
+"DeferredCompensationArrangementWithIndividualRequisiteServicePeriod": [
+"2014-01-31",
+"Element was deprecated because it has a stringItemType attribute. Possible replacement is DeferredCompensationArrangementWithIndividualRequisiteServicePeriod1."
+],
+"DeferredCompensationArrangementWithIndividualShareBasedPaymentsByTitleOfIndividualAxis": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is TitleofIndividualAxis."
+],
+"DeferredGainOnEarlyExtinguishmentOfDebtAmountMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DeferredLossOnEarlyExtinguishmentOfDebtMember."
+],
+"DeferredIncomeTaxExpenseBenefitAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"DeferredPolicyAcquisitionCostsAndPresentValueOfFutureProfits": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DeferredPolicyAcquisitionCostsAndValueOfBusinessAcquired."
+],
+"DeferredPolicyAcquisitionCostsAndPresentValueOfFutureProfitsAmortization": [
+"2012-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is DeferredPolicyAcquisitionCostsAndPresentValueOfFutureProfitsAmortization1."
+],
+"DeferredPolicyAcquisitionCostsAndPresentValueOfFutureProfitsDisclosure": [
+"2012-01-31",
+"Element was deprecated. Possible replacements are TypeOfDeferredPolicyAcquisitionCosts or NatureOfDeferredPolicyAcquisitionCosts."
+],
+"DeferredPolicyAcquisitionCostsNet": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DeferredPolicyAcquisitionCosts."
+],
+"DeferredPolicyAcquisitionCostsTextBlock": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is DeferredPolicyAcquisitionCostsTextBlock1 or CapitalizationOfDeferredPolicyAcquisitionCostsPolicy."
+],
+"DeferredTaxLiabilitiesPrepaidPensionCosts": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiability": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are\nDeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityUndistributedEarningsOfForeignSubsidiaries, DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityUndistributedEarningsOfDomesticSubsidiaries, DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityBadDebtReserveForTaxPurposesOfQualifiedLender, and DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityPolicyholdersSurplus."
+],
+"DeferredTaxLiabilityNotRecognizedAxis": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"DeferredTaxLiabilityNotRecognizedCumulativeAmountOfTemporaryDifference": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are\nUndistributedEarningsOfForeignSubsidiaries, UndistributedEarningsOfDomesticSubsidiaries, BadDebtReserveForTaxPurposesOfQualifiedLender, and PolicyholdersSurplus."
+],
+"DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifference": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferenceUndistributedEarningsOfForeignSubsidiaries, DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferenceUndistributedEarningsOfDomesticSubsidiaries, DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferenceBadDebtReserveForTaxPurposesOfQualifiedLender, and DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferencePolicyholdersSurplus."
+],
+"DeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticable": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are:\nDeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticableUndistributedEarningsOfForeignSubsidiaries\nDeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticableUndistributedEarningsOfDomesticSubsidiaries\nDeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticableBadDebtReserveForTaxPurposesOfQualifiedLender\nDeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticablePolicyholdersSurplus."
+],
+"DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxable": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxableUndistributedEarningsOfForeignSubsidiaries, DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxableUndistributedEarningsOfDomesticSubsidiaries, DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxableBadDebtReserveForTaxPurposesOfQualifiedLender,  and DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxablePolicyholdersSurplus."
+],
+"DeferredTaxLiabilityNotRecognizedLineItems": [
+"2013-01-31",
+"Element was deprecated."
+],
+"DeferredTaxLiabilityNotRecognizedNameOfTemporaryDifferenceDomain": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept remodeled as primary concepts."
+],
+"DeferredTaxLiabilityNotRecognizedTable": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"DefinedBenefitPensionMember": [
+"2012-01-31",
+"Element was deprecated due to redundancy. Possible replacement is PensionPlansDefinedBenefitMember."
+],
+"DefinedBenefitPlanAccumulatedOtherComprehensiveIncomeLossAfterTax": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is AccumulatedOtherComprehensiveIncomeLossDefinedBenefitPensionAndOtherPostretirementPlansNetOfTax."
+],
+"DefinedBenefitPlanActuarialNetGainsLosses": [
+"2012-01-31",
+"Element deprecated because it has a debit balance attribute. Possible replacement is DefinedBenefitPlanActuarialGainLoss."
+],
+"DefinedBenefitPlanAmortizationOfNetGainsLosses": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is DefinedBenefitPlanFutureAmortizationOfGainLoss."
+],
+"DefinedBenefitPlanAmortizationOfNetPriorServiceCostCredit": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is DefinedBenefitPlanFutureAmortizationOfPriorServiceCostCredit."
+],
+"DefinedBenefitPlanAmountsRecognizedInOtherComprehensiveIncomeNetGainLossBeforeTax": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is DefinedBenefitPlanAmountsRecognizedInOtherComprehensiveIncomeLossNetGainLossBeforeTax."
+],
+"DefinedBenefitPlanAmountsThatWillBeAmortizedFromAccumulatedOtherComprehensiveIncomeLossInNextFiscalYear": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is DefinedBenefitPlanAmountToBeAmortizedFromAccumulatedOtherComprehensiveIncomeLossNextFiscalYear."
+],
+"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsAccruedBenefitLiability": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsAccumulatedOtherComprehensiveIncome": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsAmountsRecognizedInBalanceSheet": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsAmountsRecognizedInBalanceSheetAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsIntangibleAsset": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsMaterialGainLossNotRecognizedInCurrentFiscalYear": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsMinimumPensionLiabilityAdjustment": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsNetAmountRecognized": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsPrepaidBenefitCost": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DefinedBenefitPlanDebtSecurities": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacement is DefinedBenefitPlanWeightedAverageAssetAllocations."
+],
+"DefinedBenefitPlanEffectOfOnePercentagePointDecreaseOnAccumulatedPostretirementBenefitObligation": [
+"2012-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is DefinedBenefitPlanEffectOfOnePercentagePointDecreaseOnAccumulatedPostretirementBenefitObligation1."
+],
+"DefinedBenefitPlanEffectOfOnePercentagePointDecreaseOnServiceAndInterestCostComponents": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is DefinedBenefitPlanEffectOfOnePercentagePointDecreaseOnServiceAndInterestCostComponents1."
+],
+"DefinedBenefitPlanEquitySecurities": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacement is DefinedBenefitPlanWeightedAverageAssetAllocations."
+],
+"DefinedBenefitPlanEstimatedFutureBenefitPaymentsDescription": [
+"2012-01-31",
+"Element was deprecated because it has a stringItemType. Possible replacement is ScheduleOfExpectedBenefitPaymentsTableTextBlock."
+],
+"DefinedBenefitPlanEstimatedFutureEmployerContributionsInCurrentFiscalYear": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is DefinedBenefitPlansEstimatedFutureEmployerContributionsInCurrentFiscalYear."
+],
+"DefinedBenefitPlanEstimatedFutureEmployerContributionsInNextFiscalYear": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is DefinedBenefitPlansEstimatedFutureEmployerContributionsInNextFiscalYear."
+],
+"DefinedBenefitPlanExpectedFutureBenefitPaymentsInFiveFiscalYearsThereafter": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is DefinedBenefitPlanExpectedFutureBenefitPaymentsFiveFiscalYearsThereafter."
+],
+"DefinedBenefitPlanExpectedFutureBenefitPaymentsInYearFive": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is DefinedBenefitPlanExpectedFutureBenefitPaymentsYearFive."
+],
+"DefinedBenefitPlanExpectedFutureBenefitPaymentsInYearFour": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is DefinedBenefitPlanExpectedFutureBenefitPaymentsYearFour."
+],
+"DefinedBenefitPlanExpectedFutureBenefitPaymentsInYearOne": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is DefinedBenefitPlanExpectedFutureBenefitPaymentsNextTwelveMonths."
+],
+"DefinedBenefitPlanExpectedFutureBenefitPaymentsInYearThree": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is DefinedBenefitPlanExpectedFutureBenefitPaymentsYearThree."
+],
+"DefinedBenefitPlanExpectedFutureBenefitPaymentsInYearTwo": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is DefinedBenefitPlanExpectedFutureBenefitPaymentsYearTwo."
+],
+"DefinedBenefitPlanFairValueOfPlanAssetsByMeasurementAxis": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is FairValueByFairValueHierarchyLevelAxis."
+],
+"DefinedBenefitPlanOtherPlanAssets": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are DefinedBenefitPlanWeightedAverageAssetAllocations and members of DefinedBenefitPlanByPlanAssetCategoriesAxis."
+],
+"DefinedBenefitPlanRealEstate": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are DefinedBenefitPlanWeightedAverageAssetAllocations and members of DefinedBenefitPlanByPlanAssetCategoriesAxis."
+],
+"DefinedBenefitPlanRecognizedNetGainLossDueToSettlements": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is DefinedBenefitPlanRecognizedNetGainLossDueToSettlements1."
+],
+"DefinedBenefitPlanRecognizedNetGainLossDueToSettlementsAndCurtailments": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is DefinedBenefitPlanRecognizedNetGainLossDueToSettlementsAndCurtailments1."
+],
+"DefinedBenefitPlanTargetAllocationPercentageOfAssetsDebtSecurities": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are DefinedBenefitPlanTargetPlanAssetAllocations and members of DefinedBenefitPlanByPlanAssetCategoriesAxis."
+],
+"DefinedBenefitPlanTargetAllocationPercentageOfAssetsDebtSecuritiesRangeMaximum": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are DefinedBenefitPlanTargetPlanAssetAllocationsRangeMaximum and members of DefinedBenefitPlanByPlanAssetCategoriesAxis."
+],
+"DefinedBenefitPlanTargetAllocationPercentageOfAssetsDebtSecuritiesRangeMinimum": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are DefinedBenefitPlanTargetPlanAssetAllocationsRangeMinimum and members of DefinedBenefitPlanByPlanAssetCategoriesAxis."
+],
+"DefinedBenefitPlanTargetAllocationPercentageOfAssetsEquitySecurities": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are DefinedBenefitPlanTargetPlanAssetAllocations and members of DefinedBenefitPlanByPlanAssetCategoriesAxis."
+],
+"DefinedBenefitPlanTargetAllocationPercentageOfAssetsEquitySecuritiesRangeMaximum": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are DefinedBenefitPlanTargetPlanAssetAllocationsRangeMaximum and members of DefinedBenefitPlanByPlanAssetCategoriesAxis."
+],
+"DefinedBenefitPlanTargetAllocationPercentageOfAssetsEquitySecuritiesRangeMinimum": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are DefinedBenefitPlanTargetPlanAssetAllocationsRangeMaximum and members of DefinedBenefitPlanByPlanAssetCategoriesAxis."
+],
+"DefinedBenefitPlanTargetAllocationPercentageOfAssetsOther": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are DefinedBenefitPlanTargetPlanAssetAllocations and members of DefinedBenefitPlanByPlanAssetCategoriesAxis."
+],
+"DefinedBenefitPlanTargetAllocationPercentageOfAssetsOtherRangeMaximum": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are DefinedBenefitPlanTargetPlanAssetAllocationsRangeMaximum and members of DefinedBenefitPlanByPlanAssetCategoriesAxis."
+],
+"DefinedBenefitPlanTargetAllocationPercentageOfAssetsOtherRangeMinimum": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are DefinedBenefitPlanTargetPlanAssetAllocationsRangeMinimum and members of DefinedBenefitPlanByPlanAssetCategoriesAxis."
+],
+"DefinedBenefitPlanTargetAllocationPercentageOfAssetsRealEstate": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are DefinedBenefitPlanTargetPlanAssetAllocations and members of DefinedBenefitPlanByPlanAssetCategoriesAxis."
+],
+"DefinedBenefitPlanTargetAllocationPercentageOfAssetsRealEstateRangeMaximum": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are DefinedBenefitPlanTargetPlanAssetAllocationsRangeMaximum and members of DefinedBenefitPlanByPlanAssetCategoriesAxis."
+],
+"DefinedBenefitPlanTargetAllocationPercentageOfAssetsRealEstateRangeMinimum": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are DefinedBenefitPlanTargetPlanAssetAllocationsRangeMinimum and members of DefinedBenefitPlanByPlanAssetCategoriesAxis."
+],
+"DefinedBenefitPlanTargetAllocationPercentagesOfAssetsDebtSecuritiesAbstract": [
+"2012-01-31",
+"This element has been deprecated."
+],
+"DefinedBenefitPlanTargetAllocationPercentagesOfAssetsEquitySecuritiesAbstract": [
+"2012-01-31",
+"This element has been deprecated."
+],
+"DefinedBenefitPlanTargetAllocationPercentagesOfAssetsOtherAbstract": [
+"2012-01-31",
+"This element has been deprecated."
+],
+"DefinedBenefitPlanTargetAllocationPercentagesOfAssetsRealEstateAbstract": [
+"2012-01-31",
+"This element has been deprecated."
+],
+"DefinedBenefitPlanWeightedAverageAssetAllocationsAbstract": [
+"2012-01-31",
+"This element was removed because the dimensionalizing of Defined Benefit Plan, Actual Plan Asset Allocations resulted in one child element to this [Abstract] element."
+],
+"DefinedContributionPensionMember": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is PensionPlansDefinedBenefitMember."
+],
+"DefinedContributionPlanMaximumAnnualContributionPerEmployeeAmount": [
+"2013-01-31",
+"Element was deprecated because it was incorrectly defined. Possible replacement is DefinedContributionPlanMaximumAnnualContributionsPerEmployeeAmount."
+],
+"DefinedContributionPlanMaximumAnnualContributionPerEmployeePercent": [
+"2013-01-31",
+"Element was deprecated because it was incorrectly defined. Possible replacement is DefinedContributionPlanMaximumAnnualContributionsPerEmployeePercent."
+],
+"DepositAssetsOrLiabilitiesAmortizationExpenseFromExpirations": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacement is DepositAssetsAmortizatonExpenseFromExpirations."
+],
+"DepositAssetsOrLiabilitiesEffectOfChangeInInterestAccrualAssumptionOnExpectedRecoveryAmounts": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DepositAssetsEffectOfIncreaseDecreaseInInterestAccrualAssumptionOnExpectedRecoveryAmounts and DepositLiabilitiesEffectOfIncreaseDecreaseInInterestAccrualAssumptionOnExpectedRecoveryAmounts."
+],
+"DepositAssetsOrLiabilitiesEffectOfChangeInPresentValueAssumptionsRecordedAsExpense": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DepositAssetsEffectOfChangeInPresentValueAssumptionsRecordedAsExpense and DepositLiabilitiesEffectOfChangeInPresentValueAssumptionsRecordedAsExpense."
+],
+"DepositAssetsOrLiabilitiesEffectOfChangeInPresentValueAssumptionsResultingInAdditionsToExpectedRecoveries": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DepositAssetsEffectOfChangeInPresentValueAssumptionsResultingInAdditionsToExpectedRecoveries and DepositLiabilitiesEffectOfChangeInPresentValueAssumptionsResultingInAdditionsToExpectedRecoveries."
+],
+"DepositAssetsOrLiabilitiesEffectOfChangeInPresentValueAssumptionsResultingInReductionsInExpectedRecoveries": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DepositAssetsEffectOfChangeInPresentValueAssumptionsResultingInReductionsToExpectedRecoveries and DepositLiabilitiesEffectOfChangeInPresentValueAssumptionsResultingInReductionsToExpectedRecoveries."
+],
+"DepositAssetsOrLiabilitiesPresentValueOfExpectedRecoveries": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacement is DepositAssetsPresentValueOfExpectedRecoveries."
+],
+"DepositLiabilitiesReclassifiedAsLoansReceivable": [
+"2012-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is DepositLiabilitiesReclassifiedAsLoansReceivable1."
+],
+"DeprecatedItems": [
+"",
+"This is a container item for US-GAAP concepts that have been deprecated."
+],
+"DepreciableAssetsMember": [
+"2014-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"DerecognizedAssetsSecuritizedOrAssetbackedFinancingArrangementAssetsAndAnyOtherFinancialAssetsManagedTogetherAverageBalanceDuringPeriod": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DerecognizedAssetsSecuritizedOrAssetbackedFinancingArrangementAssetsAndAnyOtherFinancialAssetsManagedTogetherByTypeOfFinancialInstrumentAxis": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is FinancialInstrumentAxis."
+],
+"DerivativeAssetFairValueNet": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DerivativeFairValueOfDerivativeAssetAmountNotOffsetAgainstCollateral."
+],
+"DerivativeAverageExchangeRateCap": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is DerivativeAverageExchangeRateCap1."
+],
+"DerivativeAverageExchangeRateFloor": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is DerivativeAverageExchangeRateFloor1."
+],
+"DerivativeAverageForwardExchangeRate": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is DerivativeAverageForwardExchangeRate1."
+],
+"DerivativeAverageRemainingMaturity": [
+"2012-01-31",
+"Element was deprecated because it has a durationStringItemType. Possible replacement is DerivativeAverageRemainingMaturity1."
+],
+"DerivativeDescriptionOfVariableRateBasis": [
+"2014-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeVariableInterestRate and members of VariableRateAxis."
+],
+"DerivativeExchangeRateCap": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is DerivativeExchangeRateCap1."
+],
+"DerivativeExchangeRateFloor": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is DerivativeExchangeRateFloor1."
+],
+"DerivativeFairValueGrossAmountNotOffsetAgainstCollateralNet": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DerivativeFairValueOfDerivativeNet."
+],
+"DerivativeFairValueGrossAmountNotOffsetAgainstCollateralNetAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"DerivativeFinancialInstrumentsAssetsFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
+],
+"DerivativeFinancialInstrumentsAssetsFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
+],
+"DerivativeFinancialInstrumentsLiabilitiesFairValueDisclosure": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DerivativeLiabilities."
+],
+"DerivativeFinancialInstrumentsLiabilitiesFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
+],
+"DerivativeFinancialInstrumentsLiabilitiesFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
+],
+"DerivativeForwardExchangeRate": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is DerivativeForwardExchangeRate1."
+],
+"DerivativeHedgeDesignation": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
+],
+"DerivativeHigherRemainingMaturityRange": [
+"2012-01-31",
+"Element was deprecated because it has a durationStringItemType. Possible replacement is DerivativeHigherRemainingMaturityRange1."
+],
+"DerivativeInstrumentsGainLossByIncomeStatementLocationAxis": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is IncomeStatementLocationAxis."
+],
+"DerivativeInstrumentsGainLossReclassificationFromAccumulatedOCIToIncomeEstimateOfTimeToTransfer": [
+"2012-01-31",
+"Element was deprecated because it has a durationStringItemType. Possible replacement is DerivativeInstrumentsGainLossReclassificationFromAccumulatedOCIToIncomeEstimateOfTimeToTransfer1."
+],
+"DerivativeInstrumentsGainLossRecognizedInIncomeNet": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeGainLossOnDerivativeNet and members of HedgingDesignationAxis."
+],
+"DerivativeInstrumentsGainLossRecognizedInIncomeNetAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"DerivativeInstrumentsGainRecognizedInIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeGainOnDerivative and members of HedgingDesignationAxis."
+],
+"DerivativeInstrumentsLossRecognizedInIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeLossOnDerivative and members of HedgingDesignationAxis."
+],
+"DerivativeLiabilityFairValueNet": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is DerivativeFairValueOfDerivativeLiabilityAmountNotOffsetAgainstCollateral."
+],
+"DerivativeLiabilityFairValueNet1": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DerivativeFairValueOfDerivativeLiabilityAmountNotOffsetAgainstCollateral."
+],
+"DerivativeLowerRemainingMaturityRange": [
+"2012-01-31",
+"Element was deprecated because it has a durationStringItemType. Possible replacement is DerivativeLowerRemainingMaturityRange1."
+],
+"DerivativeNonmonetaryNotionalAmountPricePerBarrel": [
+"2013-01-31",
+"Element was deprecated because the intended concept conveyed is the underlying. Possible replacement is UnderlyingDerivativeVolume."
+],
+"DerivativeNonmonetaryNotionalAmountPricePerGallon": [
+"2013-01-31",
+"Element was deprecated because the intended concept conveyed is the underlying. Possible replacement is UnderlyingDerivativeVolume."
+],
+"DerivativeNonmonetaryNotionalAmountPricePerUnit": [
+"2013-01-31",
+"Element was deprecated because the intended concept conveyed is the underlying. Possible replacements are UnderlyingDerivativeAsset, UnderlyingDerivativeLiability and UnderlyingDerivative."
+],
+"DerivativeRemainingMaturity": [
+"2012-01-31",
+"Element was deprecated because it has a durationStringItemType. Possible replacement is DerivativeRemainingMaturity1."
+],
+"DerivativesFairValueByBalanceSheetLocationAxis": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is BalanceSheetLocationAxis."
+],
+"DescriptionAndEffectsOfChangesInPrepaymentEstimateAssumptionsForCMOsAndREMICsLineItems": [
+"2013-01-31",
+"Element was deprecated."
+],
+"DescriptionOfAccountingMethodUsedForCreditRiskDerivatives": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are members of ValuationTechniqueAxis."
+],
+"DescriptionOfChangeInAccountingPrincipleSFAS158": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DescriptionOfChangeInAverageTrancheLifeEstimate": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"DescriptionOfChangeInCashFlowProjectionsEstimate": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"DescriptionOfChangeInMeasurementDateSFAS158": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DescriptionOfChangeInReinvestmentRateOfReturnEstimate": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"DescriptionOfCreditRiskDerivativeActivities": [
+"2013-01-31",
+"Element was deprecated because it has a stringItemType attribute. Possible replacement is DisclosureOfCreditDerivativesTextBlock."
+],
+"DescriptionOfDerivativeInstrumentsByRiskExposure": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DerivativeUnderlyingRisk."
+],
+"DescriptionOfMultiemployerPlan": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is MultiemployerPlansPlanBenefitsDescription."
+],
+"DevelopmentStageEnterpriseAdditionalInformationForIncomeStatementAbstract": [
+"2012-01-31",
+"This element has been deprecated because it children were deprecated."
+],
+"DevelopmentStageEnterpriseAdditionalInformationForStatementOfCashFlowsAbstract": [
+"2012-01-31",
+"This element has been deprecated because it children were deprecated."
+],
+"DevelopmentStageEnterpriseCumulativeCashInflows": [
+"2012-01-31",
+"Element was deprecated because different elements should not be used to tag cash inflows for the period and to tag cash inflows since inception. Possible replacement is the appropriate cash flow element to tag both fact values."
+],
+"DevelopmentStageEnterpriseCumulativeCashOutflows": [
+"2012-01-31",
+"Element was deprecated because different elements should not be used to tag cash outflows for the period and to tag cash outflows since inception. Possible replacement is the appropriate cash flow element to tag both fact values."
+],
+"DevelopmentStageEnterpriseCumulativeExpense": [
+"2012-01-31",
+"Element was deprecated because different elements should not be used to tag expenses for the period and to tag expenses since inception. Possible replacement is CostsAndExpenses."
+],
+"DevelopmentStageEnterpriseCumulativeRevenue": [
+"2012-01-31",
+"Element was deprecated because different elements should not be used to tag revenue for the period and to tag revenue since inception. Possible replacement is Revenues."
+],
+"DirectPremiumsEarnedAccidentAndHealth": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"DirectPremiumsEarnedFinancialGuaranteeInsuranceContracts": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"DirectPremiumsEarnedLife": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"DirectPremiumsEarnedOtherInsurance": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"DirectPremiumsEarnedPropertyAndCasualty": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"DirectPremiumsLifeInsuranceInForce": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is LifeInsuranceInForceGross."
+],
+"DirectPremiumsWrittenAccidentAndHealth": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsWritten and members ofReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"DirectPremiumsWrittenFinancialGuaranteeInsuranceContracts": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"DirectPremiumsWrittenLife": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"DirectPremiumsWrittenOtherInsurance": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"DirectPremiumsWrittenPropertyAndCasualty": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"DiscontinuedOperationOrAssetDisposalMember": [
+"2012-01-31",
+"Element was deprecated because the dimension of the financial reporting concept was remodeled. Possible replacements are IncomeStatementBalanceSheetAndAdditionalDisclosuresByDisposalGroupsIncludingDiscontinuedOperationsAxis and other elements/members as needed."
+],
+"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReserves10PercentAnnualDiscountForEstimatedTimingOfCashFlows": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesTenPercentAnnualDiscountForEstimatedTimingOfCashFlows."
+],
+"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureCashInflows": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesCashInflows."
+],
+"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureDevelopmentCosts": [
+"2013-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesDevelopmentCosts."
+],
+"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureDevelopmentCosts1": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesDevelopmentCosts."
+],
+"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureIncomeTaxExpense": [
+"2013-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesIncomeTaxExpense."
+],
+"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureIncomeTaxExpense1": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesIncomeTaxExpense."
+],
+"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureNetCashFlows": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesNetCashFlows."
+],
+"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureProductionCosts": [
+"2013-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesProductionCosts."
+],
+"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureProductionCosts1": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesProductionCosts."
+],
+"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesStandardizedMeasure": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is StandardizedMeasureOfDiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReserves."
+],
+"DiscussionOfCreditRiskDerivativeRiskManagementPolicy": [
+"2013-01-31",
+"Element was deprecated because it has a stringItemType attribute. Possible replacement is DerivativesPolicyTextBlock."
+],
+"DiscussionOfMethodOfMeasuringFairValueOfCreditRiskDerivatives": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are members of ValuationTechniqueAxis."
+],
+"DisposalDate": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. Possible replacement is DisposalDate1."
+],
+"DisposalGroupIncludingDiscontinuedOperationGoodwill": [
+"2014-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DisposalGroupIncludingDiscontinuedOperationGoodwillNoncurrent, DisposalGroupIncludingDiscontinuedOperationGoodwillCurrent or DisposalGroupIncludingDiscontinuedOperationGoodwill1."
+],
+"DisposalGroupIncludingDiscontinuedOperationIntangibleAssetsNet": [
+"2014-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DisposalGroupIncludingDiscontinuedOperationIntangibleAssetsNoncurrent, DisposalGroupIncludingDiscontinuedOperationIntangibleAssetsCurrent or DisposalGroupIncludingDiscontinuedOperationIntangibleAssets."
+],
+"DisposalGroupIncludingDiscontinuedOperationInventory": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is InventoriesPropertyHeldForSaleCurrent."
+],
+"DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipmentNet": [
+"2014-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipmentNoncurrent, DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipmentCurrent or DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipment."
+],
+"DistributionMadeToMemberOrLimitedPartnerCashDistributionsDeclared": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberCashDistributionsDeclared or DistributionMadeToLimitedPartnerCashDistributionsDeclared."
+],
+"DistributionMadeToMemberOrLimitedPartnerCashDistributionsPaid": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberCashDistributionsPaid or DistributionMadeToLimitedPartnerCashDistributionsPaid."
+],
+"DistributionMadeToMemberOrLimitedPartnerDateOfRecord": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. If you have used this element in the past, consider replacing it with DistributionMadeToLimitedLiabilityCompanyLLCMemberDateOfRecord or DistributionMadeToLimitedPartnerDateOfRecord."
+],
+"DistributionMadeToMemberOrLimitedPartnerDateOfRecord1": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberDateOfRecord or DistributionMadeToLimitedPartnerDateOfRecord."
+],
+"DistributionMadeToMemberOrLimitedPartnerDeclarationDate": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. If you have used this element in the past, consider replacing it with DistributionMadeToLimitedLiabilityCompanyLLCMemberDeclarationDate or DistributionMadeToLimitedPartnerDeclarationDate."
+],
+"DistributionMadeToMemberOrLimitedPartnerDeclarationDate1": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberDeclarationDate or DistributionMadeToLimitedPartnerDeclarationDate."
+],
+"DistributionMadeToMemberOrLimitedPartnerDistributionDate": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. If you have used this element in the past, consider replacing it with DistributionMadeToLimitedLiabilityCompanyLLCMemberDistributionDate or DistributionMadeToLimitedPartnerDistributionDate."
+],
+"DistributionMadeToMemberOrLimitedPartnerDistributionDate1": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberDistributionDate or DistributionMadeToLimitedPartnerDistributionDate."
+],
+"DistributionMadeToMemberOrLimitedPartnerDistributionsDeclaredPerUnit": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberDistributionsDeclaredPerUnit or DistributionMadeToLimitedPartnerDistributionsDeclaredPerUnit."
+],
+"DistributionMadeToMemberOrLimitedPartnerDistributionsPaidPerUnit": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberDistributionsPaidPerUnit or DistributionMadeToLimitedPartnerDistributionsPaidPerUnit."
+],
+"DistributionMadeToMemberOrLimitedPartnerLineItems": [
+"2013-01-31",
+"Element was deprecated."
+],
+"DistributionMadeToMemberOrLimitedPartnerShareDistribution": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberUnitDistribution or DistributionMadeToLimitedPartnerUnitDistribution."
+],
+"DistributionMadeToMemberOrLimitedPartnerShareDistributionDilutionPerShare": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberUnitDistributionDilutionPerUnit or DistributionMadeToLimitedPartnerUnitDistributionDilutionPerUnit."
+],
+"DistributionPaymentFormsOtherThanCashOrStockDescription": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionPaymentMadeToLimitedLiabilityCompanyLLCMemberFormsOtherThanCashOrStockDescription or DistributionPaymentMadeToLimitedPartnerFormsOtherThanCashOrStockDescription."
+],
+"DividendIncomeMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is InvestmentIncomeDividend."
+],
+"DividendPaymentRestrictionsScheduleAmountsPaid": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is PaymentsOfDividends."
+],
+"DividendsPayableAmount": [
+"2012-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DividendsPayableCurrentAndNoncurrent."
+],
+"EarningsPerShareBasicMember": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"EarningsPerShareDilutedMember": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"EffectOfChangeInAverageTrancheLifeEstimate": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"EffectOfChangeInCashFlowProjectionEstimate": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"EffectOfChangeInReinvestmentRateOfReturnEstimate": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"EffectOfIllegalActsOnFinancialStatementsAmountMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"EffectOfIllegalActsOnFinancialStatementsDisclosureMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"EffectiveDateDeferralSFAS157": [
+"2012-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"EffectsOfChangesInPrepaymentEstimateAssumptionsForCMOsAndREMICsAffectedItemDomain": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"EffectsOfChangesInPrepaymentEstimateAssumptionsForCMOsAndREMICsByAffectedItemAxis": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"EffectsOfChangesInPrepaymentEstimateAssumptionsForCMOsAndREMICsTable": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"EffectsOfReinsuranceAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"EffectsOfUnrealizedHoldingGainLossOnPresentValueOfFutureInsuranceProfits": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is EffectsOfUnrealizedHoldingGainLossOnPresentValueOfFutureInsuranceProfits1."
+],
+"EmployeeServiceShareBasedCompensationAllocationOfRecognizedPeriodCostsReportLineDomain": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is IncomeStatementLocationDomain."
+],
+"EmployeeServiceShareBasedCompensationNonvestedAwardsTotalCompensationCostNotYetRecognizedPeriodForRecognition": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is EmployeeServiceShareBasedCompensationNonvestedAwardsTotalCompensationCostNotYetRecognizedPeriodForRecognition1."
+],
+"EmployeeServiceShareBasedCompensationPolicyForIssuingSharesUponExercise": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardPolicyForIssuingSharesUponExercise."
+],
+"EntityWideDisclosureOnGeographicAreasLongLivedAssetsInEntitysCountryOfDomicile": [
+"2013-01-31",
+"Element was deprecated due to remodeling of Segment area. Possible replacement is NoncurrentAssets and members of StatementGeographicalAxis."
+],
+"EntityWideDisclosureOnGeographicAreasLongLivedAssetsInForeignCountries": [
+"2013-01-31",
+"Element was deprecated due to remodeling of Segment area. Possible replacement is NoncurrentAssets and members of StatementGeographicalAxis."
+],
+"EntityWideDisclosureOnGeographicAreasRevenueFromExternalCustomersAttributedToEntitysCountryOfDomicile": [
+"2013-01-31",
+"Element was deprecated due to remodeling of Segment area. Possible replacement is Revenues and members of StatementGeographicalAxis."
+],
+"EntityWideDisclosureOnGeographicAreasRevenueFromExternalCustomersAttributedToForeignCountries": [
+"2013-01-31",
+"Element was deprecated due to remodeling of Segment area. Possible replacement is Revenues and members of StatementGeographicalAxis."
+],
+"EntityWideRevenueMajorCustomerAmount": [
+"2013-01-31",
+"Element was deprecated due to remodeling of Segment area. Possible replacement is Revenues and members of MajorCustomersAxis."
+],
+"EntityWideRevenueMajorCustomerPercentage": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ConcentrationRiskPercentage1 and members of ConcentrationRiskByBenchmarkAxis."
+],
+"EnvironmentalCostRecognized": [
+"2012-01-31",
+"Element was deprecated because it has a stringItemType. Possible replacement is EnvironmentalCostsRecognizedCapitalized."
+],
+"EnvironmentalCostRecognizedCapitalizedInPeriod": [
+"2012-01-31",
+"Element was deprecated because it has an instant period type. Possible replacement is EnvironmentalCostsRecognizedCapitalizedInPeriod."
+],
+"EnvironmentalCostRecognizedRecoveryCreditedToExpense": [
+"2012-01-31",
+"Element was deprecated because it has an instant period type. Possible replacement is EnvironmentalCostsRecognizedRecoveryCreditedToExpense."
+],
+"EnvironmentalCostsOfPropertyForSaleDisposalOrAbandonmentAccruedExitCosts": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is EnvironmentalExitCostsCostsAccruedToDate."
+],
+"EnvironmentalCostsOfPropertyForSaleDisposalOrAbandonmentAnticipatedExitCosts": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is EnvironmentalExitCostsAnticipatedCost."
+],
+"EnvironmentalCostsOfPropertyForSaleDisposalOrAbandonmentBalanceSheetCaption": [
+"2014-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is EnvironmentalExitCostsCostsAccruedToDate and members of BalanceSheetLocationAxis."
+],
+"EnvironmentalCostsOfPropertyForSaleDisposalOrAbandonmentDisclosures": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is EnvironmentalExitCostsNatureOfCosts."
+],
+"EnvironmentalExitCostsReasonablyPossibleAdditionalLosses": [
+"2012-01-31",
+"Element was deprecated because it has a stringItemType. Possible replacement is EnvironmentalExitCostsReasonablyPossibleAdditionalLoss."
+],
+"EnvironmentalRemediationExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is EnvironmentalRemediationExpense."
+],
+"EquityClassOfTreasuryStockAxis": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is StatementClassOfStockAxis."
+],
+"EquityContributionsToFinanceLeveragedBuyout": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"EquityFinancingForLeveragedBuyout": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"EquityFinancingForLeveragedBuyoutAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"EquityForwardAgreementsMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ForwardContractsMember."
+],
+"EquityIssuanceAbstract": [
+"2012-01-31",
+"This element has been deprecated because its children have been relocated."
+],
+"EquityIssuanceDollarAmountPerShare": [
+"2012-01-31",
+"Element was deprecated because it has an instant period type. Possible replacement is EquityIssuancePerShareAmount."
+],
+"EquityIssuanceNumberOfEquitySecuritiesIssuedForCash": [
+"2012-01-31",
+"Element was deprecated because it has an instant period type and a decimalItemType. Possible replacement is StockIssuedDuringPeriodSharesIssuedForCash."
+],
+"EquityIssuanceNumberOfEquitySecuritiesIssuedForNoncashConsiderations": [
+"2012-01-31",
+"Element was deprecated because it has an instant period type and a decimalItemType. Possible replacement is StockIssuedDuringPeriodSharesIssuedForNoncashConsideration."
+],
+"EquityIssuanceSinceInceptionLineItems": [
+"2012-01-31",
+"This element has been deprecated because filers should not use a dimension to differentiate equity issuances. Filers should use the date context to differentiate equity issuances."
+],
+"EquityIssuanceTotalDollarAmount": [
+"2012-01-31",
+"Element was deprecated because it has an instant period type. Possible replacements are StockIssuedDuringPeriodValueIssuedForCash or StockIssuedDuringPeriodValueIssuedForNoncashConsiderations."
+],
+"EquityIssuedSinceInceptionByIssuanceAxis": [
+"2012-01-31",
+"Element was deprecated because it used a dimension to differentiate equity issuances. Possible replacement is the date context to differentiate equity issuances."
+],
+"EquityMethodInvestmentsFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
+],
+"EquityMethodInvestmentsFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
+],
+"EquitySecuritiesOtherMember": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"EscrowDepositDisbursementsRelatedToPropertyAcquisition": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is EscrowDepositDisbursementsRelatedToPropertyAcquisition1."
+],
+"ExchangeFeesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ExchangeFees."
+],
+"ExecutiveCompensationContractsMember": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"ExpenseRelatedToDistributionOrServicingAndUnderwritingFeesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ExpenseRelatedtoDistributionorServicingandUnderwritingFees."
+],
+"ExperienceRatedRefundsPayable": [
+"2013-01-31",
+"Element was deprecated due to remodeling of reinsurance topic area."
+],
+"ExperienceRatedRefundsReceivable": [
+"2013-01-31",
+"Element was deprecated due to remodeling of reinsurance topic area."
+],
+"ExplanationDifferencesBetweenBookAndTaxBasis": [
+"2013-01-31",
+"Element was deprecated because it is an invalid concept."
+],
+"ExpropriationOfAssetsAxis": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"ExpropriationOfAssetsDomain": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"ExpropriationOfAssetsMember": [
+"2012-01-31",
+"Element was deprecated because the dimension of the financial reporting concept was remodeled."
+],
+"FDICPremiumExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is FederalDepositInsuranceCorporationPremiumExpense."
+],
+"FairValueAdjustmentsOnHedgesAndDerivativeContractsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is UnrealizedGainLossOnDerivatives."
+],
+"FairValueAssetsMeasuredOnNonrecurringBasisValuationTechniquesAssetsHeldForSaleLongLived": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+],
+"FairValueAssetsMeasuredOnNonrecurringBasisValuationTechniquesCapitalLeasedAssetsNoncurrent": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+],
+"FairValueAssetsMeasuredOnNonrecurringBasisValuationTechniquesFiniteLivedIntangibleAssets": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+],
+"FairValueAssetsMeasuredOnNonrecurringBasisValuationTechniquesGasPurchaseContract": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+],
+"FairValueAssetsMeasuredOnNonrecurringBasisValuationTechniquesGoodwill": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+],
+"FairValueAssetsMeasuredOnNonrecurringBasisValuationTechniquesHeldToMaturitySecurities": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+],
+"FairValueAssetsMeasuredOnNonrecurringBasisValuationTechniquesIndefiniteLivedIntangibleAssetsExcludingGoodwill": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+],
+"FairValueAssetsMeasuredOnNonrecurringBasisValuationTechniquesInventoryNoncurrent": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+],
+"FairValueAssetsMeasuredOnNonrecurringBasisValuationTechniquesInvestmentInPhysicalCommodities": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+],
+"FairValueAssetsMeasuredOnNonrecurringBasisValuationTechniquesInvestmentsInAffiliatesSubsidiariesAssociatesAndJointVentures": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+],
+"FairValueAssetsMeasuredOnNonrecurringBasisValuationTechniquesInvestmentsInPowerAndDistributionProjects": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+],
+"FairValueAssetsMeasuredOnNonrecurringBasisValuationTechniquesPropertyPlantAndEquipment": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+],
+"FairValueAssetsMeasuredOnNonrecurringBasisValuationTechniquesRegulatoryAssetsNoncurrent": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+],
+"FairValueAssetsMeasuredOnRecurringAndNonrecurringBasisValuationTechniquesAbstract": [
+"2012-01-31",
+"This element was removed because its children were deprecated after the disclosure was dimensionalized."
+],
+"FairValueAssetsMeasuredOnRecurringBasisAccountsReceivableValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+],
+"FairValueAssetsMeasuredOnRecurringBasisCashAndCashEquivalentsValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+],
+"FairValueAssetsMeasuredOnRecurringBasisCashSurrenderValueValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+],
+"FairValueAssetsMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInInvestmentIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueAssetsMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
+],
+"FairValueAssetsMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInOtherIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueAssetsMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
+],
+"FairValueAssetsMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInTradingRevenue": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueAssetsMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
+],
+"FairValueAssetsMeasuredOnRecurringBasisCostMethodInvestmentsValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+],
+"FairValueAssetsMeasuredOnRecurringBasisDerivativeFinancialInstrumentsAssetsValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+],
+"FairValueAssetsMeasuredOnRecurringBasisEquityMethodInvestmentsValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+],
+"FairValueAssetsMeasuredOnRecurringBasisFederalFundsSoldAndSecuritiesBorrowedOrPurchasedUnderAgreementsToResellValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+],
+"FairValueAssetsMeasuredOnRecurringBasisGainLossIncludedInEarningsAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"FairValueAssetsMeasuredOnRecurringBasisGainLossIncludedInEarningsDescription": [
+"2012-01-31",
+"Element was deprecated due to redundancy. Possible replacement is FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisAssetGainLossIncludedInEarningsDescription."
+],
+"FairValueAssetsMeasuredOnRecurringBasisGainLossIncludedInInvestmentIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisAssetGainLossIncludedInEarnings1 and members of IncomeStatementLocationAxis."
+],
+"FairValueAssetsMeasuredOnRecurringBasisGainLossIncludedInOtherIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisAssetGainLossIncludedInEarnings1 and members of IncomeStatementLocationAxis."
+],
+"FairValueAssetsMeasuredOnRecurringBasisGainLossIncludedInTradingRevenue": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisAssetGainLossIncludedInEarnings1 and members of IncomeStatementLocationAxis."
+],
+"FairValueAssetsMeasuredOnRecurringBasisInvestmentInFederalHomeLoanBankStockValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+],
+"FairValueAssetsMeasuredOnRecurringBasisInvestmentsValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+],
+"FairValueAssetsMeasuredOnRecurringBasisLoansReceivableValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+],
+"FairValueAssetsMeasuredOnRecurringBasisNotesReceivableValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+],
+"FairValueAssetsMeasuredOnRecurringBasisPremiumsReceivableValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+],
+"FairValueAssetsMeasuredOnRecurringBasisReceivablesValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+],
+"FairValueAssetsMeasuredOnRecurringBasisRetainedInterestValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+],
+"FairValueAssetsMeasuredOnRecurringBasisServicingRightsValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+],
+"FairValueAssetsMeasuredOnRecurringBasisTradingAccountAssetsValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
+],
+"FairValueByBalanceSheetGroupingDisclosureItemAmountsAxis": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is FairValueByMeasurementBasisAxis."
+],
+"FairValueByBalanceSheetGroupingMethodologyAbstract": [
+"2012-01-31",
+"This element was removed because its children were deprecated after the disclosure was dimensionalized."
+],
+"FairValueByBalanceSheetGroupingMethodologyAndAssumptionsAbstract": [
+"2012-01-31",
+"This element was removed because its children were deprecated after the disclosure was dimensionalized."
+],
+"FairValueByBalanceSheetGroupingMethodologyFinancialAssetsAbstract": [
+"2012-01-31",
+"This element was removed because its children were deprecated after the disclosure was dimensionalized."
+],
+"FairValueByBalanceSheetGroupingMethodologyFinancialLiabilitiesAbstract": [
+"2012-01-31",
+"This element was removed because its children were deprecated after the disclosure was dimensionalized."
+],
+"FairValueByBalanceSheetGroupingSignificantAssumptionsAbstract": [
+"2012-01-31",
+"This element was removed because its children were deprecated after the disclosure was dimensionalized."
+],
+"FairValueByBalanceSheetGroupingSignificantAssumptionsFinancialAssetsAbstract": [
+"2012-01-31",
+"This element was removed because its children were deprecated after the disclosure was dimensionalized."
+],
+"FairValueByBalanceSheetGroupingSignificantAssumptionsFinancialLiabilitiesAbstract": [
+"2012-01-31",
+"This element was removed because its children were deprecated after the disclosure was dimensionalized."
+],
+"FairValueConvertibleDebtValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
+],
+"FairValueEstimateNotPracticableReasonsRetainedInterest": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"FairValueEstimateNotPracticableRetainedInterest": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInInvestmentIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
+],
+"FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInOtherIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
+],
+"FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInTradingRevenue": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
+],
+"FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisGainLossIncludedInEarningsAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisGainLossIncludedInInvestmentIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisInstrumentsClassifiedInShareholdersEquityGainLossIncludedInEarnings and members of IncomeStatementLocationAxis."
+],
+"FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisGainLossIncludedInOtherIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisInstrumentsClassifiedInShareholdersEquityGainLossIncludedInEarnings and members of IncomeStatementLocationAxis."
+],
+"FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisGainLossIncludedInTradingRevenue": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisInstrumentsClassifiedInShareholdersEquityGainLossIncludedInEarnings and members of IncomeStatementLocationAxis."
+],
+"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareInvestmentRedemptionNoticePeriod": [
+"2014-01-31",
+"Element was deprecated because it has a stringItemType attribute. Possible replacement is FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareInvestmentRedemptionNoticePeriod1."
+],
+"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareLiquidatingInvestmentRemainingPeriod": [
+"2012-01-31",
+"Element was deprecated because it has an instant period type. Possible replacement is FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareLiquidatingInvestmentRemainingPeriod1."
+],
+"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareLiquidatingInvestmentRemainingPeriodAbstract": [
+"2012-01-31",
+"Element has been deprecated."
+],
+"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareLiquidatingInvestmentRemainingPeriodDate": [
+"2012-01-31",
+"Element was deprecated due to redundancy. Possible replacement is FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareLiquidatingInvestmentRemainingPeriod1."
+],
+"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareLiquidatingInvestmentRemainingPeriodHighEstimate": [
+"2012-01-31",
+"Element was deprecated because it has an instant period type. Possible replacement is FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareLiquidatingInvestmentRemainingPeriod1."
+],
+"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareLiquidatingInvestmentRemainingPeriodLowEstimate": [
+"2012-01-31",
+"Element was deprecated because it has an instant period type. Possible replacement is FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareLiquidatingInvestmentRemainingPeriod1."
+],
+"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionFlag": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionFlag1."
+],
+"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionLapseDate": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. Possible replacement is FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionLapseDate1."
+],
+"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionLapseDateNotEstimatableFlag": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionLapseDateNotEstimableFlag."
+],
+"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionPeriodInEffect": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. Possible replacement is FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionPeriodInEffect1."
+],
+"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionRangeOfRestrictionPeriodHighEnd": [
+"2012-01-31",
+"Element was deprecated because it has an instant period type. Possible replacement is FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionPeriod and members of RangeAxis."
+],
+"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionRangeOfRestrictionPeriodLowEnd": [
+"2012-01-31",
+"Element was deprecated because it has an instant period type. Possible replacement is FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionPeriod and members of RangeAxis."
+],
+"FairValueLevel1ToLevel2TransfersAmount": [
+"2012-01-31",
+"Element was deprecated. Possible replacements are FairValueAssetsLevel1ToLevel2TransfersAmount, FairValueLiabilitiesLevel1ToLevel2TransfersAmount, or FairValueEquityLevel1ToLevel2TransfersAmount."
+],
+"FairValueLevel1ToLevel2TransfersDescription": [
+"2012-01-31",
+"Element was deprecated. Possible replacements are FairValueAssetsLevel1ToLevel2TransfersAmount, FairValueLiabilitiesLevel1ToLevel2TransfersAmount, or FairValueEquityLevel1ToLevel2TransfersAmount."
+],
+"FairValueLevel2ToLevel1TransfersAmount": [
+"2012-01-31",
+"Element was deprecated. Possible replacements are FairValueAssetsLevel2ToLevel1TransfersAmount, FairValueLiabilitiesLevel2ToLevel1TransfersAmount, or FairValueEquityLevel2ToLevel1TransfersAmount."
+],
+"FairValueLevel2ToLevel1TransfersDescription": [
+"2012-01-31",
+"Element was deprecated. Possible replacements are FairValueAssetsLevel2ToLevel1TransfersAmount, FairValueLiabilitiesLevel2ToLevel1TransfersAmount, or FairValueEquityLevel2ToLevel1TransfersAmount."
+],
+"FairValueLiabilitiesMeasuredOnRecurringAndNonrecurringBasisValuationTechniquesAbstract": [
+"2012-01-31",
+"This element has been deprecated because its children were deprecated when the disclosure was dimensionalized."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisAccountsPayableValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisAccruedLiabilitiesValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInInvestmentIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueLiabilitiesMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInOtherIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueLiabilitiesMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInTradingRevenue": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueLiabilitiesMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisCommitmentsValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisDebtInstrumentValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisDepositsValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisDerivativeFinancialInstrumentsLiabilitiesValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisFederalFundsPurchasedAndSecuritiesSoldUnderAgreementsToRepurchaseValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisFederalFundsPurchasedValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisFederalHomeLoanBankBorrowingsValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisForeignCurrencyContractsValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisGainLossIncludedInEarningsAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisGainLossIncludedInEarningsDescription": [
+"2012-01-31",
+"Element was deprecated due to redundancy. Possible replacement is FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisLiabilityGainLossIncludedInEarningsDescription."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisGainLossIncludedInInvestmentIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisLiabilityGainLossIncludedInEarnings and members of IncomeStatementLocationAxis."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisGainLossIncludedInOtherIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisLiabilityGainLossIncludedInEarnings and members of IncomeStatementLocationAxis."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisGainLossIncludedInTradingRevenue": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisLiabilityGainLossIncludedInEarnings and members of IncomeStatementLocationAxis."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisGuaranteesValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisInvestmentContractsValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisMandatorilyRedeemablePreferredStockValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisObligationsValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisSecuritiesLoanedOrSoldUnderAgreementsToRepurchaseValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisSecuritiesSoldNotYetPurchasedValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisSubordinatedDebtObligationsValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisTradingLiabilitiesValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
+],
+"FairValueLinesOfCreditValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
+],
+"FairValueLoansPayableValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
+],
+"FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisAssetAndLiabilityGainLossIncludedInOtherComprehensiveIncomeLoss": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisGainLossIncludedInOtherComprehensiveIncomeLoss."
+],
+"FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisAssetGainLossIncludedInEarnings": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisAssetGainLossIncludedInEarnings1."
+],
+"FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisAssetGainLossIncludedInOtherComprehensiveIncome": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisAssetGainLossIncludedInOtherComprehensiveIncomeLoss."
+],
+"FairValueNotesPayableValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
+],
+"FairValueOffBalanceSheetRisksByFinancialInstrumentAxis": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is FinancialInstrumentAxis."
+],
+"FairValueOffBalanceSheetRisksFinancialInstrumentsDomain": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is TransfersAndServicingOfFinancialInstrumentsTypesOfFinancialInstrumentsDomain."
+],
+"FairValueOptionChangesInFairValueGainLoss": [
+"2012-01-31",
+"Element was deprecated. Possible replacements are FairValueOptionChangesInFairValueGainLoss1 qualified by IncomeStatementLocationAxis and EligibleItemOrGroupForFairValueOptionAxis and their members."
+],
+"FairValueOptionQualitativeDisclosuresRelatedToElectionByEligibleItemOrGroupAxis": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is EligibleItemOrGroupForFairValueOptionAxis."
+],
+"FairValueOptionQuantitativeDisclosuresByEligibleItemOrGroupAxis": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is EligibleItemOrGroupForFairValueOptionAxis."
+],
+"FairValueOtherLiabilitiesValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
+],
+"FairValuePlanAssetMeasurementDomain": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is FairValueMeasurementsFairValueHierarchyDomain."
+],
+"FairValueServicingLiabilityValuationTechniques": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
+],
+"FederalFundsPurchasedFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
+],
+"FederalFundsPurchasedFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
+],
+"FederalFundsSoldAndSecuritiesBorrowedOrPurchasedUnderAgreementsToResellFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
+],
+"FederalFundsSoldAndSecuritiesBorrowedOrPurchasedUnderAgreementsToResellFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
+],
+"FederalHomeLoanBankAdvancesGeneralDebtObligationsDisclosuresCollateralPledged": [
+"2012-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is FederalHomeLoanBankAdvancesGeneralDebtObligationsDisclosuresCollateralPledged1."
+],
+"FederalHomeLoanBankAdvancesGeneralDebtObligationsDisclosuresRepaymentsAndPenalties": [
+"2012-01-31",
+"Element was deprecated because it has a stringItemType. Possible replacement is FederalHomeLoanBankAdvancesGeneralDebtObligationsDisclosuresRepaymentAndPenalties."
+],
+"FederalHomeLoanBankAdvancesMaturitiesSummary": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is AdvancesFromFederalHomeLoanBanks."
+],
+"FederalHomeLoanBankAdvancesMaturitiesSummaryByInterestRateType": [
+"2012-01-31",
+"Element deprecated due to redundancy. Possible replacement is AdvancesFromFederalHomeLoanBanks."
+],
+"FederalHomeLoanBankAdvancesMaturitiesSummaryByInterestRateTypeAfterFiveYears": [
+"2012-01-31",
+"Element was deprecated due to redundancy. Possible replacement is FederalHomeLoanBankAdvancesMaturitiesSummaryDueAfterFiveYearsOfBalanceSheetDate."
+],
+"FederalHomeLoanBankAdvancesMaturitiesSummaryByInterestRateTypeUnderOneYear": [
+"2012-01-31",
+"Element was deprecated due to redundancy. Possible replacement is FederalHomeLoanBankAdvancesMaturitiesSummaryDueWithinOneYearOfBalanceSheetDate."
+],
+"FederalHomeLoanBankAdvancesShortTerm": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is FederalHomeLoanBankAdvancesMaturitiesSummaryDueWithinOneYearOfBalanceSheetDate."
+],
+"FederalHomeLoanBankBorrowingsFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
+],
+"FederalHomeLoanBankBorrowingsFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
+],
+"FinancialGuaranteeInsuranceContractsPremiumReceivedOverContractPeriodPremiumReceivableWeightedAverageCollectionPeriod": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is FinancialGuaranteeInsuranceContractsPremiumReceivedOverContractPeriodPremiumReceivableWeightedAverageCollectionPeriod1."
+],
+"FinancialGuaranteeInsuranceContractsPremiumsReceivableNewBusinessWritten": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is FinancialGuaranteeInsuranceContractsPremiumReceivableNewBusinessWritten."
+],
+"FinancialInstrumentsOwnedAndPledgedAsCollateralAssociatedLiabilitiesCaption": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is SecurityOwnedAndPledgedAsCollateralAssociatedLiabilitiesFairValue and members of BalanceSheetLocationAxis."
+],
+"FinancialInstrumentsOwnedAndPledgedAsCollateralCaption": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is SecurityOwnedAndPledgedAsCollateralFairValue and members of BalanceSheetLocationAxis."
+],
+"FinancialInstrumentsSubjectToMandatoryRedemptionSettlementTermsForwardPriceOrOptionStrikePriceSharesSettlementDates": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. Possible replacement is FinancialInstrumentsSubjectToMandatoryRedemptionSettlementTermsForwardPriceOrOptionStrikePriceSharesSettlementDate."
+],
+"FinancingAxis": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"FinancingDomain": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"FinancingMember": [
+"2012-01-31",
+"Element was deprecated because the dimension of the financial reporting concept was remodeled."
+],
+"FinancingReceivable": [
+"2012-01-31",
+"Element was deprecated due to redundancy. Possible replacement is NotesReceivableNet."
+],
+"FinancingReceivableAllowanceDomain": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is FinancingReceivableRecordedInvestmentClassOfFinancingReceivableDomain."
+],
+"FinancingReceivableAllowanceForCreditLossesIndividuallyEvaluatedForImpairment": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is FinancingReceivableAllowanceForCreditLossesIndividuallyEvaluatedForImpairment1."
+],
+"FinancingReceivableAllowanceForCreditLossesProvisions": [
+"2012-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is ProvisionForLoanLeaseAndOtherLosses."
+],
+"FinancingReceivableAllowanceForCreditLossesRecoveries": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is FinancingReceivableAllowanceForCreditLossesRecovery."
+],
+"FinancingReceivableByCreditQualityIndicatorDomain": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are CreditRatingAMBestDomain, InternalCreditAssessmentDomain, ExternalCreditRatingFitchMember, ExternalCreditRatingStandardPoorsMember, ExternalCreditRatingMoodysMember, ExternalCreditRatingByGroupingDomain."
+],
+"FinancingReceivableInformationByCreditQualityIndicatorAxis": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are CreditRatingAMBestAxis, CreditRatingMoodysAxis, CreditRatingStandardPoorsAxis, CreditRatingFitchAxis, ExternalCreditRatingByGroupingAxis, InternalCreditAssessmentAxis."
+],
+"FinancingReceivableInformationByPortfolioSegmentAxis": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is FinancingReceivableRecordedInvestmentByClassOfFinancingReceivableAxis."
+],
+"FinancingReceivableModificationsDeterminationOfAllowanceForCreditLosses": [
+"2012-01-31",
+"Element was deprecated. Possible replacements are FinancingReceivableModificationsDeterminationOfAllowanceForCreditLosses1 and FinancingReceivableModificationsSubsequentDefaultDeterminationOfAllowanceForCreditLosses."
+],
+"FinancingReceivableModificationsNatureAndExtentOfTransaction": [
+"2012-01-31",
+"Element was deprecated. Possible replacements are FinancingReceivableModificationsDeterminationOfAllowanceForCreditLosses1 and FinancingReceivableModificationsSubsequentDefaultDeterminationOfAllowanceForCreditLosses."
+],
+"FinancingReceivableModificationsNumberOfContracts": [
+"2012-01-31",
+"Element was deprecated. Possible replacements are FinancingReceivableModificationsNumberOfContracts2 and FinancingReceivableModificationsSubsequentDefaultNumberOfContracts1."
+],
+"FinancingReceivableModificationsNumberOfContracts1": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is FinancingReceivableModificationsNumberOfContracts2."
+],
+"FinancingReceivableModificationsPostModificationRecordedInvestment": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is FinancingReceivableModificationsPostModificationRecordedInvestment2."
+],
+"FinancingReceivableModificationsPostModificationRecordedInvestment1": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is FinancingReceivableModificationsPostModificationRecordedInvestment2."
+],
+"FinancingReceivableModificationsPreModificationRecordedInvestment": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is FinancingReceivableModificationsPreModificationRecordedInvestment2."
+],
+"FinancingReceivableModificationsPreModificationRecordedInvestment1": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is FinancingReceivableModificationsPreModificationRecordedInvestment2."
+],
+"FinancingReceivableModificationsSubsequentDefaultNumberOfContracts": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is FinancingReceivableModificationsSubsequentDefaultNumberOfContracts1."
+],
+"FinancingReceivableModificationsSubsequentDefaultRecordedInvestment": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is FinancingReceivableModificationsSubsequentDefaultRecordedInvestment1."
+],
+"FinancingReceivableTroubledDebtRestructuringsAxis": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is FinancingReceivableTroubledDebtRestructuringAxis."
+],
+"FinancingReceivableTroubledDebtRestructuringsDomain": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is FinancingReceivableTroubledDebtRestructuringDomain."
+],
+"FinancingReceivableTroubledDebtRestructuringsThatSubsequentlyDefaultedAxis": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is FinancingReceivableTroubledDebtRestructuringAxis."
+],
+"FinancingReceivableTroubledDebtRestructuringsThatSubsequentlyDefaultedDomain": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is FinancingReceivableTroubledDebtRestructuringDomain."
+],
+"FiniteLivedCoalSupplyAgreementGross": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FiniteLivedIntangibleAssetsGross and members of FiniteLivedIntangibleAssetsByMajorClassAxis."
+],
+"FiniteLivedComputerSoftwareGross": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is CapitalizedComputerSoftwareGross."
+],
+"FiniteLivedCopyrightsGross": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FiniteLivedIntangibleAssetsGross and members of FiniteLivedIntangibleAssetsByMajorClassAxis."
+],
+"FiniteLivedDistributionRightsGross": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FiniteLivedIntangibleAssetsGross and members of FiniteLivedIntangibleAssetsByMajorClassAxis."
+],
+"FiniteLivedFranchiseRightsGross": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FiniteLivedIntangibleAssetsGross and members of FiniteLivedIntangibleAssetsByMajorClassAxis."
+],
+"FiniteLivedIntangibleAssetsAbstract": [
+"2012-01-31",
+"This element has been deprecated."
+],
+"FiniteLivedIntangibleAssetsAcquired": [
+"2013-01-31",
+"Element was deprecated because it was incorrectly defined.  Possible replacement element is FiniteLivedIntangibleAssetsAcquired1."
+],
+"FiniteLivedIntangibleAssetsAmortizationExpense": [
+"2012-01-31",
+"Element was deprecated due to redundancy. Possible replacement is AmortizationOfIntangibleAssets."
+],
+"FiniteLivedIntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationGross": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FiniteLivedIntangibleAssetsGross and members of FiniteLivedIntangibleAssetsByMajorClassAxis."
+],
+"FiniteLivedIntangibleAssetsAverageUsefulLife": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is FiniteLivedIntangibleAssetUsefulLife."
+],
+"FiniteLivedIntangibleAssetsFutureAmortizationExpense": [
+"2012-01-31",
+"Element was deprecated because it has a duration period type. Possible replacement is FiniteLivedIntangibleAssetsNet."
+],
+"FiniteLivedIntangibleAssetsRemainingAmortizationPeriod": [
+"2013-01-31",
+"Element was deprecated because it is has a stringItemType attribute. Possible replacement is FiniteLivedIntangibleAssetsRemainingAmortizationPeriod1."
+],
+"FiniteLivedIntangibleAssetsUsefulLife": [
+"2012-01-31",
+"Element was deprecated because it has an integerItemType. Possible replacement is FiniteLivedIntangibleAssetUsefulLife."
+],
+"FiniteLivedIntangibleAssetsUsefulLifeMaximum": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacements are FiniteLivedIntangibleAssetUsefulLife and RangeAxis (MaximumMember)."
+],
+"FiniteLivedIntangibleAssetsUsefulLifeMinimum": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacements are FiniteLivedIntangibleAssetUsefulLife and RangeAxis (MinimumMember)."
+],
+"FiniteLivedIntangibleAssetsWeightedAveragePeriodPriorToNextRenewalOrExtension": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is FiniteLivedIntangibleAssetWeightedAveragePeriodBeforeNextRenewalOrExtension."
+],
+"FiniteLivedIntangibleAssetsWeightedAverageUsefulLife": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is FiniteLivedIntangibleAssetUsefulLife."
+],
+"FiniteLivedMediaContentGross": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FiniteLivedIntangibleAssetsGross and members of FiniteLivedIntangibleAssetsByMajorClassAxis."
+],
+"FiniteLivedRoyaltyGross": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FiniteLivedIntangibleAssetsGross and members of FiniteLivedIntangibleAssetsByMajorClassAxis."
+],
+"FiniteLivedTradeSecretsGross": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FiniteLivedIntangibleAssetsGross and members of FiniteLivedIntangibleAssetsByMajorClassAxis."
+],
+"FiniteLivedTransmissionServiceAgreementGross": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FiniteLivedIntangibleAssetsGross and members of FiniteLivedIntangibleAssetsByMajorClassAxis."
+],
+"FiveYearDisclosureDomain": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept modeled as a dimension was replaced with line items. Possible replacements are line items within ScheduleOfLifeSettlementContractsFairValueMethodTextBlock and ScheduleOfLifeSettlementContractsInvestmentMethodTextBlock."
+],
+"FiveYearScheduleOfMaturitiesOfDebtOfParentCompanyAbstract": [
+"2014-01-31",
+"Element was deprecated."
+],
+"FiveYearScheduleOfMaturitiesOfParentCompanyRepaymentOfPrincipleInYearThree": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInYearThree."
+],
+"FiveYearScheduleOfMaturitiesOfParentCompanyRepaymentsOfPrincipalAfterYearFive": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalAfterYearFive."
+],
+"FiveYearScheduleOfMaturitiesOfParentCompanyRepaymentsOfPrincipleInYearFive": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInYearFive."
+],
+"FiveYearScheduleOfMaturitiesOfParentCompanyRepaymentsOfPrincipleInYearFour": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInYearFour."
+],
+"FiveYearScheduleOfMaturitiesOfParentCompanyRepaymentsOfPrincipleInYearTwo": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInYearTwo."
+],
+"FiveYearScheduleOfMaturitiesOfParentCompanyRepaymentsOfPrincipleWithinOneYear": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInNextTwelveMonths."
+],
+"FloorBrokerageExchangeClearanceFeesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is FloorBrokerageExchangeAndClearanceFees."
+],
+"FloorBrokerageMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is FloorBrokerage."
+],
+"ForeignCurrencyContractAssetFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
+],
+"ForeignCurrencyContractAssetFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
+],
+"ForeignCurrencyContractsFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
+],
+"ForeignCurrencyContractsFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
+],
+"ForeignCurrencyDerivativeAssetsAtFairValue": [
+"2014-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeFairValueOfDerivativeAsset and ForeignExchangeContractMember."
+],
+"ForeignCurrencyDerivativeLiabilitiesAtFairValue": [
+"2014-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeFairValueOfDerivativeLiability and ForeignExchangeContractMember."
+],
+"ForeignCurrencyDerivativesAtFairValueNet": [
+"2014-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeFairValueOfDerivativeNet and ForeignExchangeContractMember."
+],
+"ForeignCurrencyDerivativesAtFairValueNetAbstract": [
+"2014-01-31",
+"Element was deprecated."
+],
+"ForeignCurrencyExchangeRateRemeasurement": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is ForeignCurrencyExchangeRateRemeasurement1."
+],
+"ForeignCurrencyExchangeRateTranslation": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is ForeignCurrencyExchangeRateTranslation1."
+],
+"ForeignEarningsRepatriatedUnderAmericanJobsCreationActOf2004Abstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"ForeignEarningsRepatriatedUnderAmericanJobsCreationActOf2004Description": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"ForeignEarningsRepatriatedUnderAmericanJobsCreationActOf2004RepatriatedEarnings": [
+"2013-01-31",
+"Element was deprecated because the guidance related to this element is no longer effective.  Possible replacement is ForeignEarningsRepatriated."
+],
+"ForeignReinsuranceTransactionsAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"ForeignReinsuranceUnderOpenYearMethodAdditions": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"ForeignReinsuranceUnderOpenYearMethodPremiumsClaimsAndExpense": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"ForeignReinsuranceUnderOpenYearMethodPremiumsInUnderwritingAccount": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ForeignReinsuranceUnderOpenYearMethodPremiums."
+],
+"ForwardContractIndexedToIssuersEquityRedeemableStockRedemptionRequirements": [
+"2012-01-31",
+"Element was deprecated because it has a stringItemType. Possible replacement is ForwardContractIndexedToIssuersEquityRedeemableStockRedemptionRequirementsAmount."
+],
+"ForwardContractIndexedToIssuersEquityRedeemableStockRedemptionRequirementsAmount": [
+"2013-01-31",
+"Element was deprecated because it has debit balance and duration period type attributes. Possible replacement is OptionIndexedToIssuersEquityRedeemableStockRedemptionRequirementsAmount1."
+],
+"ForwardContractIndexedToIssuersEquitySettlementAlternativesAtFairValue": [
+"2012-01-31",
+"Element was deprecated because it has a stringItemType. Possible replacements are ForwardContractIndexedToIssuersEquitySettlementAlternativesCashAtFairValue or ForwardContractIndexedToIssuersEquitySettlementAlternativesSharesAtFairValue."
+],
+"FuelTransportationMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is FuelMember."
+],
+"FurnitureAndEquipmentRentalExpenseOperatingLeaseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is LeaseAndRentalExpense."
+],
+"FutureAmortizationExpenseAfterYearFive": [
+"2012-01-31",
+"Element was deprecated because it has a duration period type. Possible replacement is FiniteLivedIntangibleAssetsAmortizationExpenseAfterYearFive."
+],
+"FutureAmortizationExpenseRemainderOfFiscalYear": [
+"2012-01-31",
+"Element was deprecated because it has a duration period type. Possible replacement is FiniteLivedIntangibleAssetsAmortizationExpenseRemainderOfFiscalYear."
+],
+"FutureAmortizationExpenseYearFive": [
+"2012-01-31",
+"Element was deprecated because it has a duration period type. Possible replacement is FiniteLivedIntangibleAssetsAmortizationExpenseYearFive."
+],
+"FutureAmortizationExpenseYearFour": [
+"2012-01-31",
+"Element was deprecated because it has a duration period type. Possible replacement is FiniteLivedIntangibleAssetsAmortizationExpenseYearFour."
+],
+"FutureAmortizationExpenseYearOne": [
+"2012-01-31",
+"Element was deprecated because it has a duration period type. Possible replacement is FiniteLivedIntangibleAssetsAmortizationExpenseNextTwelveMonths."
+],
+"FutureAmortizationExpenseYearThree": [
+"2012-01-31",
+"Element was deprecated because it has a duration period type. Possible replacement is FiniteLivedIntangibleAssetsAmortizationExpenseYearThree."
+],
+"FutureAmortizationExpenseYearTwo": [
+"2012-01-31",
+"Element was deprecated because it has a duration period type. Possible replacement is FiniteLivedIntangibleAssetsAmortizationExpenseYearTwo."
+],
+"GainLossFromPriceRiskManagementActivityMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossFromPriceRiskManagementActivity."
+],
+"GainLossFromSaleOfFinancialAssetsInSecuritizationsOrAssetBackedFinancingArrangement": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is SecuritizationFinancialAssetForWhichTransferIsAccountedAsSaleGainLossOnSale."
+],
+"GainLossOnCondemnationNetOfTaxMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"GainLossOnCreditRiskDerivativesNet": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeGainLossOnDerivativeNet and members of CreditDerivativesByContractTypeAxis."
+],
+"GainLossOnCreditRiskHedgeIneffectiveness": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeNetHedgeIneffectivenessGainLoss and members of CreditDerivativesByContractTypeAxis."
+],
+"GainLossOnDerivativesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is UnrealizedGainLossOnDerivatives."
+],
+"GainLossOnDispositionOfAssetsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnDispositionOfAssets."
+],
+"GainLossOnDispositionOfOtherAssetsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnSaleOfOtherAssets."
+],
+"GainLossOnDispositionOfProperty": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is GainLossOnDispositionOfAssets."
+],
+"GainLossOnDispositionOfPropertyMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnDispositionOfAssets1."
+],
+"GainLossOnInvestmentsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnInvestments."
+],
+"GainLossOnOilAndGasHedgingActivityMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"GainLossOnSaleOfInterestInProjectsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"GainLossOnSaleOfLeasedAssetsNetOperatingLeasesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"GainLossOnSaleOfLoansReceivableMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"GainLossOnSaleOfOilAndGasPropertiesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnSaleOfProperty."
+],
+"GainLossOnSaleOfSubsidiarysStockMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"GainLossOnSaleOfTradeReceivablesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnSaleOfAccountsReceivable."
+],
+"GainLossOnSettlementOfDerivativeInstrumentMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnSaleOfDerivatives."
+],
+"GainOnPurchaseOfBusiness": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is BusinessCombinationBargainPurchaseGainRecognizedAmount."
+],
+"GainOnPurchaseOfBusinessMember": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"GainOrLossFromSaleOfFinancialAssetsInSecuritizations": [
+"2012-01-31",
+"Element was deprecated because it has a stringItemType. Possible replacement is SecuritizationFinancialAssetForWhichTransferIsAccountedAsSaleGainLossOnSale."
+],
+"GainsLossesOnSalesOfAssetsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnDispositionOfAssets1."
+],
+"GainsLossesOnSalesOfOtherAssets": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is GainLossOnSaleOfOtherAssets."
+],
+"GasAndOilAcreageDevelopedGross": [
+"2012-01-31",
+"Element was deprecated because it has an integerItemType. Possible replacement is GasAndOilAreaDevelopedGross."
+],
+"GasAndOilAcreageDevelopedNet": [
+"2012-01-31",
+"Element was deprecated because it has an integerItemType. Possible replacement is GasAndOilAreaDevelopedNet."
+],
+"GasAndOilAcreageUndevelopedGross": [
+"2012-01-31",
+"Element was deprecated because it has an integerItemType. Possible replacement is GasAndOilAreaUndevelopedGross."
+],
+"GasAndOilAcreageUndevelopedNet": [
+"2012-01-31",
+"Element was deprecated because it has an integerItemType. Possible replacement is GasAndOilAreaUndevelopedNet."
+],
+"GeographicalIntersegmentEliminationsMember": [
+"2013-01-31",
+"Element was deprecated due to remodeling of Segment area. Possible replacements are members of ConsolidationItemsAxis."
+],
+"GoodwillAllocationAdjustment": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is GoodwillPurchaseAccountingAdjustments."
+],
+"GuaranteedBenefitLiabilityGross": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LiabilitiesForGuaranteesOnLongDurationContractsGuaranteedBenefitLiabilityGross."
+],
+"GuaranteedBenefitsIncurred": [
+"2013-01-31",
+"Element was deprecated because it has a stringItemType attribute. Possible replacement is LiabilitiesForGuaranteesOnLongDurationContractsIncurredBenefits1."
+],
+"GuaranteedBenefitsPaid": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LiabilitiesForGuaranteesOnLongDurationContractsBenefitsPaid."
+],
+"GuaranteesFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
+],
+"GuaranteesFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
+],
+"GuarantorObligationsByUnderlyingAssetClassAxis": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is UnderlyingAssetClassAxis."
+],
+"HealthCareOrganizationAmountOfWriteOffsOfAllowanceForDoubtfulAccounts": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is AllowanceForDoubtfulAccountsReceivableWriteOffs."
+],
+"HealthCareOrganizationChangeInWriteOffs": [
+"2014-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is AllowanceForDoubtfulAccountsReceivableWriteOffs."
+],
+"HedgeDesignationsUsedForCreditRiskDerivatives": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
+],
+"HeldToMaturitySecuritiesContinuousUnrealizedLossPosition12MonthsOrLongerAggregateLosses": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is HeldToMaturitySecuritiesContinuousUnrealizedLossPosition12MonthsOrLongerAggregateLoss."
+],
+"HeldToMaturitySecuritiesContinuousUnrealizedLossPositionAggregateLosses": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is HeldToMaturitySecuritiesContinuousUnrealizedLossPositionAggregateLoss."
+],
+"HeldToMaturitySecuritiesContinuousUnrealizedLossPositionLessThan12MonthsAggregateLosses": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is HeldToMaturitySecuritiesContinuousUnrealizedLossPositionLessThan12MonthsAggregateLoss."
+],
+"HeldToMaturitySecuritiesDebtMaturitiesFairValue": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is HeldToMaturitySecuritiesFairValue."
+],
+"HeldToMaturitySecuritiesDebtMaturitiesNetCarryingAmount": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is HeldToMaturitySecurities."
+],
+"HeldToMaturitySecuritiesFairValueDisclosure": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is HeldToMaturitySecuritiesFairValue."
+],
+"HeldToMaturitySecuritiesFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
+],
+"HeldToMaturitySecuritiesFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
+],
+"HeldToMaturitySecuritiesUnrecognizedHoldingLoss": [
+"2013-01-31",
+"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is HeldToMaturitySecuritiesUnrecognizedHoldingLosses."
+],
+"HeldtomaturitySecuritiesDebtMaturityDateRangeHigh": [
+"2012-01-31",
+"Element was deprecated because it has a durationStringItemType. Possible replacements are HeldtomaturitySecuritiesDebtMaturitiesDate and RangeAxis (MaximumMember)."
+],
+"HeldtomaturitySecuritiesDebtMaturityDateRangeLow": [
+"2012-01-31",
+"Element was deprecated because it has a durationStringItemType. Possible replacements are HeldtomaturitySecuritiesDebtMaturitiesDate and RangeAxis (MinimumMember)."
+],
+"HeldtomaturitySecuritiesInUnrealizedLossPositionsQualitativeDisclosureOtherThirdPartyGuaranteesDescription": [
+"2013-01-31",
+"Element was deprecated."
+],
+"HeldtomaturitySecuritiesUnrecognizedHoldingGain": [
+"2013-01-31",
+"Element was deprecated because it has debit balance and instant period type attributes. Possible replacement is HeldtomaturitySecuritiesUnrecognizedHoldingGains."
+],
+"ImpairedFinancingReceivableWithNoRelatedAllowanceAxis": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is FinancingReceivableRecordedInvestmentByClassOfFinancingReceivableAxis."
+],
+"ImpairedFinancingReceivableWithNoRelatedAllowanceMember": [
+"2012-01-31",
+"Element was deprecated because the concept was modeled as primary concepts. Possible replacement is FinancingReceivableRecordedInvestmentClassOfFinancingReceivableDomain."
+],
+"ImpairedFinancingReceivableWithRelatedAllowanceAxis": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is FinancingReceivableRecordedInvestmentByClassOfFinancingReceivableAxis."
+],
+"ImpairedFinancingReceivableWithRelatedAllowanceMember": [
+"2012-01-31",
+"Element was deprecated because the concept was modeled as primary concepts. Possible replacement is FinancingReceivableRecordedInvestmentClassOfFinancingReceivableDomain."
+],
+"ImpairedIntangibleAssetNameDomain": [
+"2012-01-31",
+"Element was deprecated. Possible replacements are IndefiniteLivedIntangibleAssetsMajorClassNameDomain and/or FiniteLivedIntangibleAssetsMajorClassNameDomain."
+],
+"ImpairedIntangibleAssetsByDescriptionAxis": [
+"2012-01-31",
+"Element was deprecated. Possible replacements are IndefiniteLivedIntangibleAssetsByMajorClassAxis and/or FiniteLivedIntangibleAssetsByMajorClassAxis."
+],
+"ImpairmentInValueOfAssetAxis": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
 "ImpairmentInValueOfAssetDomain": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"ImpairmentInValueOfAssetMember": [
+"2012-01-31",
+"Element was deprecated because the dimension of the financial reporting concept was remodeled."
+],
+"ImpairmentOfGoodwillMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GoodwillImpairmentLoss."
+],
+"ImpairmentOfIntangibleAssetsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ImpairmentOfIntangibleAssetsExcludingGoodwill."
+],
+"ImpairmentOrDisposalOfLongLivedIntangibleAssetsAssetsToBeSoldPolicy": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is ImpairmentOrDisposalOfLongLivedAssetsIncludingIntangibleAssetsPolicyPolicyTextBlock."
+],
+"ImpairmentOrDisposalOfLongLivedIntangibleAssetsImpairmentPolicy": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is ImpairmentOrDisposalOfLongLivedAssetsIncludingIntangibleAssetsPolicyPolicyTextBlock."
+],
+"IncentiveFeeAmountPaid": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is PaymentForIncentiveFee."
+],
+"IncomeBeforeExtraordinaryItemsMember": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"IncomeLossBeforeExtraordinaryItemsAndCumulativeEffectOfChangeInAccountingPrinciplePerOutstandingGeneralPartnershipUnit": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromOperationsBeforeExtraordinaryItemsPerOutstandingGeneralPartnershipUnitNetOfTax."
+],
+"IncomeLossBeforeExtraordinaryItemsAndCumulativeEffectOfChangeInAccountingPrinciplePerOutstandingLimitedPartnershipUnit": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromOperationsBeforeExtraordinaryItemsPerOutstandingLimitedPartnershipUnitBasicNetOfTax."
+],
+"IncomeLossBeforeExtraordinaryItemsAndCumulativeEffectOfChangeInAccountingPrinciplePerOutstandingLimitedPartnershipUnitDiluted": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromOperationsBeforeExtraordinaryItemsNetOfTaxPerOutstandingLimitedPartnershipUnitDiluted."
+],
+"IncomeLossFromContinuingOperationsPerOutstandingGeneralPartnershipUnit": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromContinuingOperationsPerOutstandingGeneralPartnershipUnitNetOfTax."
+],
+"IncomeLossFromContinuingOperationsPerOutstandingLimitedPartnershipUnit": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromContinuingOperationsPerOutstandingLimitedPartnershipUnitBasicNetOfTax."
+],
+"IncomeLossFromContinuingOperationsPerOutstandingLimitedPartnershipUnitDiluted": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromContinuingOperationsNetOfTaxPerOutstandingLimitedPartnershipUnitDiluted."
+],
+"IncomeLossFromDiscontinuedOperationsNetOfTaxPerOutstandingGeneralPartnershipUnit": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromDiscontinuedOperationsNetOfTaxPerOutstandingGeneralPartnershipUnit1."
+],
+"IncomeLossFromDiscontinuedOperationsNetOfTaxPerOutstandingLimitedPartnershipUnit": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromDiscontinuedOperationsNetOfTaxPerOutstandingLimitedPartnershipUnitBasic."
+],
+"IncomeLossFromDiscontinuedOperationsNetOfTaxPerOutstandingLimitedPartnershipUnitDiluted": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromDiscontinuedOperationsNetOfTaxPerOutstandingLimitedPartnershipUnitDiluted1."
+],
+"IncomeLossFromDispositionOfDiscontinuedOperationsForOtherStockPerBasicShare": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is IncomeLossFromDiscontinuedOperationsNetOfTaxPerBasicShare."
+],
+"IncomeLossFromEquityMethodInvestmentsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is IncomeLossFromEquityMethodInvestments."
+],
+"IncomeLossFromEquityMethodInvestmentsNetOfDistributionsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is IncomeLossFromEquityMethodInvestmentsNetOfDividendsOrDistributions."
+],
+"IncomeLossFromEquityRealEstatePartnershipsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is RealEstatePartnershipInvestmentSubsidiariesNetIncomeLossBeforeTax."
+],
+"IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingGeneralPartnershipUnit": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingGeneralPartnershipUnit1."
+],
+"IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingLimitedPartnershipAndGeneralPartnershipUnitBasic": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingLimitedPartnershipAndGeneralPartnershipUnitBasic1."
+],
+"IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingLimitedPartnershipUnit": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingLimitedPartnershipUnitBasic."
+],
+"IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingLimitedPartnershipUnitDiluted": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingLimitedPartnershipUnitDiluted1."
+],
+"IncomeStatementAndOtherComprehensiveIncomeLocationDomain": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is IncomeStatementLocationDomain."
+],
+"IncomeTaxExaminationInterestFromExamination": [
+"2013-01-31",
+"Element was deprecated because of redundancy.  Possible replacement is IncomeTaxExaminationInterestExpense."
+],
+"IncomeTaxExaminationLiabilityRecorded": [
+"2013-01-31",
+"Element was deprecated due to redundancy.  Possible replacement is IncomeTaxExaminationPenaltiesAndInterestAccrued."
+],
+"IncomeTaxExaminationPenaltiesFromExamination": [
+"2013-01-31",
+"Element was deprecated due to redundancy.  Possible replacement is IncomeTaxExaminationPenaltiesExpense."
+],
+"IncomeTaxExaminationRangeOfPossibleLosses": [
+"2013-01-31",
+"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is IncomeTaxExaminationEstimateOfPossibleLoss and members of RangeAxis."
+],
+"IncomeTaxExaminationYearSUnderExamination": [
+"2012-01-31",
+"Element was deprecated because it has a stringItemType. Possible replacement is IncomeTaxExaminationYearUnderExamination."
+],
+"IncomeTaxExpenseBenefitAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"IncomeTaxExpenseBenefitContinuingOperations": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is IncomeTaxExpenseBenefit."
+],
+"IncomeTaxExpenseBenefitContinuingOperationsDiscontinuedOperationsExtraordinaryItemsAbstract": [
+"2012-01-31",
+"This element has been deprecated because the children of this element have been relocated."
+],
+"IncomeTaxPenaltiesAndInterestAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"IncreaseDecreaseInBorrowedSecurities": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is IncreaseDecreaseInSecuritiesBorrowed."
+],
+"IncreaseDecreaseInCarryingValueOfAssetsReceivedAsConsiderationInDisposalOfBusiness": [
+"2013-01-31",
+"Element was deprecated."
+],
+"IncreaseDecreaseInDeferredRentReceivables": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is StraightLineRent."
+],
+"IncreaseDecreaseInFairValueOfHedgedItemInInterestRateFairValueHedge": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is IncreaseDecreaseInFairValueOfHedgedItemInInterestRateFairValueHedge1."
+],
+"IncreaseDecreaseInFairValueOfHedgedItemInPriceRiskFairValueHedge": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is IncreaseDecreaseInFairValueOfHedgedItemInPriceRiskFairValueHedge1."
+],
+"IncreaseDecreaseInFairValueOfInterestRateFairValueHedgingInstruments": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is IncreaseDecreaseInFairValueOfInterestRateFairValueHedgingInstruments1."
+],
+"IncreaseDecreaseInFairValueOfPriceRiskFairValueHedgingInstruments": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is IncreaseDecreaseInFairValueOfPriceRiskFairValueHedgingInstruments1."
+],
+"IncreaseDecreaseInFairValueOfUnhedgedDerivativeInstruments": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DerivativeInstrumentsNotDesignatedAsHedgingInstrumentsGainLossNet."
+],
+"IncreaseDecreaseInFilmCosts": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is IncreaseDecreaseInFilmCosts1."
+],
+"IncrementalEffectsOnBalanceSheetApplicationOfSFAS158RecognitionProvisionsBalanceSheetLineItemAxis": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is BalanceSheetLocationAxis."
+],
+"IndefiniteLivedIntangibleAssets": [
+"2012-01-31",
+"Element was deprecated due to redundancy. Possible replacement is IndefiniteLivedIntangibleAssetsExcludingGoodwill."
+],
+"IndefiniteLivedIntangibleAssetsAcquiredDuringPeriod": [
+"2013-01-31",
+"Element was deprecated because it was incorrectly defined.  Possible replacement element is IndefiniteLivedIntangibleAssetsAcquired."
+],
+"IndefiniteLivedIntangibleAssetsBySegmentLineItems": [
+"2012-01-31",
+"This element has been deprecated."
+],
+"IndefiniteLivedIntangibleAssetsImpairmentLosses": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is ImpairmentOfIntangibleAssetsIndefinitelivedExcludingGoodwill."
+],
+"IndefiniteLivedTradeDress": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are IndefiniteLivedIntangibleAssetsExcludingGoodwill and members of IndefiniteLivedIntangibleAssetsByMajorClassAxis."
+],
+"IndefiniteLivedTradeSecrets": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are IndefiniteLivedIntangibleAssetsExcludingGoodwill and members of IndefiniteLivedIntangibleAssetsByMajorClassAxis."
+],
+"IneffectivenessOnCreditRiskHedgesIsImmaterial": [
+"2013-01-31",
+"Element was deprecated because it is an invalid concept."
+],
+"InitialMeasurementOfInterestsContinuedToBeHeldByTransferorWhenSecuritizedFinancialAssetsAreAccountedForAsSalePolicy": [
+"2012-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"InstrumentAxis": [
+"2013-01-31",
+"Element was deprecated because it was incorrectly defined. Possible replacement is EnergyAxis."
+],
+"InstrumentTypeMember": [
+"2013-01-31",
+"Element was deprecated because it was incorrectly defined. Possible replacement is EnergyDomain."
+],
+"InsuranceRatiosComment": [
+"2013-01-31",
+"Element was deprecated."
+],
+"IntangibleAssetsArisingAcquiredInBusinessCombinationEstimatedAmountAmortizedYearOne": [
+"2012-01-31",
+"Element was deprecated because it has a period type of duration and a credit balance attribute. Possible replacement is IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationAmortizationExpenseNextTwelveMonths."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationEstimatedAmountAmortizedYearFive": [
+"2012-01-31",
+"Element was deprecated because it has a duration period type and a credit balance attribute. Possible replacement is IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationAmortizationExpenseYearFive."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationEstimatedAmountAmortizedYearFour": [
+"2012-01-31",
+"Element was deprecated because it has a duration period type and a credit balance attribute. Possible replacement is IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationAmortizationExpenseYearFour."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationEstimatedAmountAmortizedYearThree": [
+"2012-01-31",
+"Element was deprecated because it has a duration period type and a credit balance attribute. Possible replacement is IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationAmortizationExpenseYearThree."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationEstimatedAmountAmortizedYearTwo": [
+"2012-01-31",
+"Element was deprecated because it has a duration period type and a credit balance attribute. Possible replacement is IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationAmortizationExpenseYearTwo."
+],
+"InterestAndDividendIncomeMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is InvestmentIncomeInterestAndDividend."
+],
+"InterestRevenueExpense": [
+"2012-01-31",
+"Element was deprecated due to redundancy. Possible replacements are InterestRevenueExpenseNet or InterestIncomeExpenseNet."
+],
+"IntermediateLifePlantsEstimatedUsefulLife": [
+"2013-01-31",
+"Element was deprecated because it is has a stringItemType attribute. Possible replacement is IntermediateLifePlantsUsefulLife."
+],
+"InternalCreditRatingMember": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is InternalCreditAssessmentDomain."
+],
+"InternallyAssignedGradeMember": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is InternalCreditAssessmentDomain."
+],
+"InvestmentInFederalHomeLoanBankStockFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
+],
+"InvestmentInFederalHomeLoanBankStockFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
+],
+"InvestmentIncomeCategoriesDomain": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is InvestmentTypeCategorizationMember."
+],
+"InvestmentOwnedValuedByTrusteesFlag": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is InvestmentOwnedValuedByTrusteesFlag1."
+],
+"InvestmentOwnedZeroBalanceMayReflectAmountRoundedToZeroFlag": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is InvestmentOwnedZeroBalanceMayReflectAmountRoundedToZeroFlag1."
+],
+"InvestmentsFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
+],
+"InvestmentsFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
+],
+"InvestmentsImpairmentChargeMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ImpairmentOfInvestments."
+],
+"InvestmentsInAndAdvancesToAffiliatesBalanceContracts": [
+"2013-01-31",
+"Element was deprecated because it has a decimalItemType attribute. Possible replacement is InvestmentsInAndAdvancesToAffiliatesBalanceContracts1."
+],
+"InvestmentsInForeignSubsidiariesAndForeignCorporateJointVenturesThatAreEssentiallyPermanentInDurationMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are UndistributedEarningsOfForeignSubsidiaries,  DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferenceUndistributedEarningsOfForeignSubsidiaries, DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxableUndistributedEarningsOfForeignSubsidiaries, DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityUndistributedEarningsOfForeignSubsidiaries, DeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticableUndistributedEarningsOfForeignSubsidiaries."
+],
+"IssuanceDomain": [
+"2012-01-31",
+"Element was deprecated because it used a dimension to differentiate equity issuances. Possible replacement is the date context to differentiate equity issuances."
+],
+"IssuanceOfDebtMember": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"IssuanceOfEquityMember": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"LeaseConcessions": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is AmortizationOfLeaseIncentives."
+],
+"LeaseExpirationDate": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. Possible replacement is LeaseExpirationDate1."
+],
+"LeveragedBuyoutClosingFeesAndExpense": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutConsiderationPaidForOutstandingShares": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutContinuingOwnershipInterestByContinuingStockholders": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutCostOfTransactionChargedToExpense": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutCostOfTransactionChargedToExpenseAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"LeveragedBuyoutCostOfTransactionDescription": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutDescriptionOfEquityDebitResultingFromCarryoverBasis": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutMethodologyAndAssumptions": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutOptionCostChargedToExpense": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutOptionCostPreviouslyRecognized": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutOwnershipInterestOfNewInvestors": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutPercentageOfPurchasePriceAllocatedToAssetsAndLiabilitiesAcquiredAtCarryoverBasis": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutPercentageOfPurchasePriceAllocatedToAssetsAndLiabilitiesAcquiredAtFairValue": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutPredecessorBasisAdjustment": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutPrepaymentPenaltiesOnRetiredDebt": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutProfessionalFeesAndOther": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutRedemptionOfShareBasedAwards": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutRepaymentOfExistingDebt": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutTransactionDisclosureTextBlock": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutUsesOfCashInLeveragedBuyoutTransaction": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutUsesOfCashInLeveragedBuyoutTransactionAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"LiabilitiesForGuaranteesOnLongDurationContractsIncurredBenefits": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is LiabilitiesForGuaranteesOnLongDurationContractsIncurredBenefits1."
+],
+"LiabilitiesOfAssetsHeldForSale": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LiabilitiesOfDisposalGroupIncludingDiscontinuedOperation."
+],
+"LiabilitiesRelatedToInvestmentContractsFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
+],
+"LiabilitiesRelatedToInvestmentContractsFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
+],
+"LiabilitiesSubjectToCompromiseBalanceAtBankruptcyEffectiveDate": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LiabilitiesSubjectToCompromise."
+],
+"LiabilitiesSubjectToCompromiseEndOfPeriod": [
+"2013-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is LiabilitiesSubjectToCompromise."
+],
+"LiabilityForFuturePolicyBenefitByProductSegmentAxis": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"LiabilityForFuturePolicyBenefitByProductSegmentDomain": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ReinsurancePremiumsForInsuranceCompaniesByProductSegmentDomain."
+],
+"LiabilityForFuturePolicyBenefitsLiabilitiesAssumed": [
+"2013-01-31",
+"Element was deprecated because it has credit balance attribute. Possible replacement is LiabilityForFuturePolicyBenefitsPeriodExpense."
+],
+"LiabilityForTitleClaimsAndClaimsAdjustmentExpenseAbstract": [
+"2014-01-31",
+"Element was deprecated."
+],
+"LiabilityForTitleClaimsAndClaimsAdjustmentExpenseIncurredButNotReportedIBNR": [
+"2014-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseIncurredButNotReportedIBNRClaimsAmount and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"LiabilityForTitleClaimsAndClaimsAdjustmentExpenseKnownClaims": [
+"2014-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseReportedClaimsAmount and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"LiabilityForUnpaidClaimsAdjustmentExpenseByExpenseTypeTextBlock": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ScheduleOfLiabilityForUnpaidClaimsAndClaimsAdjustmentExpense."
+],
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAdjustmentOfOpeningBalanceAmount": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseOpeningBalanceAdjustments."
+],
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAdjustmentOfOpeningBalanceAxis": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacements are AdjustmentsForChangeInAccountingPrincipleAxis and ErrorCorrectionsAndPriorPeriodAdjustmentsRestatementByRestatementPeriodAndAmountAxis."
+],
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAdjustmentOfOpeningBalanceLineItems": [
+"2014-01-31",
+"Element was deprecated."
+],
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAdjustmentOfOpeningBalanceTable": [
+"2014-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAdjustmentOfOpeningBalanceTypeDomain": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacements are ChangeInAccountingPrincipleMember and AdjustmentsForErrorCorrectionDomain."
+],
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseClaimsPaid": [
+"2014-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is PaymentsForLossesAndLossAdjustmentExpense."
+],
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseClaimsPaidCurrentYear": [
+"2014-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseClaimsPaidCurrentYear1."
+],
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseClaimsPaidPriorYears": [
+"2014-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseClaimsPaidPriorYears1."
+],
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseGross": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LiabilityForClaimsAndClaimsAdjustmentExpense."
+],
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseIncurredButNotReportedIBNRClaimsCommentary": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LiabilityForClaimsAndClaimsAdjustmentExpenseMethodologiesAndAssumptions."
+],
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseIncurredClaims": [
+"2014-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseIncurredClaims1."
+],
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseIncurredClaimsCurrentYear": [
+"2014-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is SupplementalInformationForPropertyCasualtyInsuranceUnderwritersCurrentYearClaimsAndClaimsAdjustmentExpense."
+],
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseIncurredClaimsPriorYears": [
+"2014-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is SupplementalInformationForPropertyCasualtyInsuranceUnderwritersPriorYearClaimsAndClaimsAdjustmentExpense."
+],
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseReportedAndIncurredButNotReportedIBNRClaims": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LiabilityForClaimsAndClaimsAdjustmentExpense."
+],
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseReportedAndIncurredButNotReportedIBNRClaimsAbstract": [
+"2014-01-31",
+"Element was deprecated."
+],
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseReportedAndIncurredButNotReportedIBNRClaimsCommentary": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LiabilityForClaimsAndClaimsAdjustmentExpenseMethodologiesAndAssumptions."
+],
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseReportedAndIncurredButNotReportedIBNRClaimsDisclosureAbstract": [
+"2014-01-31",
+"Element was deprecated."
+],
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseReportedClaimsCommentary": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LiabilityForClaimsAndClaimsAdjustmentExpenseMethodologiesAndAssumptions."
+],
+"LifeInsuranceInForceMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are LifeInsuranceInForceGross, LifeInsuranceInForceCeded, LifeInsuranceInForceAssumed, LifeInsuranceInForceNet, or LifeInsuranceInForcePercentageAssumedToNet."
+],
+"LifeInsuranceInForcePremiumsPercentageAssumedToNet": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is LifeInsuranceInForcePercentageAssumedToNet."
+],
+"LifeSettlementContractsFairValueMethodDisclosureItemsLineItems": [
+"2012-01-31",
+"This element has been deprecated as the maturity schedule has been remodeled using line items instead of dimensions. If you have used this element in the past, use the line items found as children of ScheduleOfLifeSettlementContractsFairValueMethodTextBlock."
+],
+"LifeSettlementContractsInvestmentMethodDisclosureItemsLineItems": [
+"2012-01-31",
+"This element has been deprecated as the maturity schedule has been remodeled using line items instead of dimensions. If you have used this element in the past, use the line items found as children of ScheduleOfLifeSettlementContractsInvestmentMethodTextBlock."
+],
+"LineItemForCreditRiskDerivativesOnBalanceSheet": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are members of BalanceSheetLocationAxis."
+],
+"LineItemForGainLossOnCreditRiskDerivativeOnIncomeStatement": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are members of IncomeStatementLocationAxis."
+],
+"LineOfCreditFacilityAmountOutstanding": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LineofCredit."
+],
+"LineOfCreditFacilityDateOfFirstRequiredPayment": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. Possible replacement is LineOfCreditFacilityDateOfFirstRequiredPayment1."
+],
+"LineOfCreditFacilityDecreaseForgiveness": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is LineOfCreditFacilityDecreaseForgiveness1."
+],
+"LineOfCreditFacilityDecreaseRepayments": [
+"2013-01-31",
+"Element was deprecated due to redundancy.  Possible replacement is RepaymentsOfLinesOfCredit."
+],
+"LineOfCreditFacilityExpirationDate": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. Possible replacement is LineOfCreditFacilityExpirationDate1."
+],
+"LineOfCreditFacilityIncreaseAdditionalBorrowings": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is ProceedsFromLinesOfCredit."
+],
+"LineOfCreditFacilityInitiationDate": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. Possible replacement is LineOfCreditFacilityInitiationDate1."
+],
+"LineOfCreditFacilityRevolvingCreditDescription": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are LineOfCreditFacilityDescription and members of CreditFacilityAxis."
+],
+"LinesOfCreditFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
+],
+"LinesOfCreditFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
+],
+"LiquidationDate": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. Possible replacement is LiquidationDate1."
+],
+"ListedOptionsMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ExchangeTradedOptionsMember."
+],
+"LitigationSettlementGross": [
+"2013-01-31",
+"Element was deprecated. Possible replacement is LitigationSettlementAmount."
+],
+"LoanPortfolioExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is LoanPortfolioExpense."
+],
+"LoanProcessingFeeMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is LoanProcessingFee."
+],
+"LoansAndLeasesReceivableMortgageAndMortgageBackedSecuritiesValuationPolicy": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LoansAndLeasesReceivableValuationPolicy."
+],
+"LoansHeldForSaleFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
+],
+"LoansHeldForSaleFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
+],
+"LoansPayableFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
+],
+"LoansPayableFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
+],
+"LoansReceivableFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
+],
+"LoansReceivableFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
+],
+"LoansReceivableWithFixedRatesOfInterest": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is LoansReceivableWithFixedRatesOfInterest1."
+],
+"LoansReceivableWithVariableRatesOfInterest": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is LoansReceivableWithVariableRatesOfInterest1."
+],
+"LoansToFinanceLeveragedBuyout": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LongLivedAssetsHeldForSaleGainLossOnSale": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is GainLossOnSaleOfPropertyPlantEquipment."
+],
+"LongLivedAssetsHeldForSaleImpairmentCharge": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is ImpairmentOfLongLivedAssetsToBeDisposedOf."
+],
+"LongLivedAssetsHeldForSaleProceedsFromSale": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is ProceedsFromSaleOfPropertyPlantAndEquipment."
+],
+"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInNextRollingTwelveMonths": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInNextRollingTwelveMonths."
+],
+"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInRemainderOfFiscalYear": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalRemainderOfFiscalYear."
+],
+"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInRollingAfterYearFive": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInRollingAfterYearFive."
+],
+"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInRollingYearFive": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInRollingYearFive."
+],
+"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInRollingYearFour": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInRollingYearFour."
+],
+"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInRollingYearThree": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInRollingYearThree."
+],
+"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInRollingYearTwo": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInRollingYearTwo."
+],
+"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalRollingMaturityAbstract": [
+"2014-01-31",
+"Element was deprecated."
+],
+"LongTermPurchaseCommitmentTimePeriod": [
+"2014-01-31",
+"Element was deprecated because it has a stringItemType attribute. Possible replacement is LongtermPurchaseCommitmentPeriod."
+],
+"LossContingencyAccrualCarryingValueProvision": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is LossContingencyAccrualProvision."
+],
+"LossContingencyRelatedReceivableCarryingValue": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is LossContingencyReceivable."
+],
+"LossContingencyRelatedReceivableCarryingValueCurrent": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is LossContingencyReceivableCurrent."
+],
+"LossContingencyRelatedReceivableCarryingValueNoncurrent": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is LossContingencyReceivableNoncurrent."
+],
+"LossContingencySettlementAgreementConsideration": [
+"2012-01-31",
+"Element was deprecated because it has a stringItemType attribute. Possible replacement is LitigationSettlementAmount."
+],
+"LossContingencySettlementAgreementConsideration1": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is LitigationSettlementAmount."
+],
+"LossOnReceivablesAxis": [
 "2013-01-31",
 "Element was deprecated due to remodeling of topic area."
 ],
@@ -6295,752 +4591,2456 @@
 "2013-01-31",
 "Element was deprecated due to remodeling of topic area."
 ],
-"VariableInterestEntityNonconsolidatedComparisonOfCarryingAmountOfAssetsAndLiabilitiesToMaximumLossExposureExplanationQuantitativeInformationDisadvantageous": [
-"2012-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FairValueAssetsMeasuredOnRecurringBasisAccountsReceivableValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
-],
-"DefinedBenefitPlanEquitySecurities": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacement is DefinedBenefitPlanWeightedAverageAssetAllocations."
-],
-"SharebasedCompensationSharesAuthorizedUnderStockOptionPlansExercisePriceRangeExercisableOptionsWeightedAverageRemainingContractualTerm1": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is SharebasedCompensationSharesAuthorizedUnderStockOptionPlansExercisePriceRangeExercisableOptionsWeightedAverageRemainingContractualTerm2."
-],
-"DevelopmentStageEnterpriseCumulativeRevenue": [
-"2012-01-31",
-"Element was deprecated because different elements should not be used to tag revenue for the period and to tag revenue since inception. Possible replacement is Revenues."
-],
-"GuaranteesFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationCapitalLeaseObligationAccrual": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"OtherTaxCarryforwardDescription": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TaxCreditCarryforwardDescription."
-],
-"AccrualForEnvironmentalLossContingenciesNet": [
-"2013-01-31",
-"Element was deprecated due to redundancy.  Possible replacement is AccrualForEnvironmentalLossContingencies."
-],
-"RoyaltyPaymentsExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is RoyaltyExpense."
-],
-"FederalHomeLoanBankAdvancesShortTerm": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is FederalHomeLoanBankAdvancesMaturitiesSummaryDueWithinOneYearOfBalanceSheetDate."
-],
-"QualitativeAndQuantitativeInformationAssetOrLiabilityTransferorsContinuingInvolvementSecuritizationOrAssetbackedFinancingPrincipalAmountOutstandingContinuedRecognitionAmount": [
-"2014-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is SecuritizedAssetsAndAnyOtherFinancialAssetsManagedTogetherPrincipalAmountOutstanding."
-],
-"AmountAvailableForDividendDistributionWithoutPriorApprovalFromRegulatoryAgency": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is StatutoryAccountingPracticesStatutoryAmountAvailableForDividendPaymentsWithoutRegulatoryApproval."
-],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardAwardVestingPeriodMaximum": [
-"2012-01-31",
-"Element was deprecated because it has a dateStringItemType. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardAwardVestingPeriod1, which has been modeled as a dimension."
-],
-"InvestmentsImpairmentChargeMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ImpairmentOfInvestments."
-],
-"LoansReceivableWithVariableRatesOfInterest": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is LoansReceivableWithVariableRatesOfInterest1."
-],
-"InvestmentIncomeCategoriesDomain": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is InvestmentTypeCategorizationMember."
-],
-"DefinedBenefitPlanAmountsThatWillBeAmortizedFromAccumulatedOtherComprehensiveIncomeLossInNextFiscalYear": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is DefinedBenefitPlanAmountToBeAmortizedFromAccumulatedOtherComprehensiveIncomeLossNextFiscalYear."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisDepositsValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
-],
-"ComponentOfOtherIncomeNonoperatingNameDomain": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"AssetsHeldForSaleCurrentAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"ScheduleOfFiniteLivedIntangibleAssetsByMajorClassTable": [
-"2012-01-31",
-"Element was deprecated because the dimension of the financial reporting concept was remodeled. Possible replacements are ScheduleOfFiniteLivedIntangibleAssetsTable and members of FiniteLivedIntangibleAssetsByMajorClassAxis."
-],
-"OtherDerivativesNotDesignatedAsHedgingInstrumentsAssetsAtFairValue": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DerivativeInstrumentsNotDesignatedAsHedgingInstrumentsAssetAtFairValue."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisAccruedLiabilitiesValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
-],
-"IncreaseDecreaseInFairValueOfInterestRateFairValueHedgingInstruments": [
-"2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is IncreaseDecreaseInFairValueOfInterestRateFairValueHedgingInstruments1."
-],
-"DefinedContributionPlanMaximumAnnualContributionPerEmployeePercent": [
-"2013-01-31",
-"Element was deprecated because it was incorrectly defined. Possible replacement is DefinedContributionPlanMaximumAnnualContributionsPerEmployeePercent."
-],
-"SummaryOfOtherTaxCarryforwardsTextBlock": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is SummaryOfTaxCreditCarryforwardsTextBlock."
-],
-"EmployeeServiceShareBasedCompensationPolicyForIssuingSharesUponExercise": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardPolicyForIssuingSharesUponExercise."
-],
-"BusinessAcquisitionPreexistingRelationshipAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"DerivativeAverageExchangeRateCap": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is DerivativeAverageExchangeRateCap1."
-],
-"SecuritizationFinancialAssetForWhichTransferIsAccountedAsSaleAxis": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is FinancialInstrumentAxis."
-],
-"ProductLiabilityContingencyLossInestimableExplanation": [
-"2012-01-31",
-"Element was deprecated because it has a durationStringItemType. Possible replacement is ProductLiabilityContingencyLossInestimableStatement."
-],
-"ExperienceRatedRefundsReceivable": [
-"2013-01-31",
-"Element was deprecated due to remodeling of reinsurance topic area."
-],
-"GainLossFromPriceRiskManagementActivityMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossFromPriceRiskManagementActivity."
-],
-"SubordinatedNotesToFinanceLeveragedBuyout": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LineOfCreditFacilityDecreaseForgiveness": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is LineOfCreditFacilityDecreaseForgiveness1."
-],
-"DebtInstrumentConvertibleEarliestDate": [
-"2012-01-31",
-"Element was deprecated because it has a dateStringItemType. Possible replacement is DebtInstrumentConvertibleEarliestDate1."
-],
-"OtherComprehensiveIncomeForeignCurrencyTransactionAndTranslationAdjustmentNetOfTaxPeriodIncreaseDecrease": [
-"2012-01-31",
-"Element was deprecated because it has no balance attribute. Possible replacement is OtherComprehensiveIncomeLossForeignCurrencyTransactionAndTranslationAdjustmentNetOfTax."
-],
-"BusinessAcquisitionContingentConsiderationSharesIssuable": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"RestructuringAndRelatedCostExpectedCostRemaining": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is RestructuringAndRelatedCostExpectedCostRemaining1."
-],
-"GainLossOnDispositionOfPropertyMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnDispositionOfAssets1."
-],
-"ScheduleOfFiniteLivedIntangibleAssetsByMajorClassTextBlock": [
-"2012-01-31",
-"Element was deprecated because the dimension of the financial reporting concept was remodeled. Possible replacement is ScheduleOfFiniteLivedIntangibleAssetsTableTextBlock."
-],
-"LeaseExpirationDate": [
-"2012-01-31",
-"Element was deprecated because it has a dateStringItemType. Possible replacement is LeaseExpirationDate1."
-],
-"GoodwillAllocationAdjustment": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is GoodwillPurchaseAccountingAdjustments."
-],
-"ReinsuranceEffectOnOperations": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is NaturePurposeAndEffectOfReinsuranceTransactions."
-],
-"BusinessAcquisitionPurchasePriceAllocationNoncurrentAssets": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"ScheduleOfIndefiniteLivedIntangibleAssetsBySegmentTable": [
-"2012-01-31",
-"Element was deprecated because the dimension of the financial reporting concept was remodeled. Possible replacements are ScheduleOfIndefiniteLivedIntangibleAssetsTable and members of StatementBusinessSegmentsAxis."
-],
-"LineOfCreditFacilityIncreaseAdditionalBorrowings": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is ProceedsFromLinesOfCredit."
-],
-"DebtInstrumentFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
-],
-"EquityIssuedSinceInceptionByIssuanceAxis": [
-"2012-01-31",
-"Element was deprecated because it used a dimension to differentiate equity issuances. Possible replacement is the date context to differentiate equity issuances."
-],
-"FutureAmortizationExpenseYearTwo": [
-"2012-01-31",
-"Element was deprecated because it has a duration period type. Possible replacement is FiniteLivedIntangibleAssetsAmortizationExpenseYearTwo."
-],
-"OtherTaxCarryforwardLineItems": [
-"2013-01-31",
-"Element was deprecated."
-],
-"OtherPremiumRevenueNet": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is PremiumsEarnedNetOtherInsurance."
-],
-"MandatorilyRedeemablePreferredStockFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
-],
-"DescriptionOfChangeInCashFlowProjectionsEstimate": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"PremiumsReceivableAllowanceForDoubtfulAccountsProvisionChargedToExpense": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is PremiumsReceivableAllowanceForDoubtfulAccountsProvisionChargedToExpense1."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisMandatorilyRedeemablePreferredStockValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
-],
-"OneYearFromBalanceSheetDateMember": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept modeled as a dimension was replaced with line items. Possible replacements are line items within ScheduleOfLifeSettlementContractsFairValueMethodTextBlock and ScheduleOfLifeSettlementContractsInvestmentMethodTextBlock."
-],
-"IncomeTaxExpenseBenefitContinuingOperations": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is IncomeTaxExpenseBenefit."
-],
-"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsAccruedBenefitLiability": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FairValueAssetsMeasuredOnRecurringBasisInvestmentInFederalHomeLoanBankStockValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByAssetClassAxis."
-],
-"ExpropriationOfAssetsMember": [
+"LossOnReceivablesMember": [
 "2012-01-31",
 "Element was deprecated because the dimension of the financial reporting concept was remodeled."
 ],
-"NotionalAmountOfCashFlowHedgeInstruments": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
-],
-"FinancialInstrumentsSubjectToMandatoryRedemptionSettlementTermsForwardPriceOrOptionStrikePriceSharesSettlementDates": [
+"LossesGainsOnSalesOfAssetsAndAssetImpairmentCharges": [
 "2012-01-31",
-"Element was deprecated because it has a dateStringItemType. Possible replacement is FinancialInstrumentsSubjectToMandatoryRedemptionSettlementTermsForwardPriceOrOptionStrikePriceSharesSettlementDate."
+"Element was deprecated because it has a debit balance attribute. Possible replacement is GainLossOnSalesOfAssetsAndAssetImpairmentCharges."
 ],
-"NetIncreaseDecreaseInAdvancePaymentsByBorrowersForTaxesAndInsurance": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is IncreaseDecreaseInAdvancePaymentsByBorrowersForTaxesAndInsurance."
-],
-"PostageExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is PostageExpense."
-],
-"ReinsuranceLiabilitiesMethodologiesAndAssumptions": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is NaturePurposeAndEffectOfReinsuranceTransactions."
-],
-"BusinessAcquisitionPurchasePriceAllocationAssetsAcquiredLiabilitiesAssumedNet": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"ProvedOilAndGasReserveQuantitiesDisclosureTextBlock": [
+"MajorTypesOfTradingSecuritiesAndAssetsDomain": [
 "2012-01-31",
-"Element was deprecated. Possible replacement is ScheduleOfProvedDevelopedAndUndevelopedOilAndGasReserveQuantitiesTextBlock."
+"Element was deprecated due to redundancy. Possible replacement is MajorTypesOfDebtAndEquitySecuritiesDomain."
 ],
-"PremiumsEarnedNetPropertyAndCasualtyAbstract": [
+"MalpracticeInsuranceDeductible": [
 "2013-01-31",
-"Element was deprecated."
+"Element was deprecated because it has an instant period type attribute. Possible replacement is MalpracticeInsuranceDeductible1."
 ],
-"AccountingStandardsUpdate201002Member": [
+"MalpracticeLossContingencyAccrualAdjustment": [
 "2014-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"PremiumsWrittenNetPropertyAndCasualtyAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"LineOfCreditFacilityDecreaseRepayments": [
-"2013-01-31",
-"Element was deprecated due to redundancy.  Possible replacement is RepaymentsOfLinesOfCredit."
-],
-"MortgageLoansOnRealEstateWriteDownOrReserveAmount": [
-"2013-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is MortgageLoansOnRealEstateWriteDownOrReserveAmount1."
-],
-"TemporaryEquityCarryingAmountAttributableToNoncontrollingInterest": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is RedeemableNoncontrollingInterestEquityCarryingAmount."
-],
-"CommercialLinesMember": [
-"2013-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is PropertyAndCasualtyCommercialInsuranceProductLineMember."
-],
-"PreferredStockSubjectToMandatoryRedemptionMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is MandatorilyRedeemablePreferredStockMember."
-],
-"DescriptionOfChangeInMeasurementDateSFAS158": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LitigationSettlementGross": [
-"2013-01-31",
-"Element was deprecated. Possible replacement is LitigationSettlementAmount."
-],
-"LoansReceivableWithFixedRatesOfInterest": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is LoansReceivableWithFixedRatesOfInterest1."
-],
-"FairValueAssetsMeasuredOnRecurringAndNonrecurringBasisValuationTechniquesAbstract": [
-"2012-01-31",
-"This element was removed because its children were deprecated after the disclosure was dimensionalized."
-],
-"RepurchaseAgreementCounterpartyWeightedAverageMaturityOfAgreements": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is RepurchaseAgreementCounterpartyWeightedAverageMaturityOfAgreements1."
-],
-"PublicUtilitiesPropertyPlantAndEquipmentVehiclesEstimatedUsefulLife": [
-"2013-01-31",
-"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentVehiclesUsefulLife."
-],
-"CreditRiskDerivativesAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"AccountsReceivableFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
-],
-"BusinessAcquisitionContingentConsiderationAtFairValueNoncurrent": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DistributionMadeToMemberOrLimitedPartnerDistributionDate1": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberDistributionDate or DistributionMadeToLimitedPartnerDistributionDate."
-],
-"DiscontinuedOperationOrAssetDisposalMember": [
-"2012-01-31",
-"Element was deprecated because the dimension of the financial reporting concept was remodeled. Possible replacements are IncomeStatementBalanceSheetAndAdditionalDisclosuresByDisposalGroupsIncludingDiscontinuedOperationsAxis and other elements/members as needed."
-],
-"CollaborativeArrangementsAndNoncollaborativeArrangementTransactionsMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ArrangementsAndNonarrangementTransactionsMember."
-],
-"CashFlowHedgeGainLossReclassifiedToInterestExpenseNet": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is InterestExpense and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"DescriptionOfChangeInAccountingPrincipleSFAS158": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"NetIncomeLossPerOutstandingLimitedPartnershipUnitDiluted": [
-"2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is NetIncomeLossNetOfTaxPerOutstandingLimitedPartnershipUnitDiluted."
-],
-"PrescriptionDrugSubsidyReceiptsYearThree": [
-"2012-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is PrescriptionDrugSubsidyReceiptsYearThree1."
-],
-"RealEstateAndAccumulatedDepreciationDescriptionOfProperty": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are corresponding primary line items and members of StatementGeographicalAxis and MortgageLoansOnRealEstateDescriptionTypeOfPropertyAxis."
-],
-"GasAndOilAcreageDevelopedNet": [
-"2012-01-31",
-"Element was deprecated because it has an integerItemType. Possible replacement is GasAndOilAreaDevelopedNet."
-],
-"BusinessAcquisitionPurchasePriceAllocationAssetsAcquiredLiabilitiesAssumedNetAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"FuelTransportationMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is FuelMember."
-],
-"DevelopmentStageEnterpriseCumulativeCashOutflows": [
-"2012-01-31",
-"Element was deprecated because different elements should not be used to tag cash outflows for the period and to tag cash outflows since inception. Possible replacement is the appropriate cash flow element to tag both fact values."
-],
-"IssuanceDomain": [
-"2012-01-31",
-"Element was deprecated because it used a dimension to differentiate equity issuances. Possible replacement is the date context to differentiate equity issuances."
-],
-"BusinessCombinationMember": [
-"2012-01-31",
-"Element was deprecated because the dimension of the financial reporting concept was remodeled. Possible replacements are BusinessAcquisitionAxis and other elements/members as needed."
-],
-"AlternativeInvestmentsFairValueDisclosureMethodology": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
-],
-"DefinedBenefitPlanEstimatedFutureEmployerContributionsInNextFiscalYear": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is DefinedBenefitPlansEstimatedFutureEmployerContributionsInNextFiscalYear."
-],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsExercisesInPeriodWeightedAverageExercisePrice": [
-"2012-01-31",
-"Element was deprecated because it has an instant period type. Possible replacement is ShareBasedCompensationArrangementsByShareBasedPaymentAwardOptionsExercisesInPeriodWeightedAverageExercisePrice."
-],
-"DerivativeExchangeRateFloor": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is DerivativeExchangeRateFloor1."
-],
-"ClassOfTreasuryStockDomain": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is ClassOfStockDomain."
-],
-"RealEstateAndAccumulatedDepreciationDateOfConstruction": [
-"2012-01-31",
-"Element was deprecated because it has a dateStringItemType. Possible replacement is RealEstateAndAccumulatedDepreciationDateOfConstruction1."
-],
-"ScheduleOfAvailableForSaleSecuritiesMajorTypesOfDebtAndEquitySecuritiesAxis": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is MajorTypesOfDebtAndEquitySecuritiesAxis."
-],
-"LeveragedBuyoutMethodologyAndAssumptions": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FairValueAssetsMeasuredOnRecurringBasisGainLossIncludedInInvestmentIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisAssetGainLossIncludedInEarnings1 and members of IncomeStatementLocationAxis."
-],
-"DirectPremiumsWrittenPropertyAndCasualty": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"BelowMarketLeasesMember": [
-"2013-01-31",
-"Element was deprecated because it is an invalid concept. Possible replacements are elements under BelowMarketLeaseAbstract."
-],
-"IncomeTaxExaminationInterestFromExamination": [
-"2013-01-31",
-"Element was deprecated because of redundancy.  Possible replacement is IncomeTaxExaminationInterestExpense."
-],
-"OtherComprehensiveIncomeReclassificationAdjustmentForSaleOfSecuritiesIncludedInNetIncomeNetOfTax": [
-"2012-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForSaleOfSecuritiesNetOfTax."
-],
-"OtherTaxCarryforwardTable": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TaxCreditCarryforwardTable."
-],
-"AuctionMarketPreferredSecuritiesStockSeriesRateSettingInterval": [
-"2012-01-31",
-"Element was deprecated because it has an integerItemType. Possible replacement is AuctionMarketPreferredSecuritiesStockSeriesRateSettingInterval1."
-],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsForfeitedInPeriodIntrinsicValue": [
-"2012-01-31",
-"Element was deprecated because it has an instant period type. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsForfeituresIntrinsicValue."
-],
-"EquityIssuanceDollarAmountPerShare": [
-"2012-01-31",
-"Element was deprecated because it has an instant period type. Possible replacement is EquityIssuancePerShareAmount."
-],
-"PremiumsWrittenNetLife": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PremiumsWrittenNet and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"EntityWideRevenueMajorCustomerPercentage": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ConcentrationRiskPercentage1 and members of ConcentrationRiskByBenchmarkAxis."
-],
-"InvestmentOwnedValuedByTrusteesFlag": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is InvestmentOwnedValuedByTrusteesFlag1."
-],
-"ImpairmentOfIntangibleAssetsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ImpairmentOfIntangibleAssetsExcludingGoodwill."
-],
-"BusinessAcquisitionPurchasePriceAllocationUnclassifiedAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"EnvironmentalCostsOfPropertyForSaleDisposalOrAbandonmentAccruedExitCosts": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is EnvironmentalExitCostsCostsAccruedToDate."
-],
-"BusinessAcquisitionPurchasePriceAllocationDeferredIncomeTaxesAssetLiabilityNet": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FinancingReceivableAllowanceForCreditLossesProvisions": [
-"2012-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is ProvisionForLoanLeaseAndOtherLosses."
-],
-"DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiability": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are\nDeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityUndistributedEarningsOfForeignSubsidiaries, DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityUndistributedEarningsOfDomesticSubsidiaries, DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityBadDebtReserveForTaxPurposesOfQualifiedLender, and DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityPolicyholdersSurplus."
-],
-"AccretionExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is AccretionExpenseIncludingAssetRetirementObligations."
-],
-"ForwardContractIndexedToIssuersEquityRedeemableStockRedemptionRequirements": [
-"2012-01-31",
-"Element was deprecated because it has a stringItemType. Possible replacement is ForwardContractIndexedToIssuersEquityRedeemableStockRedemptionRequirementsAmount."
-],
-"NetInterestIncomeLossAfterProvisionForLoanLosses": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is InterestIncomeExpenseAfterProvisionForLoanLoss."
-],
-"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInRollingYearFour": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInRollingYearFour."
-],
-"TransfersAccountedForAsSecuredBorrowingsClassificationAssociatedLiabilities": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is TransfersAccountedForAsSecuredBorrowingsAssociatedLiabilitiesCarryingAmount and members of BalanceSheetLocationAxis."
-],
-"SoftwareMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ComputerSoftwareIntangibleAssetMember."
-],
-"FutureAmortizationExpenseYearFour": [
-"2012-01-31",
-"Element was deprecated because it has a duration period type. Possible replacement is FiniteLivedIntangibleAssetsAmortizationExpenseYearFour."
-],
-"ReserveForLossesAndLossAdjustmentExpenses": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilityForClaimsAndClaimsAdjustmentExpense."
-],
-"ScheduleOfIndefiniteLivedIntangibleAssetsByMajorClassTextBlock": [
-"2012-01-31",
-"Element was deprecated because the dimension of the financial reporting concept was remodeled. Possible replacement is ScheduleOfIndefiniteLivedIntangibleAssetsTableTextBlock."
-],
-"NetIncomeMember": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"CorporateEliminationMember": [
-"2012-01-31",
-"Element was deprecated due to redundancy. Possible replacement is IntersegmentEliminationMember."
-],
-"AccountingStandardsUpdate200910Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"MaximumLengthOfTimeHedgedInPriceRiskCashFlowHedge": [
-"2012-01-31",
-"Element was deprecated because it has a durationStringItemType. Possible replacement is MaximumLengthOfTimeHedgedInPriceRiskCashFlowHedge1."
-],
-"ScheduleOfIndefiniteLivedIntangibleAssetsBySegmentTextBlock": [
-"2012-01-31",
-"Element was deprecated because the indefinite-lived intangible assets dimension was revised. Possible replacement is ScheduleOfIndefiniteLivedIntangibleAssetsTableTextBlock."
-],
-"FiniteLivedIntangibleAssetsRemainingAmortizationPeriod": [
-"2013-01-31",
-"Element was deprecated because it is has a stringItemType attribute. Possible replacement is FiniteLivedIntangibleAssetsRemainingAmortizationPeriod1."
-],
-"IneffectivenessOnCreditRiskHedgesIsImmaterial": [
-"2013-01-31",
-"Element was deprecated because it is an invalid concept."
-],
-"CapitalizedExploratoryWellCostGreaterThanOrEqualToTwoYearsAndLessThanThreeYearsNumberOfProjects": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProjectsThatHaveExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
-],
-"IncomeLossFromEquityMethodInvestmentsNetOfDistributionsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is IncomeLossFromEquityMethodInvestmentsNetOfDividendsOrDistributions."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisDebtInstrumentValuationTechniques": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques, FairValueMeasurementsChangesInValuationTechniques, and members of FairValueByLiabilityClassAxis."
-],
-"UnallocatedAmountToSegmentMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is MaterialReconcilingItemsMember."
-],
-"AverageBalanceDuringPeriodOfLoansManagedAndSecuritized": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInRollingYearThree": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInRollingYearThree."
-],
-"DeferredPolicyAcquisitionCostsAndPresentValueOfFutureProfitsDisclosure": [
-"2012-01-31",
-"Element was deprecated. Possible replacements are TypeOfDeferredPolicyAcquisitionCosts or NatureOfDeferredPolicyAcquisitionCosts."
-],
-"ForwardContractIndexedToIssuersEquityRedeemableStockRedemptionRequirementsAmount": [
-"2013-01-31",
-"Element was deprecated because it has debit balance and duration period type attributes. Possible replacement is OptionIndexedToIssuersEquityRedeemableStockRedemptionRequirementsAmount1."
-],
-"IncomeTaxExaminationRangeOfPossibleLosses": [
-"2013-01-31",
-"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is IncomeTaxExaminationEstimateOfPossibleLoss and members of RangeAxis."
-],
-"CededPremiumsEarnedPropertyAndCasualty": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"DescriptionOfAccountingMethodUsedForCreditRiskDerivatives": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are members of ValuationTechniqueAxis."
-],
-"DerivativeInstrumentsGainLossRecognizedInIncomeNet": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeGainLossOnDerivativeNet and members of HedgingDesignationAxis."
-],
-"IncomeLossBeforeExtraordinaryItemsAndCumulativeEffectOfChangeInAccountingPrinciplePerOutstandingLimitedPartnershipUnit": [
-"2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromOperationsBeforeExtraordinaryItemsPerOutstandingLimitedPartnershipUnitBasicNetOfTax."
-],
-"ReinsurancePremiumsForInsuranceCompaniesByProductSegmentGrossAmount": [
-"2013-01-31",
-"Element was deprecated. Possible replacement is DirectPremiumsEarned."
-],
-"IncentiveFeeAmountPaid": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is PaymentForIncentiveFee."
-],
-"ProfessionalFeesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ProfessionalFees."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsAssetNotToBeUsedAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"PresentValueOfFutureInsuranceProfitsUnrealizedInvestmentGains": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsUnrealizedInvestmentGains1."
 ],
 "MalpracticeLossContingencyAccrualNotRecognized": [
 "2012-01-31",
 "Element was deprecated because it has a monetary item type. Possible replacement is MalpracticeLossContingencyAccrualNotRecognized1."
 ],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsVestedAndExpectedToVestOutstandingWeightedAverageRemainingContractualTerm": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsVestedAndExpectedToVestOutstandingWeightedAverageRemainingContractualTerm1."
-],
-"VariableInterestEntityNonconsolidatedComparisonOfCarryingAmountOfAssetsAndLiabilitiesToMaximumLossExposureExplanationAbstract": [
-"2012-01-31",
-"This element has been deprecated."
-],
-"FiniteLivedIntangibleAssetsAmortizationExpense": [
-"2012-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AmortizationOfIntangibleAssets."
-],
-"LoansHeldForSaleFairValueDisclosureSignificantAssumptions": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
-],
-"RealEstateWriteDownOrReservePropertyDomain": [
+"MalpracticeLossContingencySettlementOfClaims": [
 "2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is RealEstateAndAccumulatedDepreciationNameOfPropertyDomain."
+"Element was deprecated due to redundancy. Possible replacement is MalpracticeLossContingencyPeriodCost."
 ],
-"AllowanceForCostOfEquityFundsUsedDuringConstructionMember": [
+"ManagementFeeAmountPaid": [
 "2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is PublicUtilitiesAllowanceForFundsUsedDuringConstructionCapitalizedInterest."
+"Element was deprecated because it has a debit balance attribute. Possible replacement is PaymentForManagementFee."
 ],
-"RestructuringReservePeriodExpense": [
+"MandatorilyRedeemablePreferredStockFairValueDisclosureMethodology": [
 "2012-01-31",
-"Element was deprecated due to redundancy. Possible replacement is RestructuringCharges."
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
 ],
-"ChangeInMeasurementDateSFAS158Abstract": [
+"MandatorilyRedeemablePreferredStockFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
+],
+"MarketingAndAdvertisingExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is MarketingAndAdvertisingExpense."
+],
+"MarketingExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is MarketingExpense."
+],
+"MaterialEffectOnLiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseFromChangeInAccountingPrincipleMember": [
+"2014-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are members of AdjustmentsForChangeInAccountingPrincipleAxis."
+],
+"MaterialErrorInLiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseMember": [
+"2014-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are members of ErrorCorrectionsAndPriorPeriodAdjustmentsRestatementByRestatementPeriodAndAmountAxis."
+],
+"MaturityOfForeignCurrencyDerivatives": [
+"2012-01-31",
+"Element was deprecated because it has a durationStringItemType. Possible replacement is MaturityOfForeignCurrencyDerivatives1."
+],
+"MaximumFutureEarningsFromClosedBlockAssetsAndLiabilities1": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ClosedBlockAssetsAndLiabilitiesMaximumFutureEarningsToBeRecognized."
+],
+"MaximumLengthOfTimeHedgedInCashFlowHedge": [
+"2012-01-31",
+"Element was deprecated because it has a durationStringItemType. Possible replacement is MaximumLengthOfTimeHedgedInCashFlowHedge1."
+],
+"MaximumLengthOfTimeHedgedInForeignCurrencyCashFlowHedge": [
+"2013-01-31",
+"Element was deprecated because it is has a stringItemType attribute. Possible replacement is MaximumLengthOfTimeForeignCurrencyCashFlowHedge."
+],
+"MaximumLengthOfTimeHedgedInInterestRateCashFlowHedge": [
+"2012-01-31",
+"Element was deprecated because it has a durationStringItemType. Possible replacement is MaximumLengthOfTimeHedgedInInterestRateCashFlowHedge1."
+],
+"MaximumLengthOfTimeHedgedInPriceRiskCashFlowHedge": [
+"2012-01-31",
+"Element was deprecated because it has a durationStringItemType. Possible replacement is MaximumLengthOfTimeHedgedInPriceRiskCashFlowHedge1."
+],
+"MaximumPotentialFutureExposureOnCreditRiskDerivatives": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is CreditDerivativeMaximumExposureUndiscounted."
+],
+"MaximumRemainingMaturityOfForeignCurrencyDerivatives": [
+"2012-01-31",
+"Element was deprecated because it has a durationStringItemType. Possible replacement is MaximumRemainingMaturityOfForeignCurrencyDerivatives1."
+],
+"MaximumTermOfCreditRiskDerivatives": [
+"2012-01-31",
+"Element was deprecated because it has a durationStringItemType. Possible replacement is MaximumTermOfCreditRiskDerivatives1."
+],
+"MembersOrLimitedPartnersSubsequentDistributionAmount": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberCashDistributionsPaid and members of SubsequentEventTypeAxis or DistributionMadeToLimitedPartnerCashDistributionsPaid and members of SubsequentEventTypeAxis."
+],
+"MembersOrLimitedPartnersSubsequentDistributionDate": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberDistributionDate and members of SubsequentEventTypeAxis or DistributionMadeToLimitedPartnerDistributionDate and members of SubsequentEventTypeAxis."
+],
+"MergerAndAcquisitionCosts": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"MinimumNetCapitalRequired": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is MinimumNetCapitalRequired1."
+],
+"MinimumNetCapitalRequiredForBrokerDealerSubsidiary": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is MinimumNetCapitalRequiredForBrokerDealerSubsidiary1."
+],
+"MinimumNetCapitalRequiredForEntity": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is MinimumNetCapitalRequiredForEntity1."
+],
+"MinimumRemainingTermsOfLeasesAndConcessionsOnUndevelopedAcreage": [
+"2012-01-31",
+"Element was deprecated because it has an integerItemType. Possible replacement is MinimumRemainingTermsOfLeasesAndConcessionsOnUndevelopedAcreage1."
+],
+"MinorRestatementOfOpeningLiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseSAB108Member": [
+"2014-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are members of ErrorCorrectionsAndPriorPeriodAdjustmentsRestatementByRestatementPeriodAndAmountAxis."
+],
+"MinorityInterestAndEarningsLossesEquityInvestmentsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is IncomeLossFromEquityMethodInvestments."
+],
+"MinorityInterestExpenseIncomeRealEstateInvestments": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is NetIncomeLossFromRealEstateInvestmentPartnershipAttributableToParent."
+],
+"MinorityInterestExpenseIncomeRealEstateInvestmentsAbstract": [
 "2013-01-31",
 "Element was deprecated."
 ],
-"CreditDerivativeTerm": [
+"MinorityInterestInNetIncomeLossJointVenturePartners": [
 "2013-01-31",
-"Element was deprecated because it is has a stringItemType attribute. Possible replacement is CreditDerivativeTerm1."
+"Element was deprecated because it represents multiple distinct concepts. Possible replacement is NoncontrollingInterestInNetIncomeLossJointVenturePartnersNonredeemable or NoncontrollingInterestInNetIncomeLossJointVenturePartnersRedeemable."
 ],
-"ExpropriationOfAssetsAxis": [
+"MinorityInterestInNetIncomeLossLimitedPartnerships": [
 "2013-01-31",
-"Element was deprecated due to remodeling of topic area."
+"Element was deprecated because it represents multiple distinct concepts. Possible replacement is NoncontrollingInterestInNetIncomeLossLimitedPartnershipsNonredeemable or NoncontrollingInterestInNetIncomeLossLimitedPartnershipsRedeemable."
 ],
-"AccountingStandardsUpdate201003Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CashFlowHedgeGainLossReclassifiedToOtherIncomeNet": [
+"MinorityInterestInNetIncomeLossOperatingPartnerships": [
 "2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is OtherIncome and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+"Element was deprecated because it represents multiple distinct concepts. Possible replacement is NoncontrollingInterestInNetIncomeLossOperatingPartnershipsNonredeemable or NoncontrollingInterestInNetIncomeLossOperatingPartnershipsRedeemable."
 ],
-"InstrumentTypeMember": [
+"MinorityInterestInNetIncomeLossOtherMinorityInterests": [
 "2013-01-31",
-"Element was deprecated because it was incorrectly defined. Possible replacement is EnergyDomain."
+"Element was deprecated because it represents multiple distinct concepts. Possible replacement is NoncontrollingInterestInNetIncomeLossOtherNoncontrollingInterestsNonredeemable or NoncontrollingInterestInNetIncomeLossOtherNoncontrollingInterestsRedeemable."
 ],
-"ListedOptionsMember": [
+"MinorityInterestInNetIncomeLossPreferredUnitHolders": [
 "2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ExchangeTradedOptionsMember."
+"Element was deprecated because it represents multiple distinct concepts. Possible replacement is NoncontrollingInterestInNetIncomeLossPreferredUnitHoldersRedeemable or NoncontrollingInterestInNetIncomeLossPreferredUnitHoldersNonredeemable."
 ],
-"CashSurrenderValueFairValueDisclosureMethodology": [
+"MinorityInterestIncreaseFromStockIssuance": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacement is NoncontrollingInterestIncreaseFromSubsidiaryEquityIssuance or NoncontrollingInterestIncreaseFromSaleOfParentEquityInterest."
+],
+"MoreThanFiveYearsFromBalanceSheetDateAndThereafterMember": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept modeled as a dimension was replaced with line items. Possible replacements are line items within ScheduleOfLifeSettlementContractsFairValueMethodTextBlock and ScheduleOfLifeSettlementContractsInvestmentMethodTextBlock."
+],
+"MoreThanFourAndWithinFiveYearsFromBalanceSheetDateMember": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept modeled as a dimension was replaced with line items. Possible replacements are line items within ScheduleOfLifeSettlementContractsFairValueMethodTextBlock and ScheduleOfLifeSettlementContractsInvestmentMethodTextBlock."
+],
+"MoreThanOneAndWithinTwoYearsFromBalanceSheetDateMember": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept modeled as a dimension was replaced with line items. Possible replacements are line items within ScheduleOfLifeSettlementContractsFairValueMethodTextBlock and ScheduleOfLifeSettlementContractsInvestmentMethodTextBlock."
+],
+"MoreThanThreeAndWithinFourYearsFromBalanceSheetDateMember": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept modeled as a dimension was replaced with line items. Possible replacements are line items within ScheduleOfLifeSettlementContractsFairValueMethodTextBlock and ScheduleOfLifeSettlementContractsInvestmentMethodTextBlock."
+],
+"MoreThanTwoAndWithinThreeYearsFromBalanceSheetDateMember": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept modeled as a dimension was replaced with line items. Possible replacements are line items within ScheduleOfLifeSettlementContractsFairValueMethodTextBlock and ScheduleOfLifeSettlementContractsInvestmentMethodTextBlock."
+],
+"MortgageBackedSecuritiesAvailableForSaleFairValueDisclosureAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
+],
+"MortgageBackedSecuritiesAvailableForSaleFairValueDisclosureMethodology": [
 "2012-01-31",
 "Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
 ],
-"EmployeeServiceShareBasedCompensationNonvestedAwardsTotalCompensationCostNotYetRecognizedPeriodForRecognition": [
+"MortgageBackedSecuritiesHeldToMaturityFairValueDisclosureAssumptions": [
 "2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is EmployeeServiceShareBasedCompensationNonvestedAwardsTotalCompensationCostNotYetRecognizedPeriodForRecognition1."
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
 ],
-"PrepaidReinsurancePremiumsMethodologyAndAssumptions": [
+"MortgageBackedSecuritiesHeldToMaturityFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
+],
+"MortgageLoansOnRealEstateFederalIncomeTaxBasis": [
 "2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is NaturePurposeAndEffectOfReinsuranceTransactions."
+"Element was deprecated because it has a credit balance attribute. Possible replacement is MortgageLoansOnRealEstateFederalIncomeTaxBasis1."
 ],
-"FiniteLivedIntangibleAssetsWeightedAverageUsefulLife": [
-"2012-01-31",
-"Element was deprecated because it has a decimalItemType. Possible replacement is FiniteLivedIntangibleAssetUsefulLife."
-],
-"RetrospectiveEffectOfChangeInAccountingPrincipleTabularPresentationByFinancialStatementLineItemAmountAfterApplication": [
-"2012-01-31",
-"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are NewAccountingPronouncementsOrChangeInAccountingPrincipleTable. Line items that can be used instead of this element include, but are not limited to, IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest, ProfitLoss, EarningsPerShareBasic, and EarningsPerShareDiluted."
-],
-"DividendsPayableAmount": [
-"2012-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DividendsPayableCurrentAndNoncurrent."
-],
-"AmortizationOfIntangiblesNonproductionMember": [
+"MortgageLoansOnRealEstatePeriodicPaymentTermsBalloonPaymentAmount": [
 "2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is AmortizationOfIntangibleAssets."
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are MortgageLoansOnRealEstatePeriodicPaymentTermsBalloonPaymentToBeReceived or DebtInstrumentPeriodicPaymentTermsBalloonPaymentToBePaid."
 ],
-"OtherComprehensiveIncomeLossPensionAndOtherPostretirementBenefitPlansCurtailmentTaxEffect": [
-"2012-01-31",
-"Element was deprecated. Possible replacement is OtherComprehensiveIncomeFinalizationOfPensionAndNonPensionPostretirementPlanValuationTax."
-],
-"AssetManagementFees": [
+"MortgageLoansOnRealEstatePriorLiens": [
 "2013-01-31",
-"Element was deprecated due to remodeling of topic area. Possible replacement is AssetManagementFees1 or InvestmentAdvisoryManagementAndAdministrativeFees."
+"Element was deprecated because it has a debit balance attribute. Possible replacement is MortgageLoansOnRealEstatePriorLiens1."
 ],
-"RequiredNetCapitalUnderCommodityExchangeAct": [
+"MortgageLoansOnRealEstateRenewedAndExtendedAmount": [
+"2013-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is MortgageLoansOnRealEstateRenewedAndExtendedAmount1."
+],
+"MortgageLoansOnRealEstateWriteDownOrReserveAmount": [
+"2013-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is MortgageLoansOnRealEstateWriteDownOrReserveAmount1."
+],
+"MortgagesHeldForSaleFairValueDisclosureMethodology": [
 "2012-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is RequiredNetCapitalUnderCommodityExchangeAct1."
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
+],
+"MortgagesHeldForSaleFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
+],
+"MultiemployerPlanSignificantChangesImpactingComparability": [
+"2012-01-31",
+"Element was deprecated. Possible replacements are MultiemployerPlansBusinessCombinationOrDivestitureDescription, MultiemployerPlansContributionRateIncreaseDecreaseDescription, and MultiemployerPlansEmployeesIncreaseDecreaseDescription."
+],
+"MultiemployerPlanWithdrawalObligation": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is MultiemployerPlansWithdrawalObligation."
+],
+"MultiemployerPlansCollectiveBargainingArrangementDescription": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is MultiemployerPlansCollectiveBargainingArrangementExpirationDateDescription."
+],
+"NetAmountAtRiskByProductAndGuaranteeWeightedAverageAttainedAge": [
+"2012-01-31",
+"Element was deprecated because it has an integerItemType. Possible replacement is NetAmountAtRiskByProductAndGuaranteeWeightedAverageAttainedAge1."
+],
+"NetAmountAtRiskByProductAndGuaranteeWeightedAveragePeriodRemaining": [
+"2012-01-31",
+"Element was deprecated because it has an integerItemType. Possible replacement is NetAmountAtRiskByProductAndGuaranteeWeightedAveragePeriodRemaining1."
+],
+"NetCreditLossesDuringPeriodOnLoansManagedOrSecuritized": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is NetCreditLossOnLoansManagedOrSecuritizedOrAssetbackedFinancingArrangement."
+],
+"NetIncomeLossPerOutstandingGeneralPartnershipUnit": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is NetIncomeLossPerOutstandingGeneralPartnershipUnitNetOfTax."
+],
+"NetIncomeLossPerOutstandingLimitedPartnershipUnit": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is NetIncomeLossPerOutstandingLimitedPartnershipUnitBasicNetOfTax."
+],
+"NetIncomeLossPerOutstandingLimitedPartnershipUnitDiluted": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is NetIncomeLossNetOfTaxPerOutstandingLimitedPartnershipUnitDiluted."
+],
+"NetIncomeMember": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"NetIncreaseDecreaseInAdvancePaymentsByBorrowersForTaxesAndInsurance": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is IncreaseDecreaseInAdvancePaymentsByBorrowersForTaxesAndInsurance."
+],
+"NetInterestIncomeLossAfterProvisionForLoanLosses": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is InterestIncomeExpenseAfterProvisionForLoanLoss."
+],
+"NetInvestmentIncomeInsuranceEntity": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is NetInvestmentIncome."
+],
+"NetInvestmentIncomeInsuranceEntityEquitySecurities": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NetInvestmentIncome and members of InvestmentTypeAxis."
+],
+"NetInvestmentIncomeInsuranceEntityFixedMaturities": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NetInvestmentIncome and members of InvestmentTypeAxis."
+],
+"NetInvestmentIncomeInsuranceEntityInvestmentRealEstate": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NetInvestmentIncome and members of InvestmentTypeAxis."
+],
+"NetInvestmentIncomeInsuranceEntityMortgageLoansOnRealEstate": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NetInvestmentIncome and members of InvestmentTypeAxis."
+],
+"NetInvestmentIncomeInsuranceEntityOtherLongTermInvestments": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NetInvestmentIncome and members of InvestmentTypeAxis."
+],
+"NetInvestmentIncomeInsuranceEntityPolicyLoans": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NetInvestmentIncome and members of InvestmentTypeAxis."
+],
+"NetInvestmentIncomeInsuranceEntityShortTermInvestments": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NetInvestmentIncome and members of InvestmentTypeAxis."
+],
+"NettingAndCollateralMember": [
+"2014-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are DerivativeAssetFairValueGrossLiability, DerivativeAssetCollateralObligationToReturnCashOffset, DerivativeAssetFairValueGrossLiabilityAndObligationToReturnCashOffset, SecuritiesPurchasedUnderAgreementsToResellLiability, SecuritiesBorrowedLiability, DerivativeAssetSecuritiesPurchasedUnderAgreementsToResellSecuritiesBorrowedLiability, DerivativeLiabilityFairValueGrossAsset, DerivativeLiabilityCollateralRightToReclaimCashOffset, DerivativeLiabilityFairValueGrossAssetAndRightToReclaimCashOffset, SecuritiesSoldUnderAgreementsToRepurchaseAsset, SecuritiesLoanedAsset, or DerivativeLiabilitySecuritiesSoldUnderAgreementsToResellSecuritiesLoanedAsset."
+],
+"NewAccountingPronouncementOrChangeInAccountingPrincipleCumulativeEffectOfChangeOnEquityOrNetAssets": [
+"2012-01-31",
+"Element was deprecated because it has a duration period type. Possible replacement is NewAccountingPronouncementOrChangeInAccountingPrincipleCumulativeEffectOfChangeOnEquityOrNetAssets1."
+],
+"NewAccountingPronouncementOrChangeInAccountingPrincipleProFormaDisclosuresRevenueRecognizedAmount": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"NewContractAxis": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"NewContractDomain": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"NewContractMember": [
+"2012-01-31",
+"Element was deprecated because the dimension of the financial reporting concept was remodeled."
+],
+"NondebtorReorganizationItemsNetGainLossOnSettlementOfOtherClaims": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is NondebtorReorganizationItemsNetGainLossOnSettlementOfOtherClaims1."
+],
+"NoninterestExpenseCommissionExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpenseCommissionExpense."
+],
+"NoninterestExpenseDirectorsFeesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpenseDirectorsFees."
+],
+"NoninterestExpenseInvestmentAdvisoryFeesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpenseInvestmentAdvisoryFees."
 ],
 "NoninterestExpenseMember": [
 "2013-01-31",
 "Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpense."
 ],
-"NetAmountAtRiskByProductAndGuaranteeWeightedAveragePeriodRemaining": [
+"NoninterestExpenseOfferingCostMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpenseOfferingCost."
+],
+"NoninterestExpensePrintingAndFulfillmentMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpensePrintingandFulfillment."
+],
+"NoninterestExpenseRelatedToPerformanceFeesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpenseRelatedtoPerformanceFees."
+],
+"NoninterestExpenseTransferAgentAndCustodianFeesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpenseTransferAgentandCustodianFees."
+],
+"NonmonetaryNotionalAmountOfPriceRiskCashFlowHedgeDerivatives": [
+"2013-01-31",
+"Element was deprecated because the intended concept conveyed is the underlying. Possible replacements are UnderlyingDerivativeAsset, UnderlyingDerivativeLiability, UnderlyingDerivative and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis and DerivativeInstrumentRiskAxis."
+],
+"NonmonetaryNotionalAmountOfPriceRiskDerivativeInstrumentsNotDesignatedAsHedgingInstruments": [
+"2013-01-31",
+"Element was deprecated because the intended concept conveyed is the underlying. Possible replacements are UnderlyingDerivativeAsset, UnderlyingDerivativeLiability, UnderlyingDerivative and members of HedgingDesignationAxis and DerivativeInstrumentRiskAxis."
+],
+"NonmonetaryNotionalAmountOfPriceRiskDerivatives": [
+"2013-01-31",
+"Element was deprecated because the intended concept conveyed is the underlying. Possible replacements are UnderlyingDerivativeAsset, UnderlyingDerivativeLiability, UnderlyingDerivative and members of DerivativeInstrumentRiskAxis."
+],
+"NonmonetaryNotionalAmountOfPriceRiskFairValueHedgeDerivatives": [
+"2013-01-31",
+"Element was deprecated because the intended concept conveyed is the underlying. Possible replacements are UnderlyingDerivativeAsset, UnderlyingDerivativeLiability, UnderlyingDerivative and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis and DerivativeInstrumentRiskAxis."
+],
+"NotesPayableFairValueDisclosureMethodology": [
 "2012-01-31",
-"Element was deprecated because it has an integerItemType. Possible replacement is NetAmountAtRiskByProductAndGuaranteeWeightedAveragePeriodRemaining1."
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
+],
+"NotesPayableFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
+],
+"NotesReceivableFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
+],
+"NotesReceivableFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
+],
+"NotionalAmountOfCashFlowHedgeInstruments": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
+],
+"NotionalAmountOfCreditRiskDerivatives": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of CreditDerivativesByContractTypeAxis."
+],
+"NotionalAmountOfDerivativeInstrumentsDesignatedAsNetInvestmentHedges": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
+],
+"NotionalAmountOfDerivatives": [
+"2012-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DerivativeNotionalAmount."
+],
+"NotionalAmountOfDerivativesAdditionalCategoriesOfDerivativesAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"NotionalAmountOfDerivativesTotalAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"NotionalAmountOfFairValueHedgeInstruments": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
+],
+"NotionalAmountOfForeignCurrencyCashFlowHedgeDerivatives": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
+],
+"NotionalAmountOfForeignCurrencyDerivativeInstrumentsNotDesignatedAsHedgingInstruments": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and HedgingDesignationAxis."
+],
+"NotionalAmountOfForeignCurrencyDerivativePurchaseContracts": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and PositionAxis."
+],
+"NotionalAmountOfForeignCurrencyDerivativeSaleContracts": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and PositionAxis."
+],
+"NotionalAmountOfForeignCurrencyDerivatives": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis."
+],
+"NotionalAmountOfForeignCurrencyFairValueHedgeDerivatives": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis and DerivativeInstrumentRiskAxis."
+],
+"NotionalAmountOfInterestRateCashFlowHedgeDerivatives": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis and DerivativeInstrumentRiskAxis."
+],
+"NotionalAmountOfInterestRateDerivativeInstrumentsNotDesignatedAsHedgingInstruments": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and HedgingDesignationAxis."
+],
+"NotionalAmountOfInterestRateDerivatives": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis."
+],
+"NotionalAmountOfInterestRateFairValueHedgeDerivatives": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
+],
+"NotionalAmountOfNetInvestmentHedgingInstruments": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount,  DerivativeNotionalAmount or NotionalAmountOfNonderivativeInstruments and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
+],
+"NotionalAmountOfNetInvestmentHedgingInstrumentsTotalAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"NotionalAmountOfNonderivativeInstrumentsDesignatedAsNetInvestmentHedges": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NotionalAmountOfNonderivativeInstruments and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
+],
+"NotionalAmountOfOtherDerivativesNotDesignatedAsHedgingInstruments": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of HedgingDesignationAxis."
+],
+"NotionalAmountOfPriceRiskCashFlowHedgeDerivatives": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis and DerivativeInstrumentRiskAxis."
+],
+"NotionalAmountOfPriceRiskDerivativeInstrumentsNotDesignatedAsHedgingInstruments": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and HedgingDesignationAxis."
+],
+"NotionalAmountOfPriceRiskDerivatives": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis."
+],
+"NotionalAmountOfPriceRiskFairValueHedgeDerivatives": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
+],
+"OccupancyNetMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OccupancyNet."
+],
+"OneYearFromBalanceSheetDateMember": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept modeled as a dimension was replaced with line items. Possible replacements are line items within ScheduleOfLifeSettlementContractsFairValueMethodTextBlock and ScheduleOfLifeSettlementContractsInvestmentMethodTextBlock."
+],
+"OpenTaxYearsByMajorTaxJurisdiction": [
+"2012-01-31",
+"Element was deprecated because it has a stringItemType. Possible replacement is OpenTaxYear."
+],
+"OperatingLeaseExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is LeaseAndRentalExpense."
+],
+"OperatingLeaseExpenseOtherExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is LeaseAndRentalExpense."
+],
+"OperatingLossCarryforwardsExpirationDates": [
+"2013-01-31",
+"Element was deprecated because it has a stringItemtype attribute. Possible replacement is OperatingLossCarryforwardsExpirationDate."
+],
+"OperationsCommencedDate": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. Possible replacement is OperationsCommencedDate1."
+],
+"OptionIndexedToIssuersEquityRedeemableStockRedemptionRequirements": [
+"2012-01-31",
+"Element was deprecated because it has a stringItemType. Possible replacement is OptionIndexedToIssuersEquityRedeemableStockRedemptionRequirementsAmount."
+],
+"OptionIndexedToIssuersEquityRedeemableStockRedemptionRequirementsAmount": [
+"2013-01-31",
+"Element was deprecated because it has debit balance and duration period type attributes. Possible replacement is OptionIndexedToIssuersEquityRedeemableStockRedemptionRequirementsAmount1."
+],
+"OptionIndexedToIssuersEquitySettlementAlternativesAtFairValue": [
+"2012-01-31",
+"Element was deprecated because it has a stringItemType. Possible replacements are OptionIndexedToIssuersEquitySettlementAlternativesCashAtFairValue or OptionIndexedToIssuersEquitySettlementAlternativesSharesAtFairValue."
+],
+"OptionIndexedToIssuersEquitySettlementDates": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. Possible replacement is OptionIndexedToIssuersEquitySettlementDateOrDates."
+],
+"OptionIndexedToIssuersEquityStrikePrice": [
+"2014-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is OptionIndexedToIssuersEquityStrikePrice1."
+],
+"OrderFlowFeesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OrderFlowFees."
+],
+"OriginationAndPurchasesOfMortgageBankingAssets": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is PaymentsForOriginationAndPurchasesOfLoansHeldForSale."
+],
+"OriginationOfMortgageServicingRightsMSRs": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ServicingAssetAtFairValueAdditions."
+],
+"OtherAmortizationMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OtherAmortizationOfDeferredCharges."
+],
+"OtherAssetsFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
+],
+"OtherAssetsFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
+],
+"OtherAssetsHeldForSale": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DisposalGroupIncludingDiscontinuedOperationOtherAssets."
+],
+"OtherAssetsHeldForSaleCurrent": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DisposalGroupIncludingDiscontinuedOperationOtherCurrentAssets."
+],
+"OtherComprehensiveIncomeAmortizationOfDefinedBenefitPlanNetPriorServiceCostCreditRecognizedInNetPeriodicBenefitCostBeforeTax": [
+"2012-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossAmortizationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetPriorServiceCostCreditBeforeTax."
+],
+"OtherComprehensiveIncomeAmortizationOfDefinedBenefitPlanNetPriorServiceCostRecognizedInNetPeriodicPensionCostNetOfTax": [
+"2012-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossAmortizationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetPriorServiceCostCreditNetOfTax."
+],
+"OtherComprehensiveIncomeAmortizationOfDefinedBenefitPlanNetPriorServiceCostRecognizedInNetPeriodicPensionCostTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossAmortizationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetPriorServiceCostCreditTax."
+],
+"OtherComprehensiveIncomeAvailableForSaleSecuritiesAdjustmentBeforeTaxPeriodIncreaseDecrease": [
+"2012-01-31",
+"Element was deprecated because it has no balance attribute. Possible replacement is OtherComprehensiveIncomeLossAvailableForSaleSecuritiesAdjustmentBeforeTax."
+],
+"OtherComprehensiveIncomeAvailableForSaleSecuritiesAdjustmentNetOfTaxPeriodIncreaseDecrease": [
+"2012-01-31",
+"Element was deprecated because it has no balance attribute. Possible replacement is OtherComprehensiveIncomeLossAvailableForSaleSecuritiesAdjustmentNetOfTax."
+],
+"OtherComprehensiveIncomeAvailableForSaleSecuritiesTax": [
+"2012-01-31",
+"Element was deprecated because it has no balance attribute. Possible replacement is OtherComprehensiveIncomeLossAvailableForSaleSecuritiesTax."
+],
+"OtherComprehensiveIncomeDefinedBenefitPlansAdjustmentBeforeTaxPeriodIncreaseDecrease": [
+"2012-01-31",
+"Element was deprecated because it has no balance attribute. Possible replacement is OtherComprehensiveIncomeLossPensionAndOtherPostretirementBenefitPlansAdjustmentBeforeTax."
+],
+"OtherComprehensiveIncomeDefinedBenefitPlansAdjustmentNetOfTaxPeriodIncreaseDecrease": [
+"2012-01-31",
+"Element was deprecated because it has no balance attribute. Possible replacement is OtherComprehensiveIncomeLossPensionAndOtherPostretirementBenefitPlansAdjustmentNetOfTax."
+],
+"OtherComprehensiveIncomeDefinedBenefitPlansNetUnamortizedGainLossArisingDuringPeriodBeforeTax": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is OtherComprehensiveIncomeLossPensionAndOtherPostretirementBenefitPlansNetUnamortizedGainLossArisingDuringPeriodBeforeTax."
+],
+"OtherComprehensiveIncomeDefinedBenefitPlansTax": [
+"2012-01-31",
+"Element was deprecated because it has no balance attribute. Possible replacement is OtherComprehensiveIncomeLossPensionAndOtherPostretirementBenefitPlansTax."
+],
+"OtherComprehensiveIncomeDerivativesQualifyingAsHedgesBeforeTaxPeriodIncreaseDecrease": [
+"2012-01-31",
+"Element was deprecated because it has no balance attribute. Possible replacement is OtherComprehensiveIncomeLossDerivativesQualifyingAsHedgesBeforeTax."
+],
+"OtherComprehensiveIncomeDerivativesQualifyingAsHedgesNetOfTaxPeriodIncreaseDecrease": [
+"2012-01-31",
+"Element was deprecated because it has no balance attribute. Possible replacement is OtherComprehensiveIncomeLossDerivativesQualifyingAsHedgesNetOfTax."
+],
+"OtherComprehensiveIncomeDerivativesQualifyingAsHedgesTaxEffectPeriodIncreaseDecrease": [
+"2012-01-31",
+"Element was deprecated because it has no balance attribute. Possible replacement is OtherComprehensiveIncomeLossDerivativesQualifyingAsHedgesTax."
+],
+"OtherComprehensiveIncomeFinalizationOfPensionAndNonPensionPostretirementPlanValuationBeforeTax": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is OtherComprehensiveIncomeLossFinalizationOfPensionAndNonPensionPostretirementPlanValuationBeforeTax."
+],
+"OtherComprehensiveIncomeFinalizationOfPensionAndNonPensionPostretirementPlanValuationNetOfTax": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is OtherComprehensiveIncomeLossFinalizationOfPensionAndNonPensionPostretirementPlanValuationNetOfTax."
+],
+"OtherComprehensiveIncomeForeignCurrencyTransactionAndTranslationAdjustmentBeforeTaxPeriodIncreaseDecrease": [
+"2012-01-31",
+"Element was deprecated because it has no balance attribute. Possible replacement is OtherComprehensiveIncomeLossForeignCurrencyTransactionAndTranslationAdjustmentBeforeTax."
+],
+"OtherComprehensiveIncomeForeignCurrencyTransactionAndTranslationAdjustmentNetOfTaxPeriodIncreaseDecrease": [
+"2012-01-31",
+"Element was deprecated because it has no balance attribute. Possible replacement is OtherComprehensiveIncomeLossForeignCurrencyTransactionAndTranslationAdjustmentNetOfTax."
+],
+"OtherComprehensiveIncomeForeignCurrencyTransactionAndTranslationReclassificationAdjustmentRealizedUponSaleOrLiquidationBeforeTax": [
+"2012-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossForeignCurrencyTransactionAndTranslationReclassificationAdjustmentFromAOCIRealizedUponSaleOrLiquidationBeforeTax."
+],
+"OtherComprehensiveIncomeForeignCurrencyTransactionAndTranslationReclassificationAdjustmentRealizedUponSaleOrLiquidationNetOfTax": [
+"2012-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossForeignCurrencyTransactionAndTranslationReclassificationAdjustmentFromAOCIRealizedUponSaleOrLiquidationNetOfTax."
+],
+"OtherComprehensiveIncomeForeignCurrencyTranslationAdjustmentTax": [
+"2012-01-31",
+"Element was deprecated because it has no balance attribute. Possible replacement is OtherComprehensiveIncomeLossForeignCurrencyTranslationAdjustmentTax."
+],
+"OtherComprehensiveIncomeForeignCurrencyTranslationReclassificationAdjustmentRealizedUponSaleOrLiquidationTax": [
+"2012-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossForeignCurrencyTransactionAndTranslationReclassificationAdjustmentFromAOCIRealizedUponSaleOrLiquidationTax."
+],
+"OtherComprehensiveIncomeLossAmortizationPensionAndOtherPostretirementBenefitPlansNetPriorServiceCostRecognizedInNetPeriodicBenefitCostBeforeTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossAmortizationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetPriorServiceCostCreditBeforeTax."
+],
+"OtherComprehensiveIncomeLossAmortizationPensionAndOtherPostretirementBenefitPlansNetPriorServiceCostRecognizedInNetPeriodicPensionCostNetOfTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossAmortizationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetPriorServiceCostCreditNetOfTax."
+],
+"OtherComprehensiveIncomeLossAmortizationPensionAndOtherPostretirementBenefitPlansNetPriorServiceCostRecognizedInNetPeriodicPensionCostTaxEffect": [
+"2012-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossAmortizationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetPriorServiceCostCreditTax."
+],
+"OtherComprehensiveIncomeLossBeforeTaxPeriodIncreaseDecrease": [
+"2012-01-31",
+"Element was deprecated because it has no balance attribute. Possible replacement is OtherComprehensiveIncomeLossBeforeTax."
+],
+"OtherComprehensiveIncomeLossForeignCurrencyTransactionAndTranslationReclassificationAdjustmentRealizedUponSaleOrLiquidationBeforeTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossForeignCurrencyTransactionAndTranslationReclassificationAdjustmentFromAOCIRealizedUponSaleOrLiquidationBeforeTax."
+],
+"OtherComprehensiveIncomeLossForeignCurrencyTransactionAndTranslationReclassificationAdjustmentRealizedUponSaleOrLiquidationNetOfTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossForeignCurrencyTransactionAndTranslationReclassificationAdjustmentFromAOCIRealizedUponSaleOrLiquidationNetOfTax."
+],
+"OtherComprehensiveIncomeLossForeignCurrencyTranslationReclassificationAdjustmentRealizedUponSaleOrLiquidationTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossForeignCurrencyTransactionAndTranslationReclassificationAdjustmentFromAOCIRealizedUponSaleOrLiquidationTax."
+],
+"OtherComprehensiveIncomeLossNetOfTaxPeriodIncreaseDecrease": [
+"2012-01-31",
+"Element was deprecated because it has no balance attribute. Possible replacement is OtherComprehensiveIncomeLossNetOfTax."
+],
+"OtherComprehensiveIncomeLossPensionAndOtherPostretirementBenefitPlansCurtailmentTaxEffect": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is OtherComprehensiveIncomeFinalizationOfPensionAndNonPensionPostretirementPlanValuationTax."
+],
+"OtherComprehensiveIncomeLossReclassificationAdjustmentForSaleOfSecuritiesIncludedInNetIncomeBeforeTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForSaleOfSecuritiesBeforeTax."
+],
+"OtherComprehensiveIncomeLossReclassificationAdjustmentForSaleOfSecuritiesIncludedInNetIncomeNetOfTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForSaleOfSecuritiesNetOfTax."
+],
+"OtherComprehensiveIncomeLossReclassificationAdjustmentForSaleOfSecuritiesIncludedInNetIncomeTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForSaleOfSecuritiesTax."
+],
+"OtherComprehensiveIncomeLossReclassificationAdjustmentForWriteDownOfSecuritiesIncludedInNetIncomeTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForWritedownOfSecuritiesTax."
+],
+"OtherComprehensiveIncomeLossReclassificationAdjustmentForWritedownOfSecuritiesIncludedInNetIncomeBeforeTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForWritedownOfSecuritiesBeforeTax."
+],
+"OtherComprehensiveIncomeLossReclassificationAdjustmentForWritedownOfSecuritiesIncludedInNetIncomeNetOfTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForWritedownOfSecuritiesNetOfTax."
+],
+"OtherComprehensiveIncomeLossReclassificationAdjustmentOnDerivativesIncludedInNetIncomeBeforeTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIOnDerivativesBeforeTax."
+],
+"OtherComprehensiveIncomeLossReclassificationAdjustmentOnDerivativesIncludedInNetIncomeNetOfTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIOnDerivativesNetOfTax."
+],
+"OtherComprehensiveIncomeLossReclassificationAdjustmentOnDerivativesIncludedInNetIncomeTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIOnDerivativesTax."
+],
+"OtherComprehensiveIncomeLossReclassificationPensionAndOtherPostretirementBenefitPlansNetGainLossRecognizedInNetPeriodicBenefitCostTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetGainLossTax."
+],
+"OtherComprehensiveIncomeLossReclassificationPensionAndOtherPostretirementBenefitPlansNetTransitionAssetObligationRecognizedInNetPeriodicBenefitCostTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetTransitionAssetObligationTax."
+],
+"OtherComprehensiveIncomeLossTaxPortionAttributableToParent": [
+"2012-01-31",
+"Element was deprecated because it has no balance attribute. Possible replacement is OtherComprehensiveIncomeLossTaxPortionAttributableToParent1."
+],
+"OtherComprehensiveIncomeMinimumPensionLiabilityNetAdjustmentBeforeTax": [
+"2012-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"OtherComprehensiveIncomeMinimumPensionLiabilityNetAdjustmentNetOfTax": [
+"2012-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"OtherComprehensiveIncomeMinimumPensionLiabilityNetAdjustmentTax": [
+"2012-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"OtherComprehensiveIncomeReclassificationAdjustmentForHeldToMaturityTransferredToAvailableForSaleSecuritiesNetOfTax": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is OtherComprehensiveIncomeLossTransfersFromHeldToMaturityToAvailableForSaleSecuritiesNetOfTax."
+],
+"OtherComprehensiveIncomeReclassificationAdjustmentForSaleOfSecuritiesIncludedInNetIncomeBeforeTax": [
+"2012-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForSaleOfSecuritiesBeforeTax."
+],
+"OtherComprehensiveIncomeReclassificationAdjustmentForSaleOfSecuritiesIncludedInNetIncomeNetOfTax": [
+"2012-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForSaleOfSecuritiesNetOfTax."
+],
+"OtherComprehensiveIncomeReclassificationAdjustmentForSaleOfSecuritiesIncludedInNetIncomeTax": [
+"2012-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForSaleOfSecuritiesTax."
+],
+"OtherComprehensiveIncomeReclassificationAdjustmentForWriteDownOfSecuritiesIncludedInNetIncomeBeforeTax": [
+"2012-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForWritedownOfSecuritiesBeforeTax."
+],
+"OtherComprehensiveIncomeReclassificationAdjustmentForWriteDownOfSecuritiesIncludedInNetIncomeNetOfTax": [
+"2012-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForWritedownOfSecuritiesNetOfTax."
+],
+"OtherComprehensiveIncomeReclassificationAdjustmentForWriteDownOfSecuritiesIncludedInNetIncomeTax": [
+"2012-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForWritedownOfSecuritiesTax."
+],
+"OtherComprehensiveIncomeReclassificationAdjustmentOnDerivativesIncludedInNetIncomeBeforeTax": [
+"2012-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIOnDerivativesBeforeTax."
+],
+"OtherComprehensiveIncomeReclassificationAdjustmentOnDerivativesIncludedInNetIncomeNetOfTax": [
+"2012-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIOnDerivativesNetOfTax."
+],
+"OtherComprehensiveIncomeReclassificationAdjustmentOnDerivativesIncludedInNetIncomeTax": [
+"2012-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIOnDerivativesTax."
+],
+"OtherComprehensiveIncomeReclassificationOfDefinedBenefitPlanNetTransitionAssetObligationRecognizedInNetPeriodicBenefitCostBeforeTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetTransitionAssetObligationBeforeTax."
+],
+"OtherComprehensiveIncomeReclassificationOfDefinedBenefitPlanNetTransitionAssetObligationRecognizedInNetPeriodicBenefitCostNetOfTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetTransitionAssetObligationNetOfTax."
+],
+"OtherComprehensiveIncomeReclassificationOfDefinedBenefitPlansNetGainLossRecognizedInNetPeriodicBenefitCostBeforeTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetGainLossBeforeTax."
+],
+"OtherComprehensiveIncomeReclassificationOfDefinedBenefitPlansNetGainLossRecognizedInNetPeriodicBenefitCostNetOfTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetGainLossNetOfTax."
+],
+"OtherComprehensiveIncomeReclassificationOfDefinedBenefitPlansNetGainLossRecognizedInNetPeriodicBenefitCostTax": [
+"2012-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetGainLossTax."
+],
+"OtherComprehensiveIncomeReclassificationOfDefinedBenefitPlantNetTransitionAssetObligationRecognizedInNetPeriodicBenefitCostTax": [
+"2012-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetTransitionAssetObligationTax."
+],
+"OtherCostAndExpenseDisclosureOperatingAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"OtherDeferredCostAmortizationExpense": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is OtherAmortizationOfDeferredCharges."
+],
+"OtherDerivativesNotDesignatedAsHedgingInstrumentsAssetsAtFairValue": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DerivativeInstrumentsNotDesignatedAsHedgingInstrumentsAssetAtFairValue."
+],
+"OtherExpenseCapitalizationToDeferredAcquisitionCostDAC": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is DeferredPolicyAcquisitionCostsAdditions."
+],
+"OtherExpenseOfInsuranceEntities": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is OtherExpenses."
+],
+"OtherExpenseOfInsuranceEntitiesAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"OtherInterestIncomeMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is InterestIncomeOther."
+],
+"OtherMaterialNoncashItems": [
+"2013-01-31",
+"Element was deprecated due to remodeling of Segment area. Possible replacement is corresponding primary line items and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
+],
+"OtherMember": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is OtherCreditDerivativesMember."
+],
+"OtherNoninterestExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OtherNoninterestExpense."
+],
+"OtherNonrecurringExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OtherNonrecurringExpense."
+],
+"OtherNonrecurringGainMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OtherNonrecurringGain."
+],
+"OtherOperatingExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OtherCostAndExpenseOperating."
+],
+"OtherPremiumRevenueNet": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is PremiumsEarnedNetOtherInsurance."
+],
+"OtherResearchAndDevelopmentExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OtherResearchAndDevelopmentExpense."
+],
+"OtherSellingAndMarketingExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OtherSellingAndMarketingExpense."
+],
+"OtherTaxCarryforwardDataByItemAxis": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TaxCreditCarryforwardAxis."
+],
+"OtherTaxCarryforwardDeferredTaxAsset": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TaxCreditCarryforwardDeferredTaxAsset."
+],
+"OtherTaxCarryforwardDescription": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TaxCreditCarryforwardDescription."
+],
+"OtherTaxCarryforwardExpirationDates": [
+"2013-01-31",
+"Element was deprecated because it is has a stringItemType attribute. Possible replacement is TaxCreditCarryforwardExpirationDate."
+],
+"OtherTaxCarryforwardGrossAmount": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TaxCreditCarryforwardAmount."
+],
+"OtherTaxCarryforwardLimitationsOnUse": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TaxCreditCarryforwardLimitationsOnUse."
+],
+"OtherTaxCarryforwardLineItems": [
+"2013-01-31",
+"Element was deprecated."
+],
+"OtherTaxCarryforwardNameDomain": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TaxCreditCarryforwardNameDomain."
+],
+"OtherTaxCarryforwardTable": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TaxCreditCarryforwardTable."
+],
+"OtherTaxCarryforwardValuationAllowance": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TaxCreditCarryforwardValuationAllowance."
+],
+"OtherThanTemporaryImpairmentLossesInvestmentsAvailableforsaleSecuritiesPortionRecognizedInEarningsNetQualitativeDisclosuresThirdPartyGuaranteesDescription": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is AvailableforsaleSecuritiesInUnrealizedLossPositionsQualitativeDisclosureOtherThirdPartyGuaranteesDescription."
+],
+"OtherThanTemporaryImpairmentLossesInvestmentsHeldtomaturitySecuritiesPortionRecognizedInEarningsNetQualitativeDisclosuresThirdPartyGuaranteesDescription": [
+"2013-01-31",
+"Element was deprecated."
+],
+"OutstandingStockAwardsMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is StockCompensationPlanMember."
+],
+"ParticipatingSecuritiesDistributedAndUndistributedEarnings": [
+"2014-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are ParticipatingSecuritiesDistributedAndUndistributedEarningsLossBasic or ParticipatingSecuritiesDistributedAndUndistributedEarningsLossDiluted."
+],
+"PartiesToContractualArrangementAxis": [
+"2014-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is LeaseArrangementTypeAxis."
+],
+"PartiesToContractualArrangementMember": [
+"2014-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is LeaseArrangementTypeDomain."
+],
+"PaymentAndPerformanceRiskCreditRatingAxis": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are CreditRatingAMBestAxis, CreditRatingMoodysAxis, CreditRatingStandardPoorsAxis, CreditRatingFitchAxis, ExternalCreditRatingByGroupingAxis, InternalCreditAssessmentAxis."
+],
+"PaymentsForPurchaseOfOtherAssets": [
+"2013-01-31",
+"Element was deprecated because it was being used for either operating or investing activities. Possible replacements are PaymentsForPurchaseOfOtherAssets1, PaymentsForProceedsFromOtherInvestingActivities or PaymentsToAcquireOtherProductiveAssets."
+],
+"PaymentsForRepurchaseOfCommonStockForEmployeeTaxWithholdingObligations": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is PaymentsRelatedToTaxWithholdingForShareBasedCompensation."
+],
+"PendingOrThreatenedLitigationMember": [
+"2012-01-31",
+"Element was deprecated. Possible replacements are PendingLitigationMember or ThreatenedLitigationMember."
+],
+"PensionCostMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is PensionCostsMember."
+],
+"PersonalLinesMember": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is PropertyAndCasualtyPersonalInsuranceProductLineMember."
+],
+"PhaseInPlanNetChangeInAmountOfCostsDeferredForRateMakingPurposesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"PolicyChargesInsurance": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is InsuranceCommissionsAndFees."
+],
+"PolicyholdersSurplusOfLifeInsuranceEntityMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are PolicyHoldersSurplus, DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferencePolicyHoldersSurplus, DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxablePolicyHoldersSurplus, DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityPolicyHoldersSurplus, and DeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticablePolicyHoldersSurplus."
+],
+"PostageExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is PostageExpense."
+],
+"PreOpeningCostsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is PreOpeningCosts."
+],
+"PreferredStockSubjectToMandatoryRedemptionMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is MandatorilyRedeemablePreferredStockMember."
+],
+"PremiumIncomeSubjectToParticipationThroughReinsurancePercentage": [
+"2013-01-31",
+"Element was deprecated."
+],
+"PremiumIncomeSubjectToParticipationThroughReinsuranceValue": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is AssumedPremiumsEarned."
+],
+"PremiumsEarnedNetAccidentAndHealthAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"PremiumsEarnedNetByProductSegmentAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"PremiumsEarnedNetFinancialGuaranteeInsuranceContractsAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"PremiumsEarnedNetLifeAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"PremiumsEarnedNetOtherInsuranceAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"PremiumsEarnedNetPropertyAndCasualtyAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"PremiumsNetLifeInsuranceInForce": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is LifeInsuranceInForceNet."
+],
+"PremiumsNetLifeInsuranceInForceAbstract": [
+"2014-01-31",
+"Element was deprecated."
+],
+"PremiumsReceivableAllowanceForDoubtfulAccountsProvisionChargedToExpense": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is PremiumsReceivableAllowanceForDoubtfulAccountsProvisionChargedToExpense1."
+],
+"PremiumsReceivableFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
+],
+"PremiumsReceivableFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
+],
+"PremiumsWrittenAssumedCededAndEarnedAndIndustryRatiosAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"PremiumsWrittenNetAccidentAndHealth": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PremiumsWrittenNet and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"PremiumsWrittenNetAccidentAndHealthAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"PremiumsWrittenNetFinancialGuaranteeInsuranceContracts": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PremiumsWrittenNet and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"PremiumsWrittenNetFinancialGuaranteeInsuranceContractsAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"PremiumsWrittenNetLife": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PremiumsWrittenNet and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"PremiumsWrittenNetLifeAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"PremiumsWrittenNetOtherInsurance": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PremiumsWrittenNet and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"PremiumsWrittenNetOtherInsuranceAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"PremiumsWrittenNetPropertyAndCasualty": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PremiumsWrittenNet and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"PremiumsWrittenNetPropertyAndCasualtyAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"PrepaidReinsurancePremiumsAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"PrepaidReinsurancePremiumsMethodologyAndAssumptions": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is NaturePurposeAndEffectOfReinsuranceTransactions."
+],
+"PrescriptionDrugBenefitEffectOfSubsidyOnNetPeriodicPostretirementBenefitCost": [
+"2012-01-31",
+"Element was deprecated because it has an instant period type. Possible replacement is PrescriptionDrugBenefitEffectOfSubsidyOnNetPeriodicPostretirementBenefitCost1."
+],
+"PrescriptionDrugSubsidyReceiptsFiveFiscalYearsThereafter": [
+"2012-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is PrescriptionDrugSubsidyReceiptsafterYearFive."
+],
+"PrescriptionDrugSubsidyReceiptsYearFive": [
+"2012-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is PrescriptionDrugSubsidyReceiptsYearFive1."
+],
+"PrescriptionDrugSubsidyReceiptsYearFour": [
+"2012-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is PrescriptionDrugSubsidyReceiptsYearFour1."
+],
+"PrescriptionDrugSubsidyReceiptsYearOne": [
+"2012-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is PrescriptionDrugSubsidyReceiptsNextTwelveMonths."
+],
+"PrescriptionDrugSubsidyReceiptsYearThree": [
+"2012-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is PrescriptionDrugSubsidyReceiptsYearThree1."
+],
+"PrescriptionDrugSubsidyReceiptsYearTwo": [
+"2012-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is PrescriptionDrugSubsidyReceiptsYearTwo1."
+],
+"PresentValueOfFutureInsuranceProfits": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ValueOfBusinessAcquiredVOBA."
+],
+"PresentValueOfFutureInsuranceProfitsAmortizationExpense": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsAmortizationExpense1."
+],
+"PresentValueOfFutureInsuranceProfitsDecreases": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsDecrease."
+],
+"PresentValueOfFutureInsuranceProfitsImpairmentWriteDown": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsImpairmentWriteDown1."
+],
+"PresentValueOfFutureInsuranceProfitsInterestAccrued": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsInterestAccrued1."
+],
+"PresentValueOfFutureInsuranceProfitsUnrealizedInvestmentGains": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsUnrealizedInvestmentGains1."
+],
+"PresentValueOfFutureInsuranceProfitsUnrealizedInvestmentLosses": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsUnrealizedInvestmentLosses1."
+],
+"PriorPeriodReclassificationAdjustmentAbstract": [
+"2012-01-31",
+"This element has been deprecated because its children have been relocated."
+],
+"ProceedsFromLoanAndLeaseOriginationsAndPrincipalCollections": [
+"2012-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is ProceedsFromLoanAndLeaseOriginationsAndPrincipalCollections1."
+],
+"ProceedsFromLoanOriginations": [
+"2012-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is ProceedsFromLoanOriginations1."
+],
+"ProceedsFromRecoveriesOfLoansPreviouslyChargedOff": [
+"2012-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is ProceedsFromRecoveriesOfLoanPreviouslyChargedOff."
+],
+"ProceedsFromSaleOfOtherAssets": [
+"2013-01-31",
+"Element was deprecated because it was being used for either operating or investing activities. Possible replacements are ProceedsFromSaleOfOtherAssets1 and ProceedsFromSaleOfOtherAssetsInvestingActivities."
+],
+"ProductLiabilityContingencyAccrualDiscountAmount": [
+"2012-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LossContingencyAccrualProductLiabilityDiscount."
+],
+"ProductLiabilityContingencyLossInestimableExplanation": [
+"2012-01-31",
+"Element was deprecated because it has a durationStringItemType. Possible replacement is ProductLiabilityContingencyLossInestimableStatement."
+],
+"ProductRecallAxis": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"ProductRecallDomain": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"ProductRecallMember": [
+"2012-01-31",
+"Element was deprecated because the dimension of the financial reporting concept was remodeled."
+],
+"ProductionAndDistributionCostsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ProductionAndDistributionCosts."
+],
+"ProductionAndPropertyTaxExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ProductionTaxExpense or RealEstateTaxExpense."
+],
+"ProductionBarrelsOfOilEquivalents": [
+"2013-01-31",
+"Element was deprecated because it has a boeItemType attribute. Possible replacement is ProductionBarrelsOfOilEquivalents1."
+],
+"ProfessionalFeesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ProfessionalFees."
+],
+"ProjectWithExploratoryWellCostsCapitalizedForMoreThanOneYearNameDomain": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is ProjectMember."
+],
+"ProjectsWithExploratoryWellCostsCapitalizedForMoreThanOneYearByProjectAxis": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is CapitalizedCostsOfUnprovedPropertiesExcludedFromAmortizationByPropertyOrProjectAxis."
+],
+"PropertyPlantAndEquipmentUsefulLifeAverage": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is PropertyPlantAndEquipmentUsefulLife."
+],
+"PropertyPlantAndEquipmentUsefulLifeMaximum": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType and the financial reporting concept was modeled as a dimension. Possible replacements are PropertyPlantAndEquipmentUsefulLife and RangeAxis (MaximumMember) ."
+],
+"PropertyPlantAndEquipmentUsefulLifeMinimum": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType and the financial reporting concept was modeled as a dimension. Possible replacements are PropertyPlantAndEquipmentUsefulLife and Range Axis (MinimumMember)."
+],
+"ProvedDevelopedReservesBOE": [
+"2013-01-31",
+"Element was deprecated because it has a boeItemType attribute. Possible replacement is ProvedDevelopedReservesBOE1."
+],
+"ProvedOilAndGasReserveQuantitiesDisclosureTextBlock": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is ScheduleOfProvedDevelopedAndUndevelopedOilAndGasReserveQuantitiesTextBlock."
+],
+"ProvedUndevelopedReserveBOE": [
+"2013-01-31",
+"Element was deprecated because it has a boeItemType attribute. Possible replacement is ProvedUndevelopedReserveBOE1."
+],
+"ProvisionForLossesOnOperatingAndOrDevelopmentPropertyMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"PublicUtilitiesPropertyPlantAndEquipmentAmountOfAcquisitionAdjustments": [
+"2012-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentAmountOfAcquisitionAdjustments1."
+],
+"PublicUtilitiesPropertyPlantAndEquipmentAmountOfAcquisitionAdjustmentsRelatedAccumulatedDepreciation": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentAmountOfAcquisitionAdjustmentsRelatedAccumulatedDepreciation1."
+],
+"PublicUtilitiesPropertyPlantAndEquipmentCommonEstimatedUsefulLife": [
+"2013-01-31",
+"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentCommonUsefulLife."
+],
+"PublicUtilitiesPropertyPlantAndEquipmentDescriptionOfAmortizationOfPresentValueOfRegulatedAssetForPlantAbandonment": [
+"2012-01-31",
+"Element was deprecated because it has a stringItemType. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentAmortizationOfPresentValueOfRegulatedAssetForPlantAbandonment."
+],
+"PublicUtilitiesPropertyPlantAndEquipmentDistributionEstimatedUsefulLife": [
+"2013-01-31",
+"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentDistributionUsefulLife."
+],
+"PublicUtilitiesPropertyPlantAndEquipmentEquipmentEstimatedUsefulLife": [
+"2013-01-31",
+"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentEquipmentUsefulLife."
+],
+"PublicUtilitiesPropertyPlantAndEquipmentFuelEstimatedUsefulLife": [
+"2013-01-31",
+"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentFuelUsefulLife."
+],
+"PublicUtilitiesPropertyPlantAndEquipmentGenerationEstimatedUsefulLife": [
+"2013-01-31",
+"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentGenerationUsefulLife."
+],
+"PublicUtilitiesPropertyPlantAndEquipmentOtherPropertyPlantAndEquipmentEstimatedUsefulLife": [
+"2013-01-31",
+"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentOtherPropertyPlantAndEquipmentUsefulLife."
+],
+"PublicUtilitiesPropertyPlantAndEquipmentTransmissionAndDistributionEstimatedUsefulLife": [
+"2013-01-31",
+"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentTransmissionAndDistributionUsefulLife."
+],
+"PublicUtilitiesPropertyPlantAndEquipmentTransmissionEstimatedUsefulLife": [
+"2013-01-31",
+"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentTransmissionUsefulLife."
+],
+"PublicUtilitiesPropertyPlantAndEquipmentVehiclesEstimatedUsefulLife": [
+"2013-01-31",
+"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentVehiclesUsefulLife."
+],
+"PurchasePriceAllocationAdjustmentsMember": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"PurchasedCallOptionMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CallOptionMember with LongMember."
+],
+"PurchasedPutOptionMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PutOptionMember with LongMember."
+],
+"PutOptionsPurchasedMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PutOptionMember with LongMember."
+],
+"PutOptionsWrittenMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PutOptionMember with ShortMember."
+],
+"QualitativeAndQuantitativeInformationAssetOrLiabilityTransferorsContinuingInvolvementSecuritizationOrAssetbackedFinancingPrincipalAmountOutstandingContinuedRecognitionAmount": [
+"2014-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is SecuritizedAssetsAndAnyOtherFinancialAssetsManagedTogetherPrincipalAmountOutstanding."
+],
+"QualitativeAndQuantitativeInformationAssetOrLiabilityTransferorsContinuingInvolvementSecuritizationOrAssetbackedFinancingPrincipalAmountOutstandingDerecognizedAmount": [
+"2014-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is DerecognizedAssetsSecuritizedOrAssetbackedFinancingArrangementAssetsAndAnyOtherFinancialAssetsManagedTogetherPrincipalAmountOutstanding."
+],
+"QualitativeAndQuantitativeInformationAssetsOrLiabilitiesForTransferorsContinuingInvolvementInSecuritizationOrAssetbackedFinancingArrangementPrincipalAmountsOutstanding": [
+"2014-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is ContinuingInvolvementWithTransferredFinancialAssetsPrincipalAmountOutstanding."
+],
+"RatioOfIndebtednessToNetCapital": [
+"2012-01-31",
+"Element deprecated because it is decimalItemType. If you have used in the past, Possible replacement is RatioOfIndebtednessToNetCapital1."
+],
+"RealEstateAccumulatedDepreciationDepreciationExpense": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is SECScheduleIIIRealEstateAccumulatedDepreciationDepreciationExpense."
+],
+"RealEstateAndAccumulatedDepreciationAccumulatedDepreciation": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is RealEstateAccumulatedDepreciation."
+],
+"RealEstateAndAccumulatedDepreciationCarryingAmountOfLandAndBuildingsAndImprovements": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is RealEstateGrossAtCarryingValue."
+],
+"RealEstateAndAccumulatedDepreciationDateAcquired": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. Possible replacement is RealEstateAndAccumulatedDepreciationDateAcquired1."
+],
+"RealEstateAndAccumulatedDepreciationDateOfConstruction": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. Possible replacement is RealEstateAndAccumulatedDepreciationDateOfConstruction1."
+],
+"RealEstateAndAccumulatedDepreciationDescriptionOfProperty": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are corresponding primary line items and members of StatementGeographicalAxis and MortgageLoansOnRealEstateDescriptionTypeOfPropertyAxis."
+],
+"RealEstateAndAccumulatedDepreciationLifeUsedForDepreciation": [
+"2012-01-31",
+"Element deprecated because it is modeled as decimalItemType. If you have used, Possible replacement is RealEstateAndAccumulatedDepreciationLifeUsedForDepreciation1."
+],
+"RealEstateInsuranceMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is RealEstateInsurance."
+],
+"RealEstateOwnedAmountOfLossAtAcquisition": [
+"2013-01-31",
+"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is RealEstateOwnedAmountOfLossAtAcquisition1."
+],
+"RealEstateOwnedValuationAllowanceProvision": [
+"2014-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is RealEstateOwnedValuationAllowanceProvision1."
+],
+"RealEstateTaxesAndInsuranceMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is RealEstateTaxesAndInsurance."
+],
+"RealEstateTaxesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is RealEstateTaxExpense."
+],
+"RealEstateWriteDownOrReserveAmount": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is SECScheduleIIIRealEstateWriteDownOrReserveAmount."
+],
+"RealEstateWriteDownOrReserveByPropertyAxis": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is RealEstateAndAccumulatedDepreciationDescriptionOfPropertyAxis."
+],
+"RealEstateWriteDownOrReservePropertyDomain": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is RealEstateAndAccumulatedDepreciationNameOfPropertyDomain."
+],
+"RealizedGainLossOnSaleOfInvestmentsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is RealizedInvestmentGainsLosses."
+],
+"RealizedLossesOnSaleOfInvestmentsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is MarketableSecuritiesRealizedGainLoss."
+],
+"ReceivablesFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
+],
+"ReceivablesFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
+],
+"ReceivablesHeldForSaleNetAmount": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DisposalGroupIncludingDiscontinuedOperationAccountsNotesAndLoansReceivableNet."
+],
+"RedeemableNoncontrollingInterestAbstract": [
+"2012-01-31",
+"This element was deprecated because its children were relocated."
+],
+"RefinancingOfDebtMember": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"RefundsReceivedRelatedToRevenueFromDifferentYearMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"RegulatoryCapitalDisclosuresForBusinessCombinations": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"ReinsuranceEffectOnClaimsAndBenefitsIncurredNetAmount": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is PolicyholderBenefitsAndClaimsIncurredNet."
+],
+"ReinsuranceEffectOnClaimsAndBenefitsIncurredNetAmountAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"ReinsuranceEffectOnClaimsAndBenefitsIncurredPoliciesAcquiredInPeriod": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is PolicyholderBenefitsAndClaimsIncurredGross."
+],
+"ReinsuranceEffectOnOperations": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is NaturePurposeAndEffectOfReinsuranceTransactions."
+],
+"ReinsuranceLiabilitiesMethodologiesAndAssumptions": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is NaturePurposeAndEffectOfReinsuranceTransactions."
+],
+"ReinsuranceLossOnUncollectibleAccountsInPeriodDescription": [
+"2013-01-31",
+"Element was deprecated due to remodeling of reinsurance topic area."
+],
+"ReinsuranceNote": [
+"2013-01-31",
+"Element was deprecated due to remodeling of reinsurance topic area."
+],
+"ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAmountAssumedFromOtherCompanies": [
+"2013-01-31",
+"Element was deprecated. Possible replacement is AssumedPremiumsEarned."
+],
+"ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAmountCededToOtherCompanies": [
+"2013-01-31",
+"Element was deprecated. Possible replacement is CededPremiumsEarned."
+],
+"ReinsurancePremiumsForInsuranceCompaniesByProductSegmentGrossAmount": [
+"2013-01-31",
+"Element was deprecated. Possible replacement is DirectPremiumsEarned."
+],
+"ReinsurancePremiumsForInsuranceCompaniesByProductSegmentNetAmount": [
+"2013-01-31",
+"Element was deprecated. Possible replacement is PremiumsEarnedNet."
+],
+"ReinsurancePremiumsForInsuranceCompaniesByProductSegmentPercentageOfAmountAssumedToNet": [
+"2013-01-31",
+"Element was deprecated. Possible replacement is PremiumsPercentageAssumedToNet."
+],
+"ReinsurerOtherAssetsAndLiabilitiesAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"RelatedPartyTransactionRevenuesFromTransactionsWithRelatedParty": [
+"2012-01-31",
+"Element was deprecated due to redundancy. Possible replacement is RevenueFromRelatedParties."
+],
+"RemainingRecoveryPeriodOfRegulatoryAssetsForWhichNoReturnOnInvestmentDuringRecoveryPeriodIsProvided": [
+"2012-01-31",
+"Element was deprecated because it has a durationStringItemType. Possible replacement is RemainingRecoveryPeriodOfRegulatoryAssetsForWhichNoReturnOnInvestmentDuringRecoveryPeriodIsProvided1."
+],
+"RepaymentOfDebtMember": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"ReportableSegmentsMember": [
+"2013-01-31",
+"Element was deprecated due to remodeling of Segment area. Create member element to identify specific segment."
+],
+"ReportingEntityMember": [
+"2014-01-31",
+"Element was deprecated because it is an invalid concept."
+],
+"RepurchaseAgreementCounterpartyAxis": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is CountepartyNameAxis."
+],
+"RepurchaseAgreementCounterpartyWeightedAverageMaturityOfAgreements": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is RepurchaseAgreementCounterpartyWeightedAverageMaturityOfAgreements1."
+],
+"RepurchaseOfEquityMember": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"RequiredNetCapitalUnderCommodityExchangeAct": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is RequiredNetCapitalUnderCommodityExchangeAct1."
+],
+"ResaleAgreementCounterpartyWeightedAverageMaturityOfAgreements": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is ResaleAgreementCounterpartyWeightedAverageMaturityOfAgreements1."
+],
+"ReserveForLossesAndLossAdjustmentExpenses": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LiabilityForClaimsAndClaimsAdjustmentExpense."
+],
+"ReservesProportionalInterestOfNetProvedReserveQuantitiesOfProportionatelyConsolidatedInvestees": [
+"2012-01-31",
+"Element was deprecated because it has an integerItemType. Possible replacement is ReservesProportionalInterestOfNetProvedReserveQuantitiesOfProportionatelyConsolidatedInvestees1."
+],
+"RestructuringAndRelatedCostCostIncurredToDate": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is RestructuringAndRelatedCostCostIncurredToDate1."
+],
+"RestructuringAndRelatedCostExpectedCost": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is RestructuringAndRelatedCostExpectedCost1."
+],
+"RestructuringAndRelatedCostExpectedCostRemaining": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is RestructuringAndRelatedCostExpectedCostRemaining1."
+],
+"RestructuringReservePeriodExpense": [
+"2012-01-31",
+"Element was deprecated due to redundancy. Possible replacement is RestructuringCharges."
+],
+"RestructuringReserveSettledWithCash": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is PaymentsForRestructuring."
+],
+"RestructuringReserveSettledWithoutCash": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is RestructuringReserveSettledWithoutCash1."
+],
+"RetailLandSalesReceivablesRangeOfStatedInterestRates": [
+"2012-01-31",
+"Element was deprecated because it has an integerItemType and redundant. Possible replacements are RetailLandSalesReceivablesLowEndOfRangeOfStatedInterestRates or RetailLandSalesReceivablesHighEndOfRangeOfStatedInterestRates."
+],
+"RetainedInterestFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
+],
+"RetainedInterestFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
+],
+"RetrospectiveEffectOfChangeInAccountingPrincipleTabularPresentationByFinancialStatementLineItemAmountAfterApplication": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are NewAccountingPronouncementsOrChangeInAccountingPrincipleTable. Line items that can be used instead of this element include, but are not limited to, IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest, ProfitLoss, EarningsPerShareBasic, and EarningsPerShareDiluted."
+],
+"RetrospectiveEffectOfChangeInAccountingPrincipleTabularPresentationByFinancialStatementLineItemAmountAfterApplicationAbstract": [
+"2012-01-31",
+"This element was deprecated because the children of this abstract were deprecated."
+],
+"RetrospectiveEffectOfChangeInAccountingPrincipleTabularPresentationByFinancialStatementLineItemAmountBeforeApplication": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are NewAccountingPronouncementsOrChangeInAccountingPrincipleTable. Line items that can be used instead of this element include, but are not limited to, IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest, ProfitLoss, EarningsPerShareBasic, and EarningsPerShareDiluted."
+],
+"RetrospectiveEffectOfChangeInAccountingPrincipleTabularPresentationByFinancialStatementLineItemAmountOfApplicationAdjustment": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept has been modeled as a dimension. Possible replacements are NewAccountingPronouncementsOrChangeInAccountingPrincipleTable. Line items that can be used instead of this element include, but are not limited to, IncomeLossFromContinuingOperationsBeforeIncomeTaxesExtraordinaryItemsNoncontrollingInterest, ProfitLoss, EarningsPerShareBasic, and EarningsPerShareDiluted."
+],
+"RevenueFromAdministrativeServices": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AdministrativeServicesRevenue and members of LegalEntityAxis."
+],
+"RevenueFromAdministrativeServicesAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"RevenueFromAdministrativeServicesAffiliated": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AdministrativeServicesRevenue and members of LegalEntityAxis."
+],
+"RevenueFromAdministrativeServicesOther": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AdministrativeServicesRevenue and members of LegalEntityAxis."
+],
+"RevenueFromFranchisedOutlets": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is FranchiseRevenue."
+],
+"RevenuesFromExternalCustomers": [
+"2013-01-31",
+"Element was deprecated due to remodeling of Segment area. Possible replacement is Revenues and members of ProductOrServiceAxis or MajorCustomersAxis."
+],
+"RevenuesFromTransactionsWithOtherOperatingSegmentsOfSameEntity": [
+"2013-01-31",
+"Element was deprecated due to remodeling of Segment area. Possible replacement is Revenues and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
+],
+"RevolvingLoanFacilityToFinanceLeveragedBuyout": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"RoyaltyPaymentsExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is RoyaltyExpense."
+],
+"SFAS141RElementsIncrementalToSFAS141Abstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"SaleAxis": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"SaleDomain": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"SaleLeasebackTransactionCumulativeGainRecognized": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is SaleLeasebackTransactionCumulativeGainRecognized1."
+],
+"SaleLeasebackTransactionGrossProceeds": [
+"2014-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are SaleLeasebackTransactionGrossProceedsInvestingActivities or SaleLeasebackTransactionGrossProceedsFinancingActivities."
+],
+"SaleLeasebackTransactionNetProceeds": [
+"2014-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are SaleLeasebackTransactionNetProceedsInvestingActivities or SaleLeasebackTransactionNetProceedsFinancingActivities."
+],
+"SaleLeasebackTransactionRelatedPartyTransaction": [
+"2013-01-31",
+"Element was deprecated due to redundancy.  Possible replacement is RelatedPartyTransactionDescriptionOfTransaction."
+],
+"SaleMember": [
+"2012-01-31",
+"Element was deprecated because the dimension of the financial reporting concept was remodeled."
+],
+"SaleOfStockSubsidiary": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is SubsidiariesMember."
+],
+"SalesCommissionsAndFeesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is SalesCommissionsAndFees."
+],
+"SalesOfEquityToFinanceLeveragedBuyout": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"SalesRevenueGoodsNetPercentage": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ConcentrationRiskPercentage1 and members of ConcentrationRiskByBenchmarkAxis."
+],
+"ScheduleOfAssetsOrLiabilitiesFromTransfersOfFinancialAssetsHavingNoReasonableEstimateOfFairValueTextBlock": [
+"2012-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"ScheduleOfAvailableForSaleSecuritiesMajorTypesOfDebtAndEquitySecuritiesAxis": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is MajorTypesOfDebtAndEquitySecuritiesAxis."
+],
+"ScheduleOfCalculationOfNumeratorAndDenominatorInEarningsPerShareTableTextBlock": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ScheduleOfEarningsPerShareBasicAndDilutedTableTextBlock."
+],
+"ScheduleOfClosedBlockSummarizedFinancialData": [
+"2013-01-31",
+"Element was deprecated."
+],
+"ScheduleOfCostMethodInvestmentsAxis": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is MajorTypesOfDebtAndEquitySecuritiesAxis."
+],
+"ScheduleOfDistributionsMadeToMemberOrLimitedPartnerTable": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacement is DistributionsMadeToLimitedLiabilityCompanyLLCMemberTable or DistributionsMadeToLimitedPartnerTable."
+],
+"ScheduleOfDistributionsMadeToMembersOrLimitedPartnersByDistributionTextBlock": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacement is  DistributionsMadeToLimitedLiabilityCompanyLlcMemberByDistributionTableTextBlock or DistributionsMadeToLimitedPartnerByDistributionTableTextBlock."
+],
+"ScheduleOfEarningsPerShareReconciliationTableTextBlock": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ScheduleOfEarningsPerShareBasicAndDilutedTableTextBlock."
+],
+"ScheduleOfEffectsOfChangesInPrepaymentEstimateAssumptionsForCollateralizedMortgageObligationsAndRealEstateMortgageInvestmentConduitsTextBlock": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"ScheduleOfEmployeeServiceShareBasedCompensationAllocationOfRecognizedPeriodCostsByReportLineAxis": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is IncomeStatementLocationAxis."
+],
+"ScheduleOfEquityIssuedSinceInceptionTable": [
+"2012-01-31",
+"Element was deprecated because it used a dimension to differentiate equity issuances. Possible replacement is the date context to differentiate equity issuances."
+],
+"ScheduleOfEquityIssuedSinceInceptionTextBlock": [
+"2012-01-31",
+"Element was deprecated because the disclosure is required in the statement of stockholders' equity."
+],
+"ScheduleOfExpectedAmortizationExpenseTableTextBlock": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ScheduleofFiniteLivedIntangibleAssetsFutureAmortizationExpenseTableTextBlock."
+],
+"ScheduleOfFiniteLivedIntangibleAssetsByMajorClassTable": [
+"2012-01-31",
+"Element was deprecated because the dimension of the financial reporting concept was remodeled. Possible replacements are ScheduleOfFiniteLivedIntangibleAssetsTable and members of FiniteLivedIntangibleAssetsByMajorClassAxis."
+],
+"ScheduleOfFiniteLivedIntangibleAssetsByMajorClassTextBlock": [
+"2012-01-31",
+"Element was deprecated because the dimension of the financial reporting concept was remodeled. Possible replacement is ScheduleOfFiniteLivedIntangibleAssetsTableTextBlock."
+],
+"ScheduleOfImpairedIntangibleAssetsTable": [
+"2012-01-31",
+"Element was deprecated. Possible replacements are ScheduleOfIndefiniteLivedIntangibleAssetsTable and/or ScheduleOfFiniteLivedIntangibleAssetsTable."
+],
+"ScheduleOfIndefiniteLivedIntangibleAssetsByMajorClassTable": [
+"2012-01-31",
+"Element was deprecated because the dimension of the financial reporting concept was remodeled. Possible replacements are ScheduleOfIndefiniteLivedIntangibleAssetsTable and members of IndefiniteLivedIntangibleAssetsByMajorClassAxis."
+],
+"ScheduleOfIndefiniteLivedIntangibleAssetsByMajorClassTextBlock": [
+"2012-01-31",
+"Element was deprecated because the dimension of the financial reporting concept was remodeled. Possible replacement is ScheduleOfIndefiniteLivedIntangibleAssetsTableTextBlock."
+],
+"ScheduleOfIndefiniteLivedIntangibleAssetsBySegmentTable": [
+"2012-01-31",
+"Element was deprecated because the dimension of the financial reporting concept was remodeled. Possible replacements are ScheduleOfIndefiniteLivedIntangibleAssetsTable and members of StatementBusinessSegmentsAxis."
+],
+"ScheduleOfIndefiniteLivedIntangibleAssetsBySegmentTextBlock": [
+"2012-01-31",
+"Element was deprecated because the indefinite-lived intangible assets dimension was revised. Possible replacement is ScheduleOfIndefiniteLivedIntangibleAssetsTableTextBlock."
+],
+"ScheduleOfInsuredFinancialObligationsWithCreditDeteriorationRemainingWeightedAverageContractPeriod": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is InsuredFinancialObligationsWithCreditDeteriorationRemainingWeightedAverageContractPeriod."
+],
+"ScheduleOfInvestmentIncomeReportedAmountsByCategoryAxis": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is InvestmentTypeAxis."
+],
+"ScheduleOfLifeSettlementContractsFairValueMethodFiveYearDisclosureAxis": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept modeled as a dimension was replaced with line items. Possible replacement is line items within ScheduleOfLifeSettlementContractsFairValueMethodTextBlock."
+],
+"ScheduleOfLifeSettlementContractsFairValueMethodTable": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept modeled as a dimension was replaced with line items. Possible replacement is line items within ScheduleOfLifeSettlementContractsFairValueMethodTextBlock."
+],
+"ScheduleOfLifeSettlementContractsInvestmentMethodFiveYearDisclosureAxis": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept modeled as a dimension was replaced with line items. Possible replacement is line items within ScheduleOfLifeSettlementContractsInvestmentMethodTextBlock."
+],
+"ScheduleOfLifeSettlementContractsInvestmentMethodTable": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept modeled as a dimension was replaced with line items. Possible replacement is line items within ScheduleOfLifeSettlementContractsInvestmentMethodTextBlock."
+],
+"ScheduleOfPurchasePriceAllocationTableTextBlock": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"ScheduleOfShareBasedCompensationArrangementByShareBasedPaymentAwardAwardTypeAndPlanNameAxis": [
+"2012-01-31",
+"Element was deprecated because the dimension of the financial reporting concept was remodeled. Possible replacements are PlanNameAxis and/or AwardTypeAxis."
+],
+"ScheduleOfTradingSecuritiesAndOtherTradingAssetsMajorTypesOfTradingSecuritiesAndAssetsAxis": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is MajorTypesOfDebtAndEquitySecuritiesAxis."
+],
+"ScheduleofLevelThreeDefinedBenefitPlanAssetsRollForwardTableTextBlock": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ScheduleOfEffectOfSignificantUnobservableInputsChangesInPlanAssetsTableTextBlock."
+],
+"SecuritiesLoanedOrSoldUnderAgreementsToRepurchaseFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
+],
+"SecuritiesLoanedOrSoldUnderAgreementsToRepurchaseFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
+],
+"SecuritiesSoldNotYetPurchasedFairValueDisclosure": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is FinancialInstrumentsSoldNotYetPurchasedAtFairValue."
+],
+"SecuritiesSoldNotYetPurchasedFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
+],
+"SecuritiesSoldNotYetPurchasedFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
+],
+"SecuritizationFinancialAssetForWhichTransferIsAccountedAsSaleAxis": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is FinancialInstrumentAxis."
+],
+"SecuritizedAssetsAndAnyOtherFinancialAssetsManagedTogetherAverageBalanceDuringPeriod": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"SecuritizedAssetsAndAnyOtherFinancialAssetsManagedTogetherByTypeOfFinancialInstrumentAxis": [
+"2014-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is FinancialInstrumentAxis."
+],
+"SecuritizedAssetsAndAnyOtherFinancialAssetsManagedTogetherNetCreditLossesDuringPeriod": [
+"2012-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is AssetsThatContinueToBeRecognizedSecuritizedOrAssetBackedFinancingArrangementAssetsAndAnyOtherFinancialAssetsManagedTogetherNetCreditLossesDuringPeriod."
+],
+"SegmentGeographicalGroupsOfCountriesGroupOneMember": [
+"2013-01-31",
+"Element deprecated because it was inappropriately modeled."
+],
+"SegmentGeographicalGroupsOfCountriesGroupTwoMember": [
+"2013-01-31",
+"Element deprecated because it was inappropriately modeled."
+],
+"SegmentReportingGeneralInformation": [
+"2012-01-31",
+"Element was deprecated. Possible replacements are FactorsUsedToIdentifyEntitysReportableSegments or DescriptionOfTypesOfProductsAndServicesFromWhichEachReportableSegmentDerivesItsRevenues."
+],
+"SegmentReportingInformationAverageAssets": [
+"2013-01-31",
+"Element was deprecated due to remodeling of Segment area. Possible replacement is Assets and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
+],
+"SegmentReportingInformationInventoryNet": [
+"2013-01-31",
+"Element was deprecated due to remodeling of Segment area. Possible replacement is corresponding primary line items and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
+],
+"SegmentReportingInformationInvestments": [
+"2013-01-31",
+"Element was deprecated due to remodeling of Segment area. Possible replacement is corresponding primary line items and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
+],
+"SegmentReportingInformationNetAssets": [
+"2013-01-31",
+"Element was deprecated due to remodeling of Segment area. Possible replacement is corresponding primary line items and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
+],
+"SegmentReportingInformationRevenue": [
+"2013-01-31",
+"Element was deprecated due to remodeling of Segment area. Possible replacement is Revenues and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
+],
+"SegmentReportingMeasurement": [
+"2012-01-31",
+"Element was deprecated. Possible replacements are DescriptionOfBasisOfAccountingForTransactionsBetweenReportableSegments, DescriptionOfNatureOfDifferencesBetweenMeasurementsOfReportableSegmentsProfitsOrLossesAndEntitysProfitOrLossBeforeIncomeTaxExpenseOrIncomeAndDiscontinuedOperations, DescriptionOfNatureOfDifferencesBetweenMeasurementsOfReportableSegmentsAssetsAndEntitysAssets, DescriptionOfNatureOfChangesFromPriorPeriodsInMeasurementMethodsUsedToDetermineReportedSegmentProfitOrLossAndEffectOfThoseChangesOnMeasureOfSegmentProfitOrLoss, or DescriptionOfNatureAndEffectOfAnyAsymmetricalAllocationsToReportableSegments."
+],
+"SellingExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is SellingExpense."
+],
+"SeparateAccountsAsset": [
+"2012-01-31",
+"Element was deprecated due to redundancy. Possible replacement is SeparateAccountAssets."
+],
+"ServicingAssetAtAmortizedValueAmortization": [
+"2012-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is ServicingAssetAtAmortizedValueAmortization1."
+],
+"ServicingAssetAtAmortizedValueChangesInCarryingAmountLocationInIncomeStatementDescription": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ServicingAssetAtAmortizedValue and members of IncomeStatementLocationAxis."
+],
+"ServicingAssetAtAmortizedValueOtherThanTemporaryImpairments": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is ServicingAssetAtAmortizedCostOtherThanTemporaryImpairments."
+],
+"ServicingAssetAtFairValueChangesInFairValueLocationInIncomeStatementDescription": [
+"2014-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionGainLossOnDisposition1 and members of IncomeStatementLocationAxis."
+],
+"ServicingAssetsAndServicingLiabilitiesAtFairValueAssumptionsUsedToEstimateFairValueWeightedAverageLife": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is ServicingAssetsAndServicingLiabilitiesAtFairValueAssumptionsUsedToEstimateFairValueWeightedAverageLife1."
+],
+"ServicingAssetsAtAmortizedValueByTypesOfFinancialInstrumentsAxis": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is FinancialInstrumentAxis."
+],
+"ServicingAssetsAtFairValueByTypeOfFinancialInstrumentAxis": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is FinancialInstrumentAxis."
+],
+"ServicingLiabilityAtAmortizedCostAmount": [
+"2012-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ServicingLiabilityAtAmortizedValueBalance."
+],
+"ServicingLiabilityAtAmortizedValueAmortization": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance type. Possible replacement is ServicingLiabilityAtAmortizedCostAmortization."
+],
+"ServicingLiabilityAtAmortizedValueByTypesOfFinancialAssetsAxis": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is FinancialInstrumentAxis."
+],
+"ServicingLiabilityAtAmortizedValueFairValue": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is ServicingLiabilityAtAmortizedValueFairValue1."
+],
+"ServicingLiabilityAtAmortizedValueIncreaseInObligation": [
+"2012-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is ServicingLiabilityAtAmortizedValueIncreaseInObligation1."
+],
+"SettlementOfDebtMember": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"SettlementOfLitigationMember": [
+"2012-01-31",
+"Element was deprecated because the dimension of the financial reporting concept was remodeled. Possible replacements are LitigationStatusAxis and other elements/members as needed."
+],
+"SeveranceCosts": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacement is SeveranceCosts1."
+],
+"ShareBasedCompensationArrangementByShareBasedPaymentAwardAwardExpirationDating": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardExpirationDate."
+],
+"ShareBasedCompensationArrangementByShareBasedPaymentAwardAwardRequisiteServicePeriod": [
+"2012-01-31",
+"Element was deprecated because it has a durationStringItemType. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardAwardRequisiteServicePeriod1."
+],
+"ShareBasedCompensationArrangementByShareBasedPaymentAwardAwardVestingPeriod": [
+"2012-01-31",
+"Element was deprecated because it has a durationStringItemType. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardAwardVestingPeriod1."
+],
+"ShareBasedCompensationArrangementByShareBasedPaymentAwardAwardVestingPeriodMaximum": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardAwardVestingPeriod1, which has been modeled as a dimension."
+],
+"ShareBasedCompensationArrangementByShareBasedPaymentAwardAwardVestingPeriodMinimum": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardAwardVestingPeriod1, which has been modeled as a dimension."
+],
+"ShareBasedCompensationArrangementByShareBasedPaymentAwardCompensationCost": [
+"2012-01-31",
+"Element was deprecated. Possible replacements are AllocatedShareBasedCompensationExpense and/or EmployeeServiceShareBasedCompensationAllocationOfRecognizedPeriodCostsCapitalizedAmount."
+],
+"ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityConvertedInPeriod": [
+"2012-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardSharesIssuedInPeriod."
+],
+"ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsForfeitedInPeriodIntrinsicValue": [
+"2012-01-31",
+"Element was deprecated because it has an instant period type. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsForfeituresIntrinsicValue."
+],
+"ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsForfeitedInPeriodWeightedAverageGrantDateFairValue": [
+"2012-01-31",
+"Element was deprecated because it has an instant period type. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsForfeituresWeightedAverageGrantDateFairValue."
+],
+"ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsOutstandingWeightedAverageRemainingContractualTerm": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsOutstandingWeightedAverageRemainingContractualTerms."
+],
+"ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsPeriodIncreaseDecreaseIntrinsicValue": [
+"2013-01-31",
+"Element was deprecated due to rationalization."
+],
+"ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsTotalShareBasedLiabilitiesPaid": [
+"2014-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsShareBasedLiabilitiesPaid."
+],
+"ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsWeightedAverageGrantDateFairValuePeriodIncreaseDecrease": [
+"2013-01-31",
+"Element was deprecated due to rationalization."
+],
+"ShareBasedCompensationArrangementByShareBasedPaymentAwardFairValueAssumptionsExpectedTerm": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is SharebasedCompensationArrangementBySharebasedPaymentAwardFairValueAssumptionsExpectedTerm1."
+],
+"ShareBasedCompensationArrangementByShareBasedPaymentAwardFairValueAssumptionsExpectedTermMaximum": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacements are SharebasedCompensationArrangementBySharebasedPaymentAwardFairValueAssumptionsExpectedTerm1 dimensionalized by RangeAxis (MaximumMember)."
+],
+"ShareBasedCompensationArrangementByShareBasedPaymentAwardFairValueAssumptionsExpectedTermMinimum": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacements are SharebasedCompensationArrangementBySharebasedPaymentAwardFairValueAssumptionsExpectedTerm1 and RangeAxis (MinimumMember)."
+],
+"ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsExercisableWeightedAverageRemainingContractualTerm": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsExercisableWeightedAverageRemainingContractualTerm1."
+],
+"ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsExercisesInPeriodWeightedAverageExercisePrice": [
+"2012-01-31",
+"Element was deprecated because it has an instant period type. Possible replacement is ShareBasedCompensationArrangementsByShareBasedPaymentAwardOptionsExercisesInPeriodWeightedAverageExercisePrice."
+],
+"ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsExpirationsInPeriodWeightedAverageExercisePrice": [
+"2012-01-31",
+"Element was deprecated because it has an instant period type. Possible replacement is ShareBasedCompensationArrangementsByShareBasedPaymentAwardOptionsExpirationsInPeriodWeightedAverageExercisePrice."
+],
+"ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsForfeituresInPeriodWeightedAverageExercisePrice": [
+"2012-01-31",
+"Element was deprecated because it has an instant period type. Possible replacement is ShareBasedCompensationArrangementsByShareBasedPaymentAwardOptionsForfeituresInPeriodWeightedAverageExercisePrice."
+],
+"ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsGrantsInPeriodForfeited": [
+"2012-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsForfeituresInPeriod."
+],
+"ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsGrantsInPeriodWeightedAverageExercisePrice": [
+"2012-01-31",
+"Element was deprecated because it has an instant period type. Possible replacement is ShareBasedCompensationArrangementsByShareBasedPaymentAwardOptionsGrantsInPeriodWeightedAverageExercisePrice."
+],
+"ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsOtherShareIncreaseDecreaseInPeriodWeightedAverageExercisePrice": [
+"2012-01-31",
+"Element was deprecated because it has an instant period type. Possible replacement is ShareBasedCompensationArrangementsByShareBasedPaymentAwardOptionsOtherShareIncreaseDecreaseInPeriodWeightedAverageExercisePrice."
+],
+"ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsVestedAndExpectedToVestExercisableWeightedAverageRemainingContractualTerm": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is SharebasedCompensationArrangementBySharebasedPaymentAwardOptionsVestedAndExpectedToVestExercisableWeightedAverageRemainingContractualTerm1."
+],
+"ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsVestedAndExpectedToVestOutstandingWeightedAverageRemainingContractualTerm": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsVestedAndExpectedToVestOutstandingWeightedAverageRemainingContractualTerm1."
+],
+"ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsVestedInPeriodFairValue": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsVestedInPeriodFairValue1."
+],
+"ShareBasedGoodsAndNonemployeeServicesTransactionCashFlowEffects": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is IssuanceOfStockAndWarrantsForServicesOrClaims."
+],
+"ShareBasedGoodsAndNonemployeeServicesTransactionExpense": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is IssuanceOfStockAndWarrantsForServicesOrClaims."
+],
+"ShareBasedGoodsAndNonemployeeServicesTransactionValuationMethodExpectedTerm": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is ShareBasedGoodsAndNonemployeeServicesTransactionValuationMethodExpectedTerm1."
+],
+"SharebasedCompensationArrangementBySharebasedPaymentAwardOptionsOutstandingWeightedAverageRemainingContractualTerm1": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is SharebasedCompensationArrangementBySharebasedPaymentAwardOptionsOutstandingWeightedAverageRemainingContractualTerm2."
+],
+"SharebasedCompensationSharesAuthorizedUnderStockOptionPlansExercisePriceRangeExercisableOptionsWeightedAverageRemainingContractualTerm1": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is SharebasedCompensationSharesAuthorizedUnderStockOptionPlansExercisePriceRangeExercisableOptionsWeightedAverageRemainingContractualTerm2."
+],
+"SharebasedCompensationSharesAuthorizedUnderStockOptionPlansExercisePriceRangeOutstandingOptionsWeightedAverageRemainingContractualTerm1": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is SharebasedCompensationSharesAuthorizedUnderStockOptionPlansExercisePriceRangeOutstandingOptionsWeightedAverageRemainingContractualTerm2."
+],
+"ShareholderLoansToFinanceLeveragedBuyout": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"SharesSubjectToMandatoryRedemptionSettlementTermsForwardPriceOrOptionStrikePrice": [
+"2014-01-31",
+"Element was deprecated because it has a perUnitItemType attribute, it represents multiple distinct concepts and the financial reporting concept can be conveyed dimensionally. Possible replacements are OptionIndexedToIssuersEquityStrikePrice1 or ForwardContractIndexedToIssuersEquityForwardRate and members of ScheduleOfSharesSubjectToMandatoryRedemptionBySettlementTermsAxis."
+],
+"SharesSubjectToMandatoryRedemptionSettlementTermsImpactOfChangesInFairValueOfSharesOnNumberOfShares": [
+"2012-01-31",
+"Element was deprecated because it has an integerItemType. Possible replacement is FinancialInstrumentsSubjectToMandatoryRedemptionSettlementTermsImpactOfChangesInFairValueOfSharesOnNumberOfShares."
+],
+"ShippingHandlingAndTransportationCostsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ShippingHandlingandTransportationCosts."
+],
+"SignificantChangeInUnrecognizedTaxBenefitsNatureOfUncertainty": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacement is ReasonablyPossibleSignificantChangeInUnrecognizedTaxBenefitsByItemAxis and extension member elements."
+],
+"SignificantPurchaseCommitmentRemainingMinimumAmountCommitted": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is PurchaseCommitmentRemainingMinimumAmountCommitted."
+],
+"SiteContingencyAccrualCaption": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AccrualForEnvironmentalLossContingencies and members of BalanceSheetLocationAxis."
+],
+"SiteContingencyAccrualDiscountAmount": [
+"2013-01-31",
+"Element was deprecated due to redundancy.  Possible replacement is AccrualForEnvironmentalLossContingenciesDiscount."
+],
+"SiteContingencyAccrualDiscountRate": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is AccrualForEnvironmentalLossContingenciesDiscountRate."
+],
+"SiteContingencyAccrualPresentValue": [
+"2013-01-31",
+"Element was deprecated due to redundancy.  Possible replacement is AccrualForEnvironmentalLossContingencies."
+],
+"SiteContingencyAccrualUndiscountedAmount": [
+"2013-01-31",
+"Element was deprecated due to redundancy.  Possible replacement is AccrualForEnvironmentalLossContingenciesGross."
+],
+"SiteContingencyByNatureAxis": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are EnvironmentalRemediationSiteAxis or EnvironmentalRemediationContingencyAxis."
+],
+"SiteContingencyNatureOfContingencyDomain": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are EnvironmentalRemediationSiteDomain or EnvironmentalRemediationContingencyDomain."
+],
+"SoftwareMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ComputerSoftwareIntangibleAssetMember."
+],
+"SourcesAndUsesOfCashForLeveragedBuyoutAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"SourcesAndUsesOfCashForLeveragedBuyoutTextBlock": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"SquareFootageOfRealEstateProperty": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is AreaOfRealEstateProperty."
+],
+"StockOptionsMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is EmployeeStockOptionMember."
+],
+"StockRepurchaseProgramAuthorizedAmount": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is StockRepurchaseProgramAuthorizedAmount1."
+],
+"StockRepurchaseProgramPeriodInForce": [
+"2012-01-31",
+"Element was deprecated because it has a decimalItemType. Possible replacement is StockRepurchaseProgramPeriodInForce1."
+],
+"StockRepurchaseProgramRemainingAuthorizedRepurchaseAmount": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is StockRepurchaseProgramRemainingAuthorizedRepurchaseAmount1."
+],
+"StockholdersEquityIncludingPortionAttributableToNoncontrollingInterestAdjustedBalance": [
+"2013-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is StockholdersEquityIncludingPortionAttributableToNoncontrollingInterestAdjustedBalance1."
+],
+"StockholdersEquityNotAllowableForNetCapital": [
+"2012-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is StockholdersEquityAttributableToParentNotAllowableForNetCapital."
+],
+"StockholdersEquityNoteStockSplitConversionRatio": [
+"2013-01-31",
+"Element was deprecated because it has a decimalItemType attribute. Possible replacement is StockholdersEquityNoteStockSplitConversionRatio1."
+],
+"SubordinatedNotesToFinanceLeveragedBuyout": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"SubsequentEventAmount": [
+"2013-01-31",
+"Element was deprecated because it is an invalid concept."
+],
+"SubsequentEventAmountHigherRange": [
+"2013-01-31",
+"Element was deprecated because it is an invalid concept."
+],
+"SubsequentEventAmountLowerRange": [
+"2013-01-31",
+"Element was deprecated because it is an invalid concept."
+],
+"SubsequentEventDateEvaluated": [
+"2012-01-31",
+"Element was deprecated."
+],
+"SubsequentEventDateEvaluatedDescription": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"SubsequentEventDateEvaluationEnded": [
+"2012-01-31",
+"Element was deprecated."
+],
+"SubsequentEventDateEvaluationEnded1": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"SubsequentEventDateFinancialStatementsAvailableForIssuance": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"SubsequentEventDateFinancialStatementsIssued": [
+"2012-01-31",
+"Element was deprecated."
+],
+"SubsequentEventDateFinancialStatementsIssued1": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"SubsequentEventDateThroughWhichEvaluated": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"SubsequentEventProFormaImpact": [
+"2012-01-31",
+"Element was deprecated because the dimension of the financial reporting concept was remodeled. Possible replacements are ProformaMember and other elements/members as needed."
+],
+"SubsequentEventRevisedFinancialStatementsDateEvaluated": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"SubsequentEventRevisedFinancialStatementsDateEvaluatedDescription": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"SubsequentEventTermOfContract": [
+"2013-01-31",
+"Element deprecated because it was inappropriately modeled.  Possible replacements are LesseeLeasingArrangementsOperatingLeasesTermOfContract, LessorLeasingArrangementsOperatingLeasesTermOfContract or DerivativeTermOfContract."
+],
+"SubsidiaryOrEquityMethodInvesteePricePerShare": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is SaleOfStockPricePerShare."
+],
+"SummaryOfOtherTaxCarryforwardsTextBlock": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is SummaryOfTaxCreditCarryforwardsTextBlock."
+],
+"SuppliesAndPostageExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is SuppliesAndPostageExpense."
+],
+"SuppliesExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is SuppliesExpense."
+],
+"SwaptionsMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is SwaptionMember."
+],
+"TargetOrTrackingStockClassDomain": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is ClassOfStockDomain."
+],
+"TargetOrTrackingStockStockClassAxis": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is StatementClassOfStockAxis."
+],
+"TaxBenefitFromStockOptionsExercised": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is DeferredTaxExpenseFromStockOptionsExercised."
+],
+"TaxBenefitFromStockOptionsExercised1": [
+"2013-01-31",
+"Element was deprecated because it was incorrectly defined. Possible replacement is DeferredTaxExpenseFromStockOptionsExercised."
+],
+"TaxCreditCarryforwardExpirationDates": [
+"2012-01-31",
+"Element was deprecated because it has a stringItemType. Possible replacements are CashAvailableForDistributions or TaxCreditCarryforwardExpirationDate."
+],
+"TaxesAndLicensesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is TaxesAndLicenses."
+],
+"TaxesOtherThanIncomeAndExciseTaxesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is TaxesExcludingIncomeAndExciseTaxes."
+],
+"TemporaryEquityCarryingAmount": [
+"2012-01-31",
+"Element was deprecated. Possible replacements are TemporaryEquityCarryingAmountAttributableToParent, TemporaryEquityCarryingAmountAttributableToNoncontrollingInterest or RedeemableNoncontrollingInterestEquityCarryingAmount."
+],
+"TemporaryEquityCarryingAmountAttributableToNoncontrollingInterest": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is RedeemableNoncontrollingInterestEquityCarryingAmount."
+],
+"TemporaryEquityCarryingAmountAttributableToNoncontrollingInterestAbstract": [
+"2014-01-31",
+"Element was deprecated."
+],
+"TemporaryEquityRedemptionValue": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TemporaryEquityCarryingAmountIncludingPortionAttributableToNoncontrollingInterests."
+],
+"TimeSharingTransactionsAdditionsToAllowanceForCurrentPeriodSales": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is TimeSharingTransactionsAdditionsToAllowanceForCurrentPeriodSales1."
+],
+"TimeSharingTransactionsAdditionsToAllowanceForCurrentPeriodSalesOnReceivablesSoldWithRecourse": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is TimeSharingTransactionsAdditionsToAllowanceForCurrentPeriodSalesOnReceivablesSoldWithRecourse1."
+],
+"TimeSharingTransactionsRangeOfStatedInterestRatesForNotesReceivable": [
+"2012-01-31",
+"Element was deprecated because it has an integerItemType. Possible replacements are TimeSharingTransactionsStatedInterestRatesForNotesReceivableMinimum or TimeSharingTransactionsStatedInterestRatesForNotesReceivableMaximum."
+],
+"TimeSharingTransactionsWeightedAverageOfStatedInterestRatesForNotesReceivable": [
+"2012-01-31",
+"Element was deprecated because it has an integerItemType. Possible replacement is TimeSharingTransactionsWeightedAverageOfStatedInterestRatesForNotesReceivable1."
+],
+"TradingAccountAssetsFairValueDisclosure": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TradingSecurities."
+],
+"TradingAccountAssetsFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
+],
+"TradingAccountAssetsFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
+],
+"TradingActivityGainsAndLossesByIncomeStatementLocationAxis": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is IncomeStatementLocationAxis."
+],
+"TradingActivityGainsAndLossesByIncomeStatementLocationDomain": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is IncomeStatementLocationDomain."
+],
+"TradingActivityGainsAndLossesNet": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TradingGainsLosses."
+],
+"TradingLiabilitiesFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByLiabilityClassAxis."
+],
+"TradingLiabilitiesFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByLiabilityClassAxis."
+],
+"TradingSecuritiesCurrent": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TradingSecurities."
+],
+"TradingSecuritiesCurrentAbstract": [
+"2014-01-31",
+"Element was deprecated."
+],
+"TradingSecuritiesDebtCurrent": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TradingSecuritiesDebt."
+],
+"TradingSecuritiesEquityCurrent": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TradingSecuritiesEquity."
+],
+"TradingSecuritiesFairValueDisclosure": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TradingSecurities."
+],
+"TradingSecuritiesFairValueDisclosureMethodology": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsValuationTechniques and members of FairValueByAssetClassAxis."
+],
+"TradingSecuritiesFairValueDisclosureSignificantAssumptions": [
+"2012-01-31",
+"Element was deprecated because the financial reporting concept was modeled as a dimension. Possible replacements are FairValueMeasurementsSignificantAssumptions and members of FairValueByAssetClassAxis."
+],
+"TradingSecuritiesRestrictedCurrent": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TradingSecuritiesRestricted."
+],
+"TransfersAccountedForAsSecuredBorrowingsClassificationAssets": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is TransfersAccountedForAsSecuredBorrowingsAssetsCarryingAmount and members of BalanceSheetLocationAxis."
+],
+"TransfersAccountedForAsSecuredBorrowingsClassificationAssociatedLiabilities": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is TransfersAccountedForAsSecuredBorrowingsAssociatedLiabilitiesCarryingAmount and members of BalanceSheetLocationAxis."
+],
+"TravelAndEntertainmentExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is TravelAndEntertainmentExpense."
+],
+"TypeOfDeferredCompensationDomain": [
+"2014-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacements are DeferredBonusAndProfitSharingArrangementIndividualContractTypeOfDeferredCompensationDomain, OtherPostretirementBenefitsIndividualContractsTypeOfDeferredCompensationDomain, or EquityBasedArrangementsIndividualContractsTypeOfDeferredCompensationDomain."
+],
+"TypesOfCreditRiskDerivativesUsed": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are members of CreditDerivativesByContractTypeAxis."
+],
+"TypesOfItemsHedgedByCreditRiskDerivatives": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are members of UnderlyingAssetClassAxis."
+],
+"USGovernmentAndGovernmentAgenciesAndAuthoritiesMember": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is USTreasuryAndGovernmentMember."
+],
+"UnallocatedAmountToSegmentMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is MaterialReconcilingItemsMember."
+],
+"UndistributedDomesticEarningsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are UndistributedEarningsOfDomesticSubsidiaries, DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferenceUndistributedEarningsOfDomesticSubsidiaries, DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxableUndistributedEarningsOfDomesticSubsidiaries, DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityUndistributedEarningsOfDomesticSubsidiaries, or DeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticableUndistributedEarningsOfDomesticSubsidiaries."
+],
+"UndistributedEarningsAllocatedToParticipatingSecurities": [
+"2014-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are UndistributedEarningsLossAllocatedToParticipatingSecuritiesBasic or UndistributedEarningsLossAllocatedToParticipatingSecuritiesDiluted."
+],
+"UnprovedOilAndGasPropertyOrMajorProjectDomain": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is ProjectMember."
+],
+"UnrealizedGainLossOrWriteDownMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is MarketableSecuritiesUnrealizedGainLoss."
+],
+"UnrecognizedTaxBenefitsResultingInNetOperatingLossCarryforward": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"UnsolicitedTenderOfferExpensesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"UnusualOrInfrequentItemGross": [
+"2012-01-31",
+"Element was deprecated because it represented both a gain and a loss. Possible replacement for a gain is UnusualOrInfrequentItemGainGross, or UnusualOrInfrequentItemLossGross to represent a loss."
+],
+"UnusualOrInfrequentItemGross1": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacement for a gain is UnusualOrInfrequentItemGainGross, or UnusualOrInfrequentItemLossGross to represent a loss."
+],
+"ValuationAllowanceAmount": [
+"2013-01-31",
+"Element was deprecated due to redundancy.  Possible replacement is DeferredTaxAssetsValuationAllowance."
+],
+"ValuationAllowanceForImpairmentOfRecognizedServicingAssetsByTypeOfFinancialInstrumentAxis": [
+"2012-01-31",
+"Element was deprecated. Possible replacement is FinancialInstrumentAxis."
+],
+"VariableInterestEntityNonconsolidatedComparisonOfCarryingAmountOfAssetsAndLiabilitiesToMaximumLossExposureExplanationAbstract": [
+"2012-01-31",
+"This element has been deprecated."
+],
+"VariableInterestEntityNonconsolidatedComparisonOfCarryingAmountOfAssetsAndLiabilitiesToMaximumLossExposureExplanationQuantitativeInformationAdvantageous": [
+"2012-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"VariableInterestEntityNonconsolidatedComparisonOfCarryingAmountOfAssetsAndLiabilitiesToMaximumLossExposureExplanationQuantitativeInformationDisadvantageous": [
+"2012-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"VariableInterestEntityQualitativeOrQuantitativeInformationDateInvolvementBegan": [
+"2012-01-31",
+"Element was deprecated because it has a dateStringItemType. Possible replacement is VariableInterestEntityQualitativeOrQuantitativeInformationDateInvolvementBegan1."
+],
+"WarrantsMember": [
+"2012-01-31",
+"Element was deprecated due to redundancy. Possible replacement is WarrantMember."
+],
+"WeightedAverageNumberOfSharesOutstandingBasicAndDiluted": [
+"2012-01-31",
+"Element was deprecated because it has an instant period type. Possible replacement is WeightedAverageNumberOfShareOutstandingBasicAndDiluted."
 ]
 }

--- a/dqc_us_rules/resources/DQC_US_0018/2015_deprecated-concepts.json
+++ b/dqc_us_rules/resources/DQC_US_0018/2015_deprecated-concepts.json
@@ -1,377 +1,769 @@
 {
-"TypesOfItemsHedgedByCreditRiskDerivatives": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are members of UnderlyingAssetClassAxis."
-],
-"ServicingAssetAtFairValueChangesInFairValueLocationInIncomeStatementDescription": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionGainLossOnDisposition1 and members of IncomeStatementLocationAxis."
-],
-"ProvedUndevelopedReserveBOE": [
-"2013-01-31",
-"Element was deprecated because it has a boeItemType attribute. Possible replacement is ProvedUndevelopedReserveBOE1."
-],
-"PublicUtilitiesPropertyPlantAndEquipmentGenerationEstimatedUsefulLife": [
-"2013-01-31",
-"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentGenerationUsefulLife."
-],
-"LeveragedBuyoutClosingFeesAndExpense": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DepreciableAssetsMember": [
-"2014-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"IncomeDepositSecuritiesRisksAndLimitations": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"FurnitureAndEquipmentRentalExpenseOperatingLeaseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is LeaseAndRentalExpense."
-],
-"OtherComprehensiveIncomeLossReclassificationAdjustmentOnDerivativesIncludedInNetIncomeTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIOnDerivativesTax."
-],
-"BorrowingsToFinanceLeveragedBuyoutAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"CapitalizedInterestCostsMember": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"DisposalGroupIncludingDiscontinuedOperationAssetsOfDisposalGroup": [
-"2015-01-31",
-"Element was deprecated because it has a stringItemType attribute. Possible replacement is AssetsOfDisposalGroupIncludingDiscontinuedOperation."
-],
-"BusinessAcquisitionContingentConsiderationAtFairValueNoncurrent": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FairValueEstimateNotPracticableReasonsBorrowings": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
-],
-"AccumulatedDepreciationDepletionAndAmortizationWritedownOfPropertyPlantAndEquipment": [
-"2013-01-31",
-"Element was deprecated because it has credit balance attribute. Possible replacement is ImpairmentOfLongLivedAssetsHeldForUse."
-],
-"ComponentOfOtherExpenseNonoperatingAxis": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"DevelopmentStageEnterpriseDeficitAccumulatedDuringDevelopmentStage": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DerivativeFinancialInstrumentsLiabilitiesFairValueDisclosure": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DerivativeLiabilities."
-],
-"AssumedPremiumsWrittenPropertyAndCasualty": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"DescriptionOfLongTermIntercompanyTransactions": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"DevelopmentStageEnterpriseDevelopmentStageExitStrategy": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"NetCreditLossesDuringPeriodOnLoansManagedOrSecuritized": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is NetCreditLossOnLoansManagedOrSecuritizedOrAssetbackedFinancingArrangement."
-],
-"DebtInstrumentConvertibleConversionRatio": [
-"2013-01-31",
-"Element was deprecated because it has a decimalItemType attribute. Possible replacement is DebtInstrumentConvertibleConversionRatio1."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseClaimsPaidCurrentYear": [
-"2014-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseClaimsPaidCurrentYear1."
-],
-"NotionalAmountOfForeignCurrencyDerivatives": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis."
-],
-"ForeignCurrencyDerivativeLiabilitiesAtFairValue": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeFairValueOfDerivativeLiability and ForeignExchangeContractMember."
-],
-"FinancialGuaranteeInsuranceContractsClaimLiabilitySignificantComponentsOfChangeLikelihoodOfDefaultAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"DefinedBenefitPlanAccumulatedOtherComprehensiveIncomeLossAfterTax": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AccumulatedOtherComprehensiveIncomeLossDefinedBenefitPensionAndOtherPostretirementPlansNetOfTax."
-],
-"DerivativeNonmonetaryNotionalAmountPricePerUnit": [
-"2013-01-31",
-"Element was deprecated because the intended concept conveyed is the underlying. Possible replacements are UnderlyingDerivativeAsset, UnderlyingDerivativeLiability and UnderlyingDerivative."
-],
-"CashFlowHedgeGainLossReclassifiedToOtherExpenseNetAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"HealthCareOrganizationChangeInWriteOffs": [
-"2014-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacement is AllowanceForDoubtfulAccountsReceivableWriteOffs."
-],
-"ExchangeFeesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ExchangeFees."
-],
-"MarketingExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is MarketingExpense."
-],
-"GainsLossesOnSalesOfOtherAssets": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is GainLossOnSaleOfOtherAssets."
-],
-"DiscontinuedOperationAmountOfOtherIncomeLossFromDispositionOfDiscontinuedOperationsBeforeIncomeTax": [
-"2015-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsAmountsRecognizedInBalanceSheetAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"FiveYearScheduleOfMaturitiesOfParentCompanyRepaymentOfPrincipleInYearThree": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInYearThree."
-],
-"SiteContingencyAccrualDiscountAmount": [
-"2013-01-31",
-"Element was deprecated due to redundancy.  Possible replacement is AccrualForEnvironmentalLossContingenciesDiscount."
-],
-"BusinessCombinationGoodwillRecognizedSegmentAllocation": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is Goodwill and members of StatementBusinessSegmentsAxis."
-],
-"PurchasePriceAllocationAdjustmentsMember": [
+"AccountingStandardsUpdate200905Member": [
 "2014-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"CreditDerivativeOriginAndPurpose": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DiscussionOfObjectivesForUsingCreditRiskDerivativeInstruments."
-],
-"CommonStockIncludingAdditionalPaidInCapital": [
-"2013-01-31",
-"Element was deprecated due to ambiguous definition. Possible replacement is CommonStocksIncludingAdditionalPaidInCapital."
-],
-"SuppliesExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is SuppliesExpense."
-],
-"BusinessAcquisitionPurchasePriceAllocationEquipment": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CashFlowHedgeLossReclassifiedToOtherIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is OtherIncome and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"SubsequentEventDateEvaluatedDescription": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"TradingSecuritiesCurrent": [
+"AccountingStandardsUpdate200908Member": [
 "2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TradingSecurities."
-],
-"AcquiredFiniteLivedIntangibleAssetAmount": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is FinitelivedIntangibleAssetsAcquired1."
-],
-"LongDurationContractsAssumptionsByProductAndGuaranteeVolatilityRateHighEnd": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are LongDurationContractsAssumptionsByProductAndGuaranteeVolatilityRate, RangeAxis and MaximumMember."
-],
-"LineItemInFinancialStatementsForGainLossOnHybridInstruments": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is UnrealizedGainLossOnHybridInstrumentNet and members of IncomeStatementLocationAxis."
-],
-"BankruptcyProceedingsReasonsForBankruptcyFiling": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingGeneralPartnershipUnit": [
-"2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingGeneralPartnershipUnit1."
-],
-"DescriptionOfLocationOfGainLossOnPriceRiskCashFlowHedgeDerivativesInFinancialStatements": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is UnrealizedGainLossOnPriceRiskCashFlowDerivativesBeforeTax and members of IncomeStatementLocationAxis."
-],
-"NotionalAmountOfForeignCurrencyDerivativeInstrumentsNotDesignatedAsHedgingInstruments": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and HedgingDesignationAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsRawMaterials": [
-"2013-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"CommonStockIncludingAdditionalPaidInCapitalNetOfDiscount": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is CommonStocksIncludingAdditionalPaidInCapitalNetOfDiscount."
-],
-"AssumedPremiumsEarnedOtherInsurance": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"CapitalizedExploratoryWellCostGreaterThanOrEqualToTwoYearsAndLessThanThreeYearsNumberOfProjects": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProjectsThatHaveExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
-],
-"DepositAssetsOrLiabilitiesEffectOfChangeInPresentValueAssumptionsResultingInReductionsInExpectedRecoveries": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DepositAssetsEffectOfChangeInPresentValueAssumptionsResultingInReductionsToExpectedRecoveries and DepositLiabilitiesEffectOfChangeInPresentValueAssumptionsResultingInReductionsToExpectedRecoveries."
-],
-"AssumedPremiumsEarnedPropertyAndCasualty": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"CertainLoansAcquiredInTransferAccountedForAsAvailableForSaleDebtSecuritiesOtherThanTemporaryImpairmentCharges": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsAvailableforsaleDebtSecuritiesOtherthanTemporaryImpairmentChargesCreditLoss."
-],
-"CollaborativeArrangementsCopromotionAgreementAggregatedDisclosureMember": [
-"2013-01-31",
-"Element was deprecated because of unnecessary level of disaggregation in a parent-child relationship."
-],
-"AmortizationOfRegulatoryAssetMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is AmortizationOfRegulatoryAsset."
-],
-"AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionTextBlock": [
-"2015-01-31",
-"Element deprecated due to redundancy. Possible replacement is ScheduleOfDisposalGroupsIncludingDiscontinuedOperationsIncomeStatementBalanceSheetAndAdditionalDisclosuresTextBlock."
-],
-"LoansHeldForSaleConsumerInstallmentStudent": [
-"2015-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacement is LoansReceivableHeldForSaleNetNotPartOfDisposalGroupConsumerStudent."
-],
-"ProductRecallAxis": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"ClearanceFeesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ClearanceFees."
-],
-"RepurchaseOfEquityMember": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"LongDurationContractsAssumptionsByProductAndGuaranteeDiscountRateHighEnd": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LongDurationContractsAssumptionsByProductAndGuaranteeDiscountRate, RangeAxis and MaximumMember."
-],
-"ConsumerCreditCardFinancingReceivableMember": [
-"2015-01-31",
-"Element was deprecated due to remodeling of topic area. Possible replacements are CreditCardReceivablesMember and ConsumerPortfolioSegmentMember."
-],
-"BusinessAcquisitionCostOfAcquiredEntityPurchasePrice": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AssetsHeldForSaleLongLived": [
+"AccountingStandardsUpdate200910Member": [
 "2014-01-31",
-"Element was deprecated because it was inappropriately modeled."
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"IncomeDepositSecuritiesAbstract": [
+"AccountingStandardsUpdate200912Member": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"AccountingStandardsUpdate200913Member": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"AccountingStandardsUpdate200914Member": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"AccountingStandardsUpdate200915Member": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"AccountingStandardsUpdate200916Member": [
 "2015-01-31",
-"Element was deprecated."
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"PresentValueOfFutureInsuranceProfitsDecreases": [
-"2013-01-31",
-"Element was deprecated."
+"AccountingStandardsUpdate200917Member": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"NotionalAmountOfDerivativeInstrumentsDesignatedAsNetInvestmentHedges": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
+"AccountingStandardsUpdate201001Member": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"CededPremiumsWrittenOtherInsurance": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+"AccountingStandardsUpdate201002Member": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"MaximumPotentialFutureExposureOnCreditRiskDerivatives": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is CreditDerivativeMaximumExposureUndiscounted."
+"AccountingStandardsUpdate201003Member": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"DeferredCompensationArrangementWithIndividualCashAwardsGrantedAmount": [
-"2013-01-31",
-"Element was deprecated because it has debit balance and duration period type attributes. Possible replacement is DeferredCompensationArrangementWithIndividualCashAwardGrantedAmount."
+"AccountingStandardsUpdate201008Member": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"FinancingReceivableModificationsNumberOfContracts1": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is FinancingReceivableModificationsNumberOfContracts2."
+"AccountingStandardsUpdate201011Member": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"AccountingStandardsUpdate201013Member": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"AccountingStandardsUpdate201015Member": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"AccountingStandardsUpdate201016Member": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"AccountingStandardsUpdate201017Member": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"AccountingStandardsUpdate201018Member": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"AccountingStandardsUpdate201024Member": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
 "AccountingStandardsUpdate201028Member": [
 "2015-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"DistributionMadeToMemberOrLimitedPartnerCashDistributionsDeclared": [
+"AccretionExpenseMember": [
 "2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberCashDistributionsDeclared or DistributionMadeToLimitedPartnerCashDistributionsDeclared."
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is AccretionExpenseIncludingAssetRetirementObligations."
 ],
-"CededPremiumsLifeInsuranceInForce": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is LifeInsuranceInForceCeded."
+"AccrualForEnvironmentalLossContingenciesCaption": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AccrualForEnvironmentalLossContingencies and members of BalanceSheetLocationAxis."
 ],
-"SegmentReportingInformationInventoryNet": [
+"AccrualForEnvironmentalLossContingenciesNet": [
+"2013-01-31",
+"Element was deprecated due to redundancy.  Possible replacement is AccrualForEnvironmentalLossContingencies."
+],
+"AccrualForEnvironmentalLossContingenciesNetAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"AccrualForEnvironmentalLossContingenciesNetRollingMaturityAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"AccumulatedDeficitDuringDevelopmentStageMember": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"AccumulatedDepreciationDepletionAndAmortizationReclassificationsOfPropertyPlantAndEquipment": [
+"2015-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is AccumulatedDepreciationDepletionAndAmortizationReclassificationsFromPropertyPlantAndEquipment1."
+],
+"AccumulatedDepreciationDepletionAndAmortizationSaleOfPropertyPlantAndEquipment": [
+"2015-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is AccumulatedDepreciationDepletionAndAmortizationSaleOfPropertyPlantAndEquipment1."
+],
+"AccumulatedDepreciationDepletionAndAmortizationWritedownOfPropertyPlantAndEquipment": [
+"2013-01-31",
+"Element was deprecated because it has credit balance attribute. Possible replacement is ImpairmentOfLongLivedAssetsHeldForUse."
+],
+"AccumulatedOtherComprehensiveIncomeLossBeforeTaxRollForward": [
+"2015-01-31",
+"Element was deprecated."
+],
+"AccumulatedOtherComprehensiveIncomeLossNetOfTaxRollForward": [
+"2015-01-31",
+"Element was deprecated."
+],
+"AcquiredFiniteLivedIntangibleAssetAmount": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is FinitelivedIntangibleAssetsAcquired1."
+],
+"AcquiredIndefiniteLivedIntangibleAssetAmount": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is IndefinitelivedIntangibleAssetsAcquired."
+],
+"AdditionsToNoncurrentAssets": [
 "2013-01-31",
 "Element was deprecated due to remodeling of Segment area. Possible replacement is corresponding primary line items and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
 ],
-"IncreaseDecreaseInFilmCosts": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is IncreaseDecreaseInFilmCosts1."
-],
-"DepositAssetsOrLiabilitiesEffectOfChangeInPresentValueAssumptionsRecordedAsExpense": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DepositAssetsEffectOfChangeInPresentValueAssumptionsRecordedAsExpense and DepositLiabilitiesEffectOfChangeInPresentValueAssumptionsRecordedAsExpense."
-],
-"IncomeLossBeforeExtraordinaryItemsAndCumulativeEffectOfChangeInAccountingPrinciplePerOutstandingGeneralPartnershipUnit": [
-"2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromOperationsBeforeExtraordinaryItemsPerOutstandingGeneralPartnershipUnitNetOfTax."
-],
-"LifeInsuranceInForcePremiumsPercentageAssumedToNet": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is LifeInsuranceInForcePercentageAssumedToNet."
-],
-"AdjustmentsToAdditionalPaidInCapitalShareBasedCompensationNonvestedSharesRequisiteServicePeriodRecognition": [
-"2013-01-31",
-"Element was deprecated due to redundancy."
-],
-"FairValueEstimateNotPracticableReasonsGuarantees": [
+"AdjustmentPlantCapacity": [
 "2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+"Element was deprecated because of low usage."
 ],
 "AdjustmentsToAdditionalPaidInCapitalReallocationOfMinorityInterest": [
 "2013-01-31",
 "Element was deprecated due to redundancy. Possible replacement is NoncontrollingInterestIncreaseFromSubsidiaryEquityIssuance."
 ],
-"ReceivablesWithImputedInterestAmortizationDescription": [
+"AdjustmentsToAdditionalPaidInCapitalShareBasedCompensationNonvestedSharesRequisiteServicePeriodRecognition": [
+"2013-01-31",
+"Element was deprecated due to redundancy."
+],
+"AdministrativeFeesAmountPaid": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is PaymentForAdministrativeFees."
+],
+"AdvertisingExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is AdvertisingExpense."
+],
+"AgingOfCapitalizedExploratoryWellCostAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"AgingOfCapitalizedExploratoryWellCostsNumberOfProjectsAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"AllCertainLoansAcquiredInTransferAccountedForAsHeldToMaturityDebtSecuritiesNotAccountedForUsingIncomeRecognitionModelEndOfPeriodAtCarryingValue": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AllCertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesNotAccountedForUsingIncomeRecognitionModelEndOfPeriodAtCarryingValue and members of InformationByCategoryOfDebtSecurityAxis."
+],
+"AllowanceForCostOfEquityFundsUsedDuringConstructionMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is PublicUtilitiesAllowanceForFundsUsedDuringConstructionCapitalizedInterest."
+],
+"AllowanceForDoubtfulAccountsReceivableChargeOffs": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is AllowanceForDoubtfulAccountsReceivableWriteOffs."
+],
+"AllowanceForFundsUsedDuringConstructionCapitalizedInterestMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is PublicUtilitiesAllowanceForFundsUsedDuringConstructionCapitalizedInterest."
+],
+"AllowanceForLoanAndLeaseLossesAdjustmentsNetAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"AllowanceForLoanAndLeaseLossesProvisionForLossGross": [
+"2013-01-31",
+"Element was deprecated because it is an invalid concept. Possible replacement is ProvisionForLoanAndLeaseLosses."
+],
+"AllowanceForLoanAndLeaseLossesProvisionForLossNet": [
+"2013-01-31",
+"Element was deprecated because it is an invalid concept. Possible replacement is ProvisionForLoanAndLeaseLosses."
+],
+"AllowanceForLoanAndLeaseLossesProvisionForLossNetAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"AllowanceForLoanAndLeaseLossesRecoveriesOfBadDebts": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is AllowanceForLoanAndLeaseLossRecoveryOfBadDebts."
+],
+"AmortizationOfAcquiredIntangibleAssets": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is AmortizationOfIntangibleAssets."
+],
+"AmortizationOfCapitalizedValueOfBusinessAcquiredAsset": [
+"2015-01-31",
+"Element deprecated due to redundancy. Possible replacement is PresentValueOfFutureInsuranceProfitsAmortizationExpense1."
+],
+"AmortizationOfDeferredSalesCommissionsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"AmortizationOfIntangiblesNonproductionMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is AmortizationOfIntangibleAssets."
+],
+"AmortizationOfRegulatoryAssetMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is AmortizationOfRegulatoryAsset."
+],
+"AmountAvailableForDividendDistributionWithApprovalFromRegulatoryAgencies": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is StatutoryAccountingPracticesStatutoryAmountAvailableForDividendPaymentsWithRegulatoryApproval."
+],
+"AmountAvailableForDividendDistributionWithoutPriorApprovalFromRegulatoryAgency": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is StatutoryAccountingPracticesStatutoryAmountAvailableForDividendPaymentsWithoutRegulatoryApproval."
+],
+"AmountOfRegulatoryAssistanceReceived": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is AmountOfRegulatoryAssistanceReceived1."
+],
+"AncillaryFeeIncomeGeneratedByServicingFinancialAssetsDescriptionOfWhereReportedOnStatementOfIncome": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AncillaryFeeIncomeGeneratedByServicingFinancialAssetsAmount and members of IncomeStatementLocationAxis."
+],
+"AssetManagementFees": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacement is AssetManagementFees1 or InvestmentAdvisoryManagementAndAdministrativeFees."
+],
+"AssetManagementMember": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions."
+],
+"AssetsDesignatedToClosedBlockOtherClosedBlockAssets": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacement is AssetsDesignatedToClosedBlockOtherClosedBlockAssets1."
+],
+"AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionAssetNameDomain": [
+"2015-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are PropertyPlantAndEquipmentTypeDomain and DisposalGroupClassificationDomain."
+],
+"AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionByAssetAxis": [
+"2015-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are PropertyPlantAndEquipmentByTypeAxis and DisposalGroupClassificationAxis."
+],
+"AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionIncomeStatementClassificationOfGainLossOnDisposal": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionGainLossOnDisposition1 and members of IncomeStatementLocationAxis."
+],
+"AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionLineItems": [
+"2015-01-31",
+"Element was deprecated."
+],
+"AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionMethodOfDisposal": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are members of DisposalGroupClassificationAxis."
+],
+"AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionSegmentClassification": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionGainLossOnDisposition1 and members of StatementBusinessSegmentsAxis."
+],
+"AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionTextBlock": [
+"2015-01-31",
+"Element deprecated due to redundancy. Possible replacement is ScheduleOfDisposalGroupsIncludingDiscontinuedOperationsIncomeStatementBalanceSheetAndAdditionalDisclosuresTextBlock."
+],
+"AssetsHeldForSaleAtCarryingValue": [
+"2014-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are AssetsOfDisposalGroupIncludingDiscontinuedOperation or AssetsHeldForSaleNotPartOfDisposalGroup."
+],
+"AssetsHeldForSaleAtCarryingValueAbstract": [
+"2014-01-31",
+"Element was deprecated."
+],
+"AssetsHeldForSaleCapitalLeasedAssetsNet": [
+"2014-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacements are DisposalGroupIncludingDiscontinuedOperationCapitalLeasedAssetsCurrent, DisposalGroupIncludingDiscontinuedOperationCapitalLeasedAssetsNoncurrent or DisposalGroupIncludingDiscontinuedOperationCapitalLeasedAssets."
+],
+"AssetsHeldForSaleCurrent": [
+"2014-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are AssetsOfDisposalGroupIncludingDiscontinuedOperationCurrent or AssetsHeldForSaleNotPartOfDisposalGroupCurrent."
+],
+"AssetsHeldForSaleCurrentAbstract": [
+"2014-01-31",
+"Element was deprecated."
+],
+"AssetsHeldForSaleLongLived": [
+"2014-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"AssetsHeldForSaleLongLivedAbstract": [
+"2014-01-31",
+"Element was deprecated."
+],
+"AssetsHeldForSaleMember": [
+"2015-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is DisposalGroupHeldForSaleNotDiscontinuedOperationsMember."
+],
+"AssetsHeldForSaleOtherNoncurrent": [
+"2014-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is DisposalGroupIncludingDiscontinuedOperationOtherNoncurrentAssets."
+],
+"AssetsHeldForSalePropertyPlantAndEquipment": [
+"2014-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacements are DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipmentNoncurrent, DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipmentCurrent or DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipment."
+],
+"AssetsOfDisposalGroupIncludingDiscontinuedOperationNoncurrent": [
+"2014-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is DisposalGroupIncludingDiscontinuedOperationAssetsNoncurrent."
+],
+"AssumedPremiumsEarnedAccidentAndHealth": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"AssumedPremiumsEarnedFinancialGuaranteeInsuranceContracts": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"AssumedPremiumsEarnedLife": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"AssumedPremiumsEarnedOtherInsurance": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"AssumedPremiumsEarnedPropertyAndCasualty": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"AssumedPremiumsLifeInsuranceInForce": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is LifeInsuranceInForceAssumed."
+],
+"AssumedPremiumsWrittenAccidentAndHealth": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"AssumedPremiumsWrittenFinancialGuaranteeInsuranceContracts": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"AssumedPremiumsWrittenLife": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"AssumedPremiumsWrittenOtherInsurance": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"AssumedPremiumsWrittenPropertyAndCasualty": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"AvailableForSaleSecuritiesDebtMaturitiesAmortizedCost": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is AvailableForSaleDebtSecuritiesAmortizedCostBasis."
+],
+"AvailableForSaleSecuritiesFairValueDisclosure": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is AvailableForSaleSecurities."
+],
+"AvailableForSaleSecuritiesGrossUnrealizedGainLoss": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is AvailableForSaleSecuritiesGrossUnrealizedGainLoss1."
+],
+"AvailableForSaleSecuritiesGrossUnrealizedLosses1": [
+"2013-01-31",
+"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is AvailableForSaleSecuritiesGrossUnrealizedLoss."
+],
+"AvailableForSaleSecuritiesInUnrealizedLossPositionsQualitativeDisclosureNumberOfPositions": [
+"2013-01-31",
+"Element was deprecated because it was a decimalItemType attribute. Possible replacement is AvailableForSaleSecuritiesInUnrealizedLossPositionsQualitativeDisclosureNumberOfPositions1."
+],
+"AvailableforsaleSecuritiesContinuousUnrealizedLossPosition12MonthsOrLongerAggregateLosses2": [
+"2013-01-31",
+"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is AvailableForSaleSecuritiesContinuousUnrealizedLossPosition12MonthsOrLongerAggregateLosses."
+],
+"AvailableforsaleSecuritiesContinuousUnrealizedLossPositionAggregateLosses2": [
+"2013-01-31",
+"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is AvailableForSaleSecuritiesContinuousUnrealizedLossPositionAggregateLosses."
+],
+"AvailableforsaleSecuritiesContinuousUnrealizedLossPositionLessThan12MonthsAggregateLosses2": [
+"2013-01-31",
+"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is AvailableForSaleSecuritiesContinuousUnrealizedLossPositionLessThan12MonthsAggregateLosses."
+],
+"AvailableforsaleSecuritiesGrossUnrealizedGain": [
+"2013-01-31",
+"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is AvailableForSaleSecuritiesGrossUnrealizedGains."
+],
+"AverageBalanceDuringPeriodOfLoansHeldForSaleOrSecuritization": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"AverageBalanceDuringPeriodOfLoansHeldInPortfolio": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"AverageBalanceDuringPeriodOfLoansHeldInPortfolioAbstract": [
+"2014-01-31",
+"Element was deprecated."
+],
+"AverageBalanceDuringPeriodOfLoansManagedAndSecuritized": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"AverageBalanceDuringPeriodOfLoansSecuritized": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BadDebtReserveForTaxPurposesOfUSSavingsAndLoanAssociationsOrOtherQualifiedThriftLenderMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are BadDebtReserveForTaxPurposesOfQualifiedLender, DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferenceBadDebtReserveForTaxPurposesOfQualifiedLender, DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxableBadDebtReserveForTaxPurposesOfQualifiedLender, DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityBadDebtReserveForTaxPurposesOfQualifiedLender,  and DeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticableBadDebtReserveForTaxPurposesOfQualifiedLender."
+],
+"BankruptcyClaimsDateByWhichContractsMustBeRejectedByDebtors": [
 "2015-01-31",
 "Element was deprecated because of low usage."
 ],
-"PremiumsNetLifeInsuranceInForce": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is LifeInsuranceInForceNet."
+"BankruptcyClaimsDescriptionOfClaimsUnderReviewByManagement": [
+"2015-01-31",
+"Element was deprecated because of low usage."
 ],
-"InstrumentAxis": [
+"BankruptcyClaimsDescriptionOfMaterialContractsRejected": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"BankruptcyDomain": [
 "2013-01-31",
-"Element was deprecated because it was incorrectly defined. Possible replacement is EnergyAxis."
+"Element was deprecated due to remodeling of topic area."
+],
+"BankruptcyOfPartyAxis": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"BankruptcyProceedingsDescriptionOfManagementForEntitiesInBankruptcy": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"BankruptcyProceedingsDescriptionOfNonUSEntities": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"BankruptcyProceedingsDescriptionOfOperationalImprovementPlans": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"BankruptcyProceedingsDescriptionOfOrdersApprovedByCourt": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"BankruptcyProceedingsEntitiesIncludedInBankruptcyFiling": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"BankruptcyProceedingsEntitiesNotIncludedInBankruptcyFiling": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"BankruptcyProceedingsReasonsForBankruptcyFiling": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"BelowMarketLeasesMember": [
+"2013-01-31",
+"Element was deprecated because it is an invalid concept. Possible replacements are elements under BelowMarketLeaseAbstract."
+],
+"BoardMemberCompensationContractsMember": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"BorrowedFunds": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DebtAndCapitalLeaseObligations."
+],
+"BorrowingsToFinanceLeveragedBuyout": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BorrowingsToFinanceLeveragedBuyoutAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BreakpointDiscountRefund": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"BusinessAcquisitionContingentConsiderationAccountingTreatment": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionContingentConsiderationAtFairValue": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionContingentConsiderationAtFairValueCurrent": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionContingentConsiderationAtFairValueNoncurrent": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionContingentConsiderationPotentialCashPayment": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionContingentConsiderationSharesIssuable": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionContingentConsiderationSharesIssuableDescription": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionCostOfAcquiredEntityAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionCostOfAcquiredEntityCashPaid": [
+"2013-01-31",
+"Element was deprecated because it has debit balance and instant period type attributes. Possible replacement is PaymentsToAcquireBusinessesGross."
+],
+"BusinessAcquisitionCostOfAcquiredEntityDescriptionOfPurchasePriceComponents": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionCostOfAcquiredEntityEquityInterestsIssuedAndIssuable": [
+"2013-01-31",
+"Element deprecated because it has a debit balance attribute and instant period type. Possible replacement is BusinessCombinationConsiderationTransferredEquityInterestsIssuedAndIssuable."
+],
+"BusinessAcquisitionCostOfAcquiredEntityLiabilitiesIncurred": [
+"2013-01-31",
+"Element was deprecated because it has debit balance and instant period type attributes.  Possible replacement is BusinessCombinationConsiderationTransferredLiabilitiesIncurred."
+],
+"BusinessAcquisitionCostOfAcquiredEntityOtherNoncashConsideration": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionCostOfAcquiredEntityPlannedRestructuringActivities": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionCostOfAcquiredEntityPurchasePrice": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionCostOfAcquiredEntityPurchasePriceAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionEntityAcquiredAndReasonForAcquisitionAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionPreacquisitionContingencyAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionPreacquisitionContingencyAmount": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPreacquisitionContingencyDescription": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPreacquisitionContingencyDescriptionOfSettlement": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPreexistingRelationshipAbstract": [
+"2014-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionPreexistingRelationshipDescription": [
+"2014-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is BusinessCombinationSeparatelyRecognizedTransactionsDescription and members of BusinessCombinationSeparatelyRecognizedTransactionsAxis."
+],
+"BusinessAcquisitionPreexistingRelationshipGainLossRecognized": [
+"2014-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is BusinessCombinationSeparatelyRecognizedTransactionsNetGainsAndLosses and members of BusinessCombinationSeparatelyRecognizedTransactionsAxis."
+],
+"BusinessAcquisitionPurchasePriceAllocationAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionPurchasePriceAllocationAmortizableIntangibleAssets": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationAssetsAcquired": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationAssetsAcquiredLiabilitiesAssumedNet": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationAssetsAcquiredLiabilitiesAssumedNetAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionPurchasePriceAllocationBuildings": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCapitalLeaseObligationAccrual": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssets": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsAssetHeldForSale": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsAssetNotToBeUsed": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsAssetNotToBeUsedAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsAssetToBeDisposedOf": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsCashAndCashEquivalents": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsDescription": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsFinishedGoods": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsInventory": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsInventoryAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsMarketableSecurities": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsMerchandise": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsPrepaidExpenseAndOtherAssets": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsRawMaterials": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsReceivables": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsWorkInProgress": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentLiabilities": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentLiabilitiesAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentLiabilitiesAccountsPayable": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentLiabilitiesAccruedLiabilities": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
 "BusinessAcquisitionPurchasePriceAllocationCurrentLiabilitiesDeferredRevenue": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentLiabilitiesDescription": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentLiabilitiesLongTermDebt": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationCurrentLiabilitiesOtherLiabilities": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationDeferredIncomeTaxesAssetLiabilityNet": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationDeferredTaxAssetsNoncurrent": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationDeferredTaxLiabilitiesNoncurrent": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationEquipment": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationGoodwillAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionPurchasePriceAllocationGoodwillAmount": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationGoodwillExpectedTaxDeductibleAmountDescription": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationIntangibleAssetsDescription": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationIntangibleAssetsNotAmortizable": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationIntangibleAssetsOtherThanGoodwill": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationLand": [
 "2013-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
@@ -379,211 +771,847 @@
 "2013-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"PublicUtilitiesPropertyPlantAndEquipmentTransmissionEstimatedUsefulLife": [
+"BusinessAcquisitionPurchasePriceAllocationMethodology": [
 "2013-01-31",
-"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentTransmissionUsefulLife."
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"OtherComprehensiveIncomeReclassificationOfDefinedBenefitPlansNetGainLossRecognizedInNetPeriodicBenefitCostNetOfTax": [
+"BusinessAcquisitionPurchasePriceAllocationMineralRights": [
 "2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetGainLossNetOfTax."
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"SubsequentEventAmount": [
+"BusinessAcquisitionPurchasePriceAllocationNaturalResources": [
 "2013-01-31",
-"Element was deprecated because it is an invalid concept."
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"BankruptcyProceedingsDescriptionOfOrdersApprovedByCourt": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"CapitalizedExploratoryWellCostsThereafterNumberOfProjects": [
+"BusinessAcquisitionPurchasePriceAllocationNegativeGoodwillDescription": [
 "2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProjectsThatHaveExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"InvestmentOwnedZeroBalanceMayReflectAmountRoundedToZeroFlag": [
+"BusinessAcquisitionPurchasePriceAllocationNetTangibleAssets": [
 "2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is InvestmentOwnedZeroBalanceMayReflectAmountRoundedToZeroFlag1."
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationNoncontrollingInterest": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationNoncurrentAssets": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationNoncurrentAssetsAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionPurchasePriceAllocationNoncurrentAssetsDescription": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationNoncurrentLiabilities": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationNoncurrentLiabilitiesAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionPurchasePriceAllocationNoncurrentLiabilitiesDescription": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationNoncurrentLiabilitiesLongTermDebt": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
 "BusinessAcquisitionPurchasePriceAllocationNoncurrentLiabilitiesRestructuringCostAccrual": [
 "2013-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"DistributionMadeToMemberOrLimitedPartnerLineItems": [
+"BusinessAcquisitionPurchasePriceAllocationNotesPayableAndLongTermDebt": [
 "2013-01-31",
-"Element was deprecated."
-],
-"PremiumsEarnedNetByProductSegmentAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"AccountingStandardsUpdate201001Member": [
-"2014-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"NonmonetaryNotionalAmountOfPriceRiskDerivatives": [
+"BusinessAcquisitionPurchasePriceAllocationOtherAssets": [
 "2013-01-31",
-"Element was deprecated because the intended concept conveyed is the underlying. Possible replacements are UnderlyingDerivativeAsset, UnderlyingDerivativeLiability, UnderlyingDerivative and members of DerivativeInstrumentRiskAxis."
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"PublicUtilitiesPropertyPlantAndEquipmentOtherPropertyPlantAndEquipmentEstimatedUsefulLife": [
+"BusinessAcquisitionPurchasePriceAllocationOtherLiabilities": [
 "2013-01-31",
-"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentOtherPropertyPlantAndEquipmentUsefulLife."
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInOtherIncome": [
+"BusinessAcquisitionPurchasePriceAllocationOtherNoncurrentAssets": [
 "2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"DebtInstrumentIncreaseAdditionalBorrowings": [
+"BusinessAcquisitionPurchasePriceAllocationOtherNoncurrentLiabilities": [
 "2013-01-31",
-"Element was deprecated because it has a credit balance attribute.  Possible replacement is ProceedsFromIssuanceOfDebt."
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationPlant": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationPreacquisitionContingencyAccrual": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationProjectedBenefitObligationAsset": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationProperty": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationPropertyPlantAndEquipment": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationPropertyPlantAndEquipmentAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionPurchasePriceAllocationRealEstateAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionPurchasePriceAllocationStatus": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationTangibleAssets": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationTangibleAssetsAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionPurchasePriceAllocationUnclassifiedAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"BusinessAcquisitionPurchasePriceAllocationUnfavorableContractAccrual": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationUnmarketableSecurities": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessAcquisitionPurchasePriceAllocationWarrantyLiability": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"BusinessCombinationAssetsAndLiabilitiesArisingFromContingenciesNoAmountRecognized": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"BusinessCombinationBargainPurchaseGainRecognizedAmountFinancialStatementCaption": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is BusinessCombinationBargainPurchaseGainRecognizedAmount and members of IncomeStatementLocationAxis."
 ],
 "BusinessCombinationConsiderationTransferred": [
 "2013-01-31",
 "Element was deprecated because it has debit balance and instant period type attributes.  Possible replacement is BusinessCombinationConsiderationTransferred1."
 ],
-"IncomeLossFromDispositionOfDiscontinuedOperationsForOtherStockPerBasicShare": [
+"BusinessCombinationConsiderationTransferredIncludingEquityInterestInAcquireeHeldPriorToCombination": [
 "2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is IncomeLossFromDiscontinuedOperationsNetOfTaxPerBasicShare."
+"Element was deprecated because it has debit balance and instant period type attributes. Possible replacement is BusinessCombinationConsiderationTransferredIncludingEquityInterestInAcquireeHeldPriorToCombination1."
 ],
-"OriginationOfMortgageServicingRightsMSRs": [
+"BusinessCombinationConsiderationTransferredOther": [
 "2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ServicingAssetAtFairValueAdditions."
+"Element was deprecated because it has debit balance and instant period type attributes.  Possible replacement is BusinessCombinationConsiderationTransferredOther1."
 ],
-"ScheduleOfCostMethodInvestmentsAxis": [
-"2013-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is MajorTypesOfDebtAndEquitySecuritiesAxis."
-],
-"AverageBalanceDuringPeriodOfLoansSecuritized": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"EnvironmentalCostsOfPropertyForSaleDisposalOrAbandonmentBalanceSheetCaption": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is EnvironmentalExitCostsCostsAccruedToDate and members of BalanceSheetLocationAxis."
-],
-"GainLossFromSaleOfFinancialAssetsInSecuritizationsOrAssetBackedFinancingArrangement": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is SecuritizationFinancialAssetForWhichTransferIsAccountedAsSaleGainLossOnSale."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInInvestmentIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueLiabilitiesMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
-],
-"SaleAxis": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"SegmentReportingInformationRevenue": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Possible replacement is Revenues and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
-],
-"CumulativeEffectAdjustmentBifurcationOfHybridsGrossLosses": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"RevenueFromAdministrativeServicesAbstract": [
+"BusinessCombinationContingentConsiderationArrangementsAndIndemnificationAssetsAbstract": [
 "2013-01-31",
 "Element was deprecated."
 ],
-"ConsumerCreditScoreMember": [
+"BusinessCombinationContingentConsiderationArrangementsChangeInAmountOfContingentConsiderationAsset": [
 "2013-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is InternalCreditAssessmentDomain."
+"Element was deprecated because it has a debit balance attribute. Possible replacement is BusinessCombinationContingentConsiderationArrangementsChangeInAmountOfContingentConsiderationAsset1."
 ],
-"LiabilitiesForGuaranteesOnLongDurationContractsIncurredBenefits": [
+"BusinessCombinationContingentConsiderationArrangementsChangeInAmountOfContingentConsiderationLiability": [
 "2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is LiabilitiesForGuaranteesOnLongDurationContractsIncurredBenefits1."
+"Element was deprecated because it has a credit balance attribute. Possible replacement is BusinessCombinationContingentConsiderationArrangementsChangeInAmountOfContingentConsiderationLiability1."
 ],
-"AvailableforsaleSecuritiesContinuousUnrealizedLossPosition12MonthsOrLongerAggregateLosses2": [
+"BusinessCombinationGoodwillRecognizedSegmentAllocation": [
 "2013-01-31",
-"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is AvailableForSaleSecuritiesContinuousUnrealizedLossPosition12MonthsOrLongerAggregateLosses."
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is Goodwill and members of StatementBusinessSegmentsAxis."
 ],
-"AdjustmentPlantCapacity": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"AmortizationOfCapitalizedValueOfBusinessAcquiredAsset": [
-"2015-01-31",
-"Element deprecated due to redundancy. Possible replacement is PresentValueOfFutureInsuranceProfitsAmortizationExpense1."
-],
-"EquityIssuanceNoncashConsiderationsDetails": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"MaterialComponentsOfRecordedThirdPartyEnvironmentalRecoveriesAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"DiscontinuedOperationIntercompanyAmountsWithDiscontinuedOperationBeforeDisposalTransactionRevenue": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LineItemForGainLossOnCreditRiskDerivativeOnIncomeStatement": [
+"BusinessCombinationProFormaInformationAbstract": [
 "2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are members of IncomeStatementLocationAxis."
-],
-"AmountOfRegulatoryAssistanceReceived": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is AmountOfRegulatoryAssistanceReceived1."
-],
-"DefinedBenefitPlanAmortizationOfNetGainsLosses": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is DefinedBenefitPlanFutureAmortizationOfGainLoss."
-],
-"DeferredCompensationArrangementWithIndividualExcludingShareBasedPaymentsAndPostretirementBenefitsByTitleOfIndividualAxis": [
-"2013-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is TitleofIndividualAxis."
-],
-"ContractuallySpecifiedServicingFeesDescriptionOfWhereReportedOnStatementOfIncome": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ContractuallySpecifiedServicingFeesAmount and members of IncomeStatementLocationAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationIntangibleAssetsNotAmortizable": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"EffectOfChangeInReinvestmentRateOfReturnEstimate": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"RevenueFromFranchisedOutlets": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is FranchiseRevenue."
-],
-"OtherTaxCarryforwardDeferredTaxAsset": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DeferredTaxAssetsTaxCreditCarryforwards."
-],
-"IncomeLossFromEquityMethodInvestmentsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is IncomeLossFromEquityMethodInvestments."
-],
-"StockRepurchaseProgramRemainingAuthorizedRepurchaseAmount": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is StockRepurchaseProgramRemainingAuthorizedRepurchaseAmount1."
-],
-"DescriptionOfChangeInReinvestmentRateOfReturnEstimate": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"NotionalAmountOfNetInvestmentHedgingInstruments": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount,  DerivativeNotionalAmount or NotionalAmountOfNonderivativeInstruments and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
-],
-"CertainLoansAcquiredInTransferAccountedForAsAvailableForSaleDebtSecuritiesAccretableYieldMovementScheduleRollForward": [
-"2015-01-31",
 "Element was deprecated."
 ],
 "BusinessCombinationSeparatelyRecognizedTransactionsAssetsAbstract": [
 "2015-01-31",
 "Element was deprecated."
 ],
-"OtherCostAndExpenseDisclosureOperatingAbstract": [
+"BusinessCombinationSeparatelyRecognizedTransactionsAssetsFinancialStatementCaption": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is BusinessCombinationSeparatelyRecognizedTransactionsAssetsRecognized and members of BalanceSheetLocationAxis."
+],
+"BusinessCombinationSeparatelyRecognizedTransactionsExpensesAndLossesAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"BusinessCombinationSeparatelyRecognizedTransactionsExpensesAndLossesFinancialStatementCaption": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is BusinessCombinationSeparatelyRecognizedTransactionsExpensesAndLossesRecognized and members of IncomeStatementLocationAxis."
+],
+"BusinessCombinationSeparatelyRecognizedTransactionsLiabilitiesAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"BusinessCombinationSeparatelyRecognizedTransactionsLiabilitiesFinancialStatementCaption": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is BusinessCombinationSeparatelyRecognizedTransactionsLiabilitiesRecognized and members of BalanceSheetLocationAxis."
+],
+"BusinessCombinationSeparatelyRecognizedTransactionsNetGainsAndLossesAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"BusinessCombinationSeparatelyRecognizedTransactionsNetGainsAndLossesFinancialStatementCaption": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is BusinessCombinationSeparatelyRecognizedTransactionsNetGainsAndLosses and members of IncomeStatementLocationAxis."
+],
+"BusinessCombinationSeparatelyRecognizedTransactionsRevenuesAndGainsAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"BusinessCombinationSeparatelyRecognizedTransactionsRevenuesAndGainsFinancialStatementCaption": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is BusinessCombinationSeparatelyRecognizedTransactionsRevenuesAndGainsRecognized and members of IncomeStatementLocationAxis."
+],
+"BusinessCombinationStepAcquisitionEquityInterestInAcquireeFairValue": [
+"2013-01-31",
+"Element was deprecated because it has debit balance and instant period type attributes. Possible replacement is BusinessCombinationStepAcquisitionEquityInterestInAcquireeFairValue1."
+],
+"BusinessDevelopmentMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is BusinessDevelopment."
+],
+"BusinessExitCosts": [
+"2013-01-31",
+"Element was deprecated. Possible replacement is BusinessExitCosts1."
+],
+"BusinessInterruptionInsuranceRecoveryStatementOfIncomeLineItems": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is GainOnBusinessInterruptionInsuranceRecovery and members of IncomeStatementLocationAxis."
+],
+"CallOptionsPurchasedMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CallOptionMember with LongMember."
+],
+"CallOptionsWrittenMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CallOptionMember with ShortMember."
+],
+"CancellationOfContractAxis": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"CancellationOfContractDomain": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"CapitalLeaseExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is CapitalLeasesIncomeStatementInterestExpense."
+],
+"CapitalizedExploratoryWellCostGreaterThanOrEqualToTwoYearsAndLessThanThreeYearsNumberOfProjects": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProjectsThatHaveExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
+],
+"CapitalizedExploratoryWellCostsGreaterThanOrEqualToFourYearsAndLessThanFiveYears": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CapitalizedExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
+],
+"CapitalizedExploratoryWellCostsGreaterThanOrEqualToFourYearsAndLessThanFiveYearsNumberOfProjects": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProjectsThatHaveExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
+],
+"CapitalizedExploratoryWellCostsGreaterThanOrEqualToOneYearAndLessThanTwoYears": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CapitalizedExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
+],
+"CapitalizedExploratoryWellCostsGreaterThanOrEqualToOneYearAndLessThanTwoYearsNumberOfProjects": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProjectsThatHaveExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
+],
+"CapitalizedExploratoryWellCostsGreaterThanOrEqualToThreeYearsAndLessThanFourYears": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CapitalizedExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
+],
+"CapitalizedExploratoryWellCostsGreaterThanOrEqualToThreeYearsAndLessThanFourYearsNumberOfProjects": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProjectsThatHaveExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
+],
+"CapitalizedExploratoryWellCostsGreaterThanOrEqualToTwoYearsAndLessThanThreeYears": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CapitalizedExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
+],
+"CapitalizedExploratoryWellCostsThereafter": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CapitalizedExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
+],
+"CapitalizedExploratoryWellCostsThereafterNumberOfProjects": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProjectsThatHaveExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
+],
+"CapitalizedInterestCostsMember": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"CashAndSecuritiesSegregatedUnderOtherRegulationsDescription": [
+"2015-01-31",
+"Element deprecated due to redundancy. Possible replacement is CashAndSecuritiesSegregatedUnderFederalAndOtherRegulationsDescription."
+],
+"CashAndSecuritiesSegregatedUnderSecuritiesExchangeCommissionRegulationDescription": [
+"2015-01-31",
+"Element deprecated due to redundancy. Possible replacement is CashAndSecuritiesSegregatedUnderFederalAndOtherRegulationsDescription."
+],
+"CashFlowHedgeGainLossReclassifiedToCostOfSalesNet": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CostOfGoodsSold and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeGainLossReclassifiedToCostOfSalesNetAbstract": [
 "2013-01-31",
 "Element was deprecated."
 ],
-"RealEstateTaxesAndInsuranceMember": [
+"CashFlowHedgeGainLossReclassifiedToEarningsNet": [
 "2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is RealEstateTaxesAndInsurance."
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProfitLoss and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
 ],
-"CashFlowHedgeGainLossReclassifiedToCostOfSalesNetAbstract": [
+"CashFlowHedgeGainLossReclassifiedToEarningsNetAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"CashFlowHedgeGainLossReclassifiedToInterestExpenseNet": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is InterestExpense and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeGainLossReclassifiedToInterestExpenseNetAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"CashFlowHedgeGainLossReclassifiedToInvestmentIncomeNet": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is InvestmentIncomeNet and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeGainLossReclassifiedToInvestmentIncomeNetAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"CashFlowHedgeGainLossReclassifiedToOtherExpenseNet": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is OtherCostAndExpenseOperating and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeGainLossReclassifiedToOtherExpenseNetAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"CashFlowHedgeGainLossReclassifiedToOtherIncomeNet": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is OtherIncome and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeGainLossReclassifiedToOtherIncomeNetAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"CashFlowHedgeGainLossReclassifiedToRevenueNet": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is Revenues and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeGainLossReclassifiedToRevenueNetAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"CashFlowHedgeGainReclassifiedToCostOfSales": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CostOfGoodsSold and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeGainReclassifiedToEarnings": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProfitLoss and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeGainReclassifiedToInterestExpense": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is InterestExpense and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeGainReclassifiedToInvestmentIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is InvestmentIncomeNet and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeGainReclassifiedToOtherExpense": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is OtherCostAndExpenseOperating and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeGainReclassifiedToOtherIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is OtherIncome and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeGainReclassifiedToRevenue": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is Revenues and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeLossReclassifiedToCostOfSales": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CostOfGoodsSold and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeLossReclassifiedToEarnings": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProfitLoss and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeLossReclassifiedToInterestExpense": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is InterestExpense and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeLossReclassifiedToInvestmentIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is InvestmentIncomeNet and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeLossReclassifiedToOtherExpense": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is OtherCostAndExpenseOperating and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeLossReclassifiedToOtherIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is OtherIncome and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashFlowHedgeLossReclassifiedToRevenue": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is Revenues and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+],
+"CashForLeveragedBuyout": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"CashForLeveragedBuyoutBySourceAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"CategoriesOfInvestmentsCostMethodInvestmentsMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is CostmethodInvestmentsMember."
+],
+"CategoriesOfInvestmentsMarketableSecuritiesAvailableForSaleSecuritiesMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is AvailableforsaleSecuritiesMember."
+],
+"CategoriesOfInvestmentsMarketableSecuritiesHeldToMaturitySecuritiesMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is HeldtomaturitySecuritiesMember."
+],
+"CategoriesOfInvestmentsMarketableSecuritiesTradingSecuritiesMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TradingAccountAssetsMember."
+],
+"CausesOfIncreaseDecreaseInLiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAmount": [
+"2014-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is SupplementalInformationForPropertyCasualtyInsuranceUnderwritersPriorYearClaimsAndClaimsAdjustmentExpense."
+],
+"CausesOfIncreaseDecreaseInLiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAxis": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LiabilityForCatastropheClaimsByCatastrophicEventAxis."
+],
+"CausesOfIncreaseDecreaseInLiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseCauseDomain": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is CatastrophicEventDomain."
+],
+"CededCreditRiskAmount": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ReinsuranceRecoverables with CededCreditRiskConcentratedCreditRiskMember."
+],
+"CededCreditRiskAmountAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"CededCreditRiskClaimsLossAdjustmentExpenseIncurred": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"CededCreditRiskClaimsReceivable": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"CededCreditRiskConcentratedCreditRiskMember": [
+"2015-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacements are ConcentrationRiskByTypeAxis and its member ReinsurerConcentrationRiskMember and members of ConcentrationRiskByBenchmarkAxis."
+],
+"CededCreditRiskNotConcentratedCreditRiskMember": [
+"2015-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacements are ConcentrationRiskByTypeAxis and its member ReinsurerConcentrationRiskMember and members of ConcentrationRiskByBenchmarkAxis."
+],
+"CededCreditRiskOtherRisks": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"CededCreditRiskPremiumsEarned": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"CededCreditRiskRiskClassificationAxis": [
+"2015-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacements are ConcentrationRiskByBenchmarkAxis and ConcentrationRiskByTypeAxis."
+],
+"CededCreditRiskRiskClassificationDomain": [
+"2015-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacements are ConcentrationRiskBenchmarkDomain and ConcentrationRiskTypeDomain."
+],
+"CededPremiumsEarnedAccidentAndHealth": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"CededPremiumsEarnedFinancialGuaranteeInsuranceContracts": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"CededPremiumsEarnedLife": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"CededPremiumsEarnedOtherInsurance": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"CededPremiumsEarnedPropertyAndCasualty": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"CededPremiumsLifeInsuranceInForce": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is LifeInsuranceInForceCeded."
+],
+"CededPremiumsWrittenAccidentAndHealth": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"CededPremiumsWrittenFinancialGuaranteeInsuranceContracts": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"CededPremiumsWrittenLife": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"CededPremiumsWrittenOtherInsurance": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"CededPremiumsWrittenPropertyAndCasualty": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"CertainLoansAcquiredInTransferAccountedForAsAvailableForSaleDebtSecuritiesAccretableYield": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesAccretableYield and members of InformationByCategoryOfDebtSecurityAxis."
+],
+"CertainLoansAcquiredInTransferAccountedForAsAvailableForSaleDebtSecuritiesAccretableYieldAccretion": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesAccretableYieldAccretion and members of InformationByCategoryOfDebtSecurityAxis."
+],
+"CertainLoansAcquiredInTransferAccountedForAsAvailableForSaleDebtSecuritiesAccretableYieldAdditions": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesAccretableYieldAdditions and members of InformationByCategoryOfDebtSecurityAxis."
+],
+"CertainLoansAcquiredInTransferAccountedForAsAvailableForSaleDebtSecuritiesAccretableYieldDisposalsOfLoans": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesAccretableYieldDisposalsOfLoans and members of InformationByCategoryOfDebtSecurityAxis."
+],
+"CertainLoansAcquiredInTransferAccountedForAsAvailableForSaleDebtSecuritiesAccretableYieldMovementScheduleRollForward": [
+"2015-01-31",
+"Element was deprecated."
+],
+"CertainLoansAcquiredInTransferAccountedForAsAvailableForSaleDebtSecuritiesAccretableYieldPeriodIncreaseDecrease": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesAccretableYieldPeriodIncreaseDecrease and members of InformationByCategoryOfDebtSecurityAxis."
+],
+"CertainLoansAcquiredInTransferAccountedForAsAvailableForSaleDebtSecuritiesAccretableYieldReclassificationsFromNonaccretableDifference": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesAccretableYieldReclassificationsFromNonaccretableDifference and members of InformationByCategoryOfDebtSecurityAxis."
+],
+"CertainLoansAcquiredInTransferAccountedForAsAvailableForSaleDebtSecuritiesAccretableYieldReclassificationsToNonaccretableDifference": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesAccretableYieldReclassificationsToNonaccretableDifference and members of InformationByCategoryOfDebtSecurityAxis."
+],
+"CertainLoansAcquiredInTransferAccountedForAsAvailableForSaleDebtSecuritiesOtherThanTemporaryImpairmentCharges": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsAvailableforsaleDebtSecuritiesOtherthanTemporaryImpairmentChargesCreditLoss."
+],
+"CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesOtherThanTemporaryImpairmentCharges": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesOtherthanTemporaryImpairmentChargesCreditLoss."
+],
+"CertainLoansAcquiredInTransferAccountedForAsHeldToMaturityDebtSecuritiesAccretableYield": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesAccretableYield and members of InformationByCategoryOfDebtSecurityAxis."
+],
+"CertainLoansAcquiredInTransferAccountedForAsHeldToMaturityDebtSecuritiesAccretableYieldAccretion": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesAccretableYieldAccretion and members of InformationByCategoryOfDebtSecurityAxis."
+],
+"CertainLoansAcquiredInTransferAccountedForAsHeldToMaturityDebtSecuritiesAccretableYieldAdditions": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesAccretableYieldAdditions and members of InformationByCategoryOfDebtSecurityAxis."
+],
+"CertainLoansAcquiredInTransferAccountedForAsHeldToMaturityDebtSecuritiesAccretableYieldDisposalsOfLoans": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesAccretableYieldDisposalsOfLoans and members of InformationByCategoryOfDebtSecurityAxis."
+],
+"CertainLoansAcquiredInTransferAccountedForAsHeldToMaturityDebtSecuritiesAccretableYieldMovementScheduleRollForward": [
+"2015-01-31",
+"Element was deprecated."
+],
+"CertainLoansAcquiredInTransferAccountedForAsHeldToMaturityDebtSecuritiesAccretableYieldPeriodIncreaseDecrease": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesAccretableYieldPeriodIncreaseDecrease and members of InformationByCategoryOfDebtSecurityAxis."
+],
+"CertainLoansAcquiredInTransferAccountedForAsHeldToMaturityDebtSecuritiesAccretableYieldReclassificationsFromNonaccretableDifference": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesAccretableYieldReclassificationsFromNonaccretableDifference and members of InformationByCategoryOfDebtSecurityAxis."
+],
+"CertainLoansAcquiredInTransferAccountedForAsHeldToMaturityDebtSecuritiesAccretableYieldReclassificationsToNonaccretableDifference": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesAccretableYieldReclassificationsToNonaccretableDifference and members of InformationByCategoryOfDebtSecurityAxis."
+],
+"CertainLoansAcquiredInTransferAccountedForAsHeldToMaturityDebtSecuritiesOtherThanTemporaryImpairmentCharges": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsHeldtomaturityDebtSecuritiesOtherthanTemporaryImpairmentChargesCreditLoss."
+],
+"ChangeInHistoricalClaimsRateExperienceMember": [
+"2014-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"ChangeInMeasurementDateSFAS158Abstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"ChangeInTaxStatusAxis": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"ChangeInTaxStatusDomain": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"ChangeInUnrealizedGainLossOnFairValueHedgingInstruments": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is ChangeInUnrealizedGainLossOnFairValueHedgingInstruments1."
+],
+"ChangeInUnrealizedGainLossOnHedgedItemInFairValueHedge": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is ChangeInUnrealizedGainLossOnHedgedItemInFairValueHedge1."
+],
+"ChangesInFranchises": [
+"2015-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are SignificantChangesFranchisesSold, SignificantChangesFranchisesPurchasedDuringPeriod, SignificantChangesFrachisedOutletsInOperation, or SignificantChangesFrachisorOutletsInOperation."
+],
+"ClassOfFinancingReceivableMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is FinancingReceivableRecordedInvestmentClassOfFinancingReceivableDomain."
+],
+"ClassOfWarrantOrRightExercisePriceOfWarrantsOrRights": [
+"2014-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is ClassOfWarrantOrRightExercisePriceOfWarrantsOrRights1."
+],
+"ClearanceFeesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ClearanceFees."
+],
+"ClosedBlockAssetsAndLiabilitiesTableTextBlock": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ScheduleOfClosedBlockAssetsAndLiabilities."
+],
+"ClosedBlockDividendObligation": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ClosedBlockLiabilitiesPolicyholderDividendObligation."
+],
+"ClosedBlockOperationsChangeInPolicyholderDividendObligation": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ClosedBlockDividendObligationPeriodIncreaseDecrease."
+],
+"CollaborativeArrangementProductAggregatedDisclosureMember": [
+"2013-01-31",
+"Element was deprecated because of unnecessary level of disaggregation in a parent-child relationship."
+],
+"CollaborativeArrangementProductMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is CollaborativeArrangementProductAgreementMember."
+],
+"CollaborativeArrangementsAndNoncollaborativeArrangementTransactionsAxis": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TypeOfArrangementAxis."
+],
+"CollaborativeArrangementsAndNoncollaborativeArrangementTransactionsMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ArrangementsAndNonarrangementTransactionsMember."
+],
+"CollaborativeArrangementsCopromotionAgreementAggregatedDisclosureMember": [
+"2013-01-31",
+"Element was deprecated because of unnecessary level of disaggregation in a parent-child relationship."
+],
+"CollaborativeArrangementsCopromotionAgreementAgreementMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is CollaborativeArrangementCopromotionMember."
+],
+"CommercialLinesMember": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is PropertyAndCasualtyCommercialInsuranceProductLineMember."
+],
+"CommercialRealEstateConstructionFinancingReceivableMember": [
+"2015-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacements are CommercialRealEstatePortfolioSegmentMember and ConstructionLoansMember."
+],
+"CommercialRealEstateOtherReceivableMember": [
+"2015-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacements are CommercialPortfolioSegmentMember and RealEstateLoanMember."
+],
+"CommonStockIncludingAdditionalPaidInCapital": [
+"2013-01-31",
+"Element was deprecated due to ambiguous definition. Possible replacement is CommonStocksIncludingAdditionalPaidInCapital."
+],
+"CommonStockIncludingAdditionalPaidInCapitalNetOfDiscount": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is CommonStocksIncludingAdditionalPaidInCapitalNetOfDiscount."
+],
+"CommonStockholdersEquity": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is StockholdersEquity."
+],
+"CommunicationsAndDataProcessingMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is CommunicationsAndInformationTechnology."
+],
+"CommunicationsDataProcessingAndOccupancyMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is CommunicationsInformationTechnologyAndOccupancy."
+],
+"CompensatedAbsencesAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"CompensatedAbsencesLiabilityVacationAndHoliday": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is AccruedVacationCurrentAndNoncurrent."
+],
+"CompensatingBalancesCashAndCashEquivalentsAxis": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is CashAndCashEquivalentsAxis."
+],
+"CompensatingBalancesCashAndCashEquivalentsMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is RestrictedCashAndCashEquivalentsCashAndCashEquivalentsMember."
+],
+"CompetitiveTransitionChargeMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is StrandedCostsMember."
+],
+"ComponentOfOtherExpenseNonoperatingAxis": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"ComponentOfOtherExpenseNonoperatingNameDomain": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"ComponentOfOtherExpenseNonoperatingTable": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"ComponentOfOtherIncomeNonoperatingAxis": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"ComponentOfOtherIncomeNonoperatingNameDomain": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"ComponentOfOtherIncomeNonoperatingTable": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"ComponentOfOtherOperatingCostAndExpenseGeneralAxis": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"ComponentOfOtherOperatingCostAndExpenseNameDomain": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"ComponentOfOtherOperatingCostAndExpenseTable": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"ConcentrationOfCededCreditRisk": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ConcentrationRiskCreditRiskReinsurance."
+],
+"ConsumerCreditCardFinancingReceivableMember": [
+"2015-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacements are CreditCardReceivablesMember and ConsumerPortfolioSegmentMember."
+],
+"ConsumerCreditScoreMember": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is InternalCreditAssessmentDomain."
+],
+"ConsumerLoansAutoFinancingReceivableMember": [
+"2015-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacements are ConsumerPortfolioSegmentMember and AutomobileLoanMember."
+],
+"ConsumerOtherFinancingReceivableMember": [
+"2015-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacement is ConsumerPortfolioSegmentMember."
+],
+"ContingentlyIssuableSharesMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is StockCompensationPlanMember."
+],
+"ContractHolderReceivables": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is PremiumsReceivableGross."
+],
+"ContractsInForceSubjectToParticipationThroughReinsuranceValue": [
+"2013-01-31",
+"Element was deprecated."
+],
+"ContractuallySpecifiedServicingFeesDescriptionOfWhereReportedOnStatementOfIncome": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ContractuallySpecifiedServicingFeesAmount and members of IncomeStatementLocationAxis."
+],
+"ContributionsFromNoncontrollingInterests": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ProceedsFromMinorityShareholders."
+],
+"CooperativeAdvertisingExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is CooperativeAdvertisingExpense."
+],
+"CorporateCreditQualityIndicatorMember": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is InternalCreditAssessmentDomain."
+],
+"CostMethodInvestmentsAggregateCarryingAmount": [
+"2013-01-31",
+"Element deprecated due to redundancy. Possible replacement is CostMethodInvestments."
+],
+"CreditDerivativeCurrentFairValue": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is CreditRiskDerivativeLiabilitiesAtFairValue."
+],
+"CreditDerivativeOriginAndPurpose": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DiscussionOfObjectivesForUsingCreditRiskDerivativeInstruments."
+],
+"CreditDerivativeTerm": [
+"2013-01-31",
+"Element was deprecated because it is has a stringItemType attribute. Possible replacement is CreditDerivativeTerm1."
+],
+"CreditRatingDomain": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are CreditRatingAMBestDomain, InternalCreditAssessmentDomain, ExternalCreditRatingFitchMember, ExternalCreditRatingStandardPoorsMember, ExternalCreditRatingMoodysMember, ExternalCreditRatingByGroupingDomain."
+],
+"CreditRiskDerivativesAbstract": [
 "2013-01-31",
 "Element was deprecated."
 ],
@@ -591,145 +1619,2101 @@
 "2014-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"FairValueEstimateNotPracticableReasonsFederalFundsPurchased": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
-],
-"MinorityInterestExpenseIncomeRealEstateInvestmentsAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"CapitalLeaseExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is CapitalLeasesIncomeStatementInterestExpense."
-],
-"AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionIncomeStatementClassificationOfGainLossOnDisposal": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionGainLossOnDisposition1 and members of IncomeStatementLocationAxis."
-],
-"LongDurationContractsAssumptionsByProductAndGuaranteeEstimatedInvestmentYieldLowEnd": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LongDurationContractsAssumptionsByProductAndGuaranteeEstimatedAverageInvestmentYield, RangeAxis and MinimumMember."
-],
-"EquityFinancingForLeveragedBuyoutAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"DiscontinuedOperationAmountOfOtherIncomeLossFromDispositionOfDiscontinuedOperationNetOfTaxAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"OtherExpenseOfInsuranceEntitiesAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"OtherComprehensiveIncomeLossReclassificationAdjustmentForWritedownOfSecuritiesIncludedInNetIncomeNetOfTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForWritedownOfSecuritiesNetOfTax."
-],
-"RealEstateTaxesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is RealEstateTaxExpense."
-],
-"NotionalAmountOfDerivativesAdditionalCategoriesOfDerivativesAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"FinancingReceivableRecordedInvestment60To89DaysPastDue": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FinancingReceivableRecordedInvestmentPastDue and FinancingReceivables60To89DaysPastDueMember."
-],
-"LateFeeIncomeGeneratedByServicingFinancialAssetsDescriptionOfWhereReportedOnStatementOfIncome": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LateFeeIncomeGeneratedByServicingFinancialAssetsAmount and members of IncomeStatementLocationAxis."
-],
-"UnusualOrInfrequentItemGross1": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacement for a gain is UnusualOrInfrequentItemGainGross, or UnusualOrInfrequentItemLossGross to represent a loss."
-],
-"IncomeTaxExaminationPenaltiesFromExamination": [
-"2013-01-31",
-"Element was deprecated due to redundancy.  Possible replacement is IncomeTaxExaminationPenaltiesExpense."
-],
-"FairValueEstimateNotPracticableReasonsLoansReceivable": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
-],
-"StockRepurchaseProgramAuthorizedAmount": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is StockRepurchaseProgramAuthorizedAmount1."
-],
-"RestructuringReserveSettledWithoutCash": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is RestructuringReserveSettledWithoutCash1."
-],
-"FairValueEstimateNotPracticableReasonsAccruedLiabilities": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
-],
-"TravelAndEntertainmentExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is TravelAndEntertainmentExpense."
-],
-"RealizedLossesOnSaleOfInvestmentsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is MarketableSecuritiesRealizedGainLoss."
-],
 "CumulativeEffectAdjustmentApplicationOfFairValueOptionGrossGains": [
 "2014-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"DeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticable": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are:\nDeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticableUndistributedEarningsOfForeignSubsidiaries\nDeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticableUndistributedEarningsOfDomesticSubsidiaries\nDeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticableBadDebtReserveForTaxPurposesOfQualifiedLender\nDeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticablePolicyholdersSurplus."
+"CumulativeEffectAdjustmentApplicationOfFairValueOptionGrossGainsAbstract": [
+"2014-01-31",
+"Element was deprecated."
 ],
-"RevenueRecognitionNewAccountingPronouncementMaterialEffectRevenueDeferredUnderAmendedGuidance": [
-"2015-01-31",
+"CumulativeEffectAdjustmentApplicationOfFairValueOptionGrossLosses": [
+"2014-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"BusinessDevelopmentMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is BusinessDevelopment."
+"CumulativeEffectAdjustmentApplicationOfFairValueOptionGrossLossesAbstract": [
+"2014-01-31",
+"Element was deprecated."
 ],
-"CashFlowHedgeGainReclassifiedToOtherExpense": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is OtherCostAndExpenseOperating and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"GainLossOnDerivativesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is UnrealizedGainLossOnDerivatives."
-],
-"SourcesAndUsesOfCashForLeveragedBuyoutTextBlock": [
-"2013-01-31",
+"CumulativeEffectAdjustmentApplicationOfFairValueOptionUnrealizedGainsRecognized": [
+"2014-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"EmbeddedDerivativeLineItemOnBalanceSheet": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are EmbeddedDerivativeFairValueOfEmbeddedDerivativeAsset, EmbeddedDerivativeFairValueOfEmbeddedDerivativeLiability, EmbeddedDerivativeFairValueOfEmbeddedDerivativeNet and members of BalanceSheetLocationAxis."
+"CumulativeEffectAdjustmentApplicationOfFairValueOptionUnrealizedGainsUnrecognized": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"EffectOfIllegalActsOnFinancialStatementsDisclosureMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+"CumulativeEffectAdjustmentApplicationOfFairValueOptionUnrealizedLossesRecognized": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"GainLossOnCondemnationNetOfTaxMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+"CumulativeEffectAdjustmentApplicationOfFairValueOptionUnrealizedLossesUnrecognized": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"CumulativeEffectAdjustmentBifurcationOfHybridsGrossGains": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"CumulativeEffectAdjustmentBifurcationOfHybridsGrossLosses": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
 "CumulativeEffectAdjustmentGrossGains": [
 "2014-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"OtherComprehensiveIncomeLossReclassificationAdjustmentForSaleOfSecuritiesIncludedInNetIncomeBeforeTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForSaleOfSecuritiesBeforeTax."
+"CumulativeEffectAdjustmentGrossLosses": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"ComponentOfOtherExpenseNonoperatingNameDomain": [
+"CumulativeEffectOfProspectiveApplicationOfNewAccountingPrinciple": [
+"2015-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is CumulativeEffectOfNewAccountingPrincipleInPeriodOfAdoption."
+],
+"CurrentIncomeTaxExpenseBenefitAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"CustomerSecuritiesForWhichEntityHasRightToSellOrRepledgeClassification": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CustomerSecuritiesForWhichEntityHasRightToSellOrRepledgeFairValue and members of BalanceSheetLocationAxis."
+],
+"CustomerSecuritiesForWhichEntityHasRightToSellOrRepledgeDescription": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"CustomerSecuritiesForWhichEntityHasRightToSellOrRepledgeSecuritiesSoldOrRepledgedClassification": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CustomerSecuritiesForWhichEntityHasRightToSellOrRepledgeFairValueOfSecuritiesSoldOrRepledged and members of BalanceSheetLocationAxis."
+],
+"DebtInstrumentBasisSpreadOnVariableRate": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is DebtInstrumentBasisSpreadOnVariableRate1."
+],
+"DebtInstrumentCommitteeForUniformSecuritiesIdentificationProceduresCUSIP": [
+"2013-01-31",
+"Element was deprecated because it is has a stringItemType attribute. Possible replacement is CommitteeForUniformSecuritiesIdentificationProceduresCUSIP."
+],
+"DebtInstrumentConvertibleConversionRatio": [
+"2013-01-31",
+"Element was deprecated because it has a decimalItemType attribute. Possible replacement is DebtInstrumentConvertibleConversionRatio1."
+],
+"DebtInstrumentConvertibleEffectiveInterestRate": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DebtInstrumentInterestRateEffectivePercentage, DebtInstrumentInterestRateEffectivePercentageRateRangeMinimum, DebtInstrumentInterestRateEffectivePercentageRateRangeMaximum and members of LongtermDebtTypeAxis or ShortTermDebtTypeAxis."
+],
+"DebtInstrumentConvertibleInterestExpense": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is InterestExpenseDebt and members of LongtermDebtTypeAxis or ShortTermDebtTypeAxis."
+],
+"DebtInstrumentDecreaseRepayments": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replace is RepaymentsOfDebt."
+],
+"DebtInstrumentIncreaseAdditionalBorrowings": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute.  Possible replacement is ProceedsFromIssuanceOfDebt."
+],
+"DebtInstrumentInterestRateAtPeriodEnd": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DebtInstrumentInterestRateEffectivePercentage."
+],
+"DebtInstrumentInterestRateIncrease": [
+"2013-01-31",
+"Element was deprecated because it has a pureItemType attribute. Possible replacement is DebtInstrumentInterestRateIncreaseDecrease."
+],
+"DebtorInPossessionFinancingPurposeOfArrangement": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"DeconsolidationGainOrLossIfNotPresentedSeparatelyFinancialStatementCaption": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DeconsolidationGainOrLossAmount and members of IncomeStatementLocationAxis."
+],
+"DeferredCompensationArrangementWithIndividualCashAwardsGrantedAmount": [
+"2013-01-31",
+"Element was deprecated because it has debit balance and duration period type attributes. Possible replacement is DeferredCompensationArrangementWithIndividualCashAwardGrantedAmount."
+],
+"DeferredCompensationArrangementWithIndividualExcludingShareBasedPaymentsAndPostretirementBenefitsByTitleOfIndividualAxis": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is TitleofIndividualAxis."
+],
+"DeferredCompensationArrangementWithIndividualMaximumContractualTerm": [
+"2014-01-31",
+"Element was deprecated because it has a stringItemType attribute. Possible replacement is DeferredCompensationArrangementWithIndividualMaximumContractualTerm1."
+],
+"DeferredCompensationArrangementWithIndividualPostretirementBenefitsByTitleOfIndividualAxis": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is TitleofIndividualAxis."
+],
+"DeferredCompensationArrangementWithIndividualRequisiteServicePeriod": [
+"2014-01-31",
+"Element was deprecated because it has a stringItemType attribute. Possible replacement is DeferredCompensationArrangementWithIndividualRequisiteServicePeriod1."
+],
+"DeferredCompensationArrangementWithIndividualShareBasedPaymentsByTitleOfIndividualAxis": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is TitleofIndividualAxis."
+],
+"DeferredGainOnEarlyExtinguishmentOfDebtAmountMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DeferredLossOnEarlyExtinguishmentOfDebtMember."
+],
+"DeferredIncomeTaxExpenseBenefitAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"DeferredPolicyAcquisitionCostsAndPresentValueOfFutureProfits": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DeferredPolicyAcquisitionCostsAndValueOfBusinessAcquired."
+],
+"DeferredPolicyAcquisitionCostsNet": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DeferredPolicyAcquisitionCosts."
+],
+"DeferredPolicyAcquisitionCostsTextBlock": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is DeferredPolicyAcquisitionCostsTextBlock1 or CapitalizationOfDeferredPolicyAcquisitionCostsPolicy."
+],
+"DeferredTaxLiabilitiesPrepaidPensionCosts": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiability": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are\nDeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityUndistributedEarningsOfForeignSubsidiaries, DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityUndistributedEarningsOfDomesticSubsidiaries, DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityBadDebtReserveForTaxPurposesOfQualifiedLender, and DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityPolicyholdersSurplus."
+],
+"DeferredTaxLiabilityNotRecognizedAxis": [
 "2013-01-31",
 "Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"DeferredTaxLiabilityNotRecognizedCumulativeAmountOfTemporaryDifference": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are\nUndistributedEarningsOfForeignSubsidiaries, UndistributedEarningsOfDomesticSubsidiaries, BadDebtReserveForTaxPurposesOfQualifiedLender, and PolicyholdersSurplus."
+],
+"DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifference": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferenceUndistributedEarningsOfForeignSubsidiaries, DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferenceUndistributedEarningsOfDomesticSubsidiaries, DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferenceBadDebtReserveForTaxPurposesOfQualifiedLender, and DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferencePolicyholdersSurplus."
+],
+"DeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticable": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are:\nDeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticableUndistributedEarningsOfForeignSubsidiaries\nDeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticableUndistributedEarningsOfDomesticSubsidiaries\nDeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticableBadDebtReserveForTaxPurposesOfQualifiedLender\nDeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticablePolicyholdersSurplus."
+],
+"DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxable": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxableUndistributedEarningsOfForeignSubsidiaries, DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxableUndistributedEarningsOfDomesticSubsidiaries, DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxableBadDebtReserveForTaxPurposesOfQualifiedLender,  and DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxablePolicyholdersSurplus."
+],
+"DeferredTaxLiabilityNotRecognizedLineItems": [
+"2013-01-31",
+"Element was deprecated."
+],
+"DeferredTaxLiabilityNotRecognizedNameOfTemporaryDifferenceDomain": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept remodeled as primary concepts."
+],
+"DeferredTaxLiabilityNotRecognizedTable": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"DefinedBenefitPlanAccumulatedOtherComprehensiveIncomeLossAfterTax": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is AccumulatedOtherComprehensiveIncomeLossDefinedBenefitPensionAndOtherPostretirementPlansNetOfTax."
+],
+"DefinedBenefitPlanAmortizationOfNetGainsLosses": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is DefinedBenefitPlanFutureAmortizationOfGainLoss."
+],
+"DefinedBenefitPlanAmortizationOfNetPriorServiceCostCredit": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is DefinedBenefitPlanFutureAmortizationOfPriorServiceCostCredit."
+],
+"DefinedBenefitPlanAmountsThatWillBeAmortizedFromAccumulatedOtherComprehensiveIncomeLossInNextFiscalYear": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is DefinedBenefitPlanAmountToBeAmortizedFromAccumulatedOtherComprehensiveIncomeLossNextFiscalYear."
+],
+"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsAccruedBenefitLiability": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsAccumulatedOtherComprehensiveIncome": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsAmountsRecognizedInBalanceSheet": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsAmountsRecognizedInBalanceSheetAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsIntangibleAsset": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsMaterialGainLossNotRecognizedInCurrentFiscalYear": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsMinimumPensionLiabilityAdjustment": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsNetAmountRecognized": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsPrepaidBenefitCost": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DefinedBenefitPlanEstimatedFutureEmployerContributionsInCurrentFiscalYear": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is DefinedBenefitPlansEstimatedFutureEmployerContributionsInCurrentFiscalYear."
+],
+"DefinedBenefitPlanEstimatedFutureEmployerContributionsInNextFiscalYear": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is DefinedBenefitPlansEstimatedFutureEmployerContributionsInNextFiscalYear."
+],
+"DefinedBenefitPlanPurchasesSalesAndSettlementsAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"DefinedContributionPensionMember": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is PensionPlansDefinedBenefitMember."
+],
+"DefinedContributionPlanMaximumAnnualContributionPerEmployeeAmount": [
+"2013-01-31",
+"Element was deprecated because it was incorrectly defined. Possible replacement is DefinedContributionPlanMaximumAnnualContributionsPerEmployeeAmount."
+],
+"DefinedContributionPlanMaximumAnnualContributionPerEmployeePercent": [
+"2013-01-31",
+"Element was deprecated because it was incorrectly defined. Possible replacement is DefinedContributionPlanMaximumAnnualContributionsPerEmployeePercent."
+],
+"DepositAssetsOrLiabilitiesAmortizationExpenseFromExpirations": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacement is DepositAssetsAmortizatonExpenseFromExpirations."
+],
+"DepositAssetsOrLiabilitiesEffectOfChangeInInterestAccrualAssumptionOnExpectedRecoveryAmounts": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DepositAssetsEffectOfIncreaseDecreaseInInterestAccrualAssumptionOnExpectedRecoveryAmounts and DepositLiabilitiesEffectOfIncreaseDecreaseInInterestAccrualAssumptionOnExpectedRecoveryAmounts."
+],
+"DepositAssetsOrLiabilitiesEffectOfChangeInPresentValueAssumptionsRecordedAsExpense": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DepositAssetsEffectOfChangeInPresentValueAssumptionsRecordedAsExpense and DepositLiabilitiesEffectOfChangeInPresentValueAssumptionsRecordedAsExpense."
+],
+"DepositAssetsOrLiabilitiesEffectOfChangeInPresentValueAssumptionsResultingInAdditionsToExpectedRecoveries": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DepositAssetsEffectOfChangeInPresentValueAssumptionsResultingInAdditionsToExpectedRecoveries and DepositLiabilitiesEffectOfChangeInPresentValueAssumptionsResultingInAdditionsToExpectedRecoveries."
+],
+"DepositAssetsOrLiabilitiesEffectOfChangeInPresentValueAssumptionsResultingInReductionsInExpectedRecoveries": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DepositAssetsEffectOfChangeInPresentValueAssumptionsResultingInReductionsToExpectedRecoveries and DepositLiabilitiesEffectOfChangeInPresentValueAssumptionsResultingInReductionsToExpectedRecoveries."
+],
+"DepositAssetsOrLiabilitiesPresentValueOfExpectedRecoveries": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacement is DepositAssetsPresentValueOfExpectedRecoveries."
+],
+"DepositLiabilitiesWithAbnormalTermsDescription": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"DeprecatedItems": [
+"",
+"This is a container item for US-GAAP concepts that have been deprecated."
+],
+"DepreciableAssetsMember": [
+"2014-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"DerecognizedAssetsSecuritizedOrAssetbackedFinancingArrangementAssetsAndAnyOtherFinancialAssetsManagedTogetherAverageBalanceDuringPeriod": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DerivativeAssetFairValueNet": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DerivativeFairValueOfDerivativeAssetAmountNotOffsetAgainstCollateral."
+],
+"DerivativeDescriptionOfVariableRateBasis": [
+"2014-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeVariableInterestRate and members of VariableRateAxis."
+],
+"DerivativeFairValueGrossAmountNotOffsetAgainstCollateralNet": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DerivativeFairValueOfDerivativeNet."
+],
+"DerivativeFairValueGrossAmountNotOffsetAgainstCollateralNetAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"DerivativeFinancialInstrumentsLiabilitiesFairValueDisclosure": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DerivativeLiabilities."
+],
+"DerivativeHedgeDesignation": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
+],
+"DerivativeInstrumentsGainLossRecognizedInIncomeNet": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeGainLossOnDerivativeNet and members of HedgingDesignationAxis."
+],
+"DerivativeInstrumentsGainLossRecognizedInIncomeNetAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"DerivativeInstrumentsGainRecognizedInIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeGainOnDerivative and members of HedgingDesignationAxis."
+],
+"DerivativeInstrumentsLossRecognizedInIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeLossOnDerivative and members of HedgingDesignationAxis."
+],
+"DerivativeLiabilityFairValueNet1": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DerivativeFairValueOfDerivativeLiabilityAmountNotOffsetAgainstCollateral."
+],
+"DerivativeNonmonetaryNotionalAmountPricePerBarrel": [
+"2013-01-31",
+"Element was deprecated because the intended concept conveyed is the underlying. Possible replacement is UnderlyingDerivativeVolume."
+],
+"DerivativeNonmonetaryNotionalAmountPricePerGallon": [
+"2013-01-31",
+"Element was deprecated because the intended concept conveyed is the underlying. Possible replacement is UnderlyingDerivativeVolume."
+],
+"DerivativeNonmonetaryNotionalAmountPricePerUnit": [
+"2013-01-31",
+"Element was deprecated because the intended concept conveyed is the underlying. Possible replacements are UnderlyingDerivativeAsset, UnderlyingDerivativeLiability and UnderlyingDerivative."
+],
+"DescriptionAndEffectsOfChangesInPrepaymentEstimateAssumptionsForCMOsAndREMICsLineItems": [
+"2013-01-31",
+"Element was deprecated."
+],
+"DescriptionOfAccountingMethodUsedForCreditRiskDerivatives": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are members of ValuationTechniqueAxis."
+],
+"DescriptionOfAdoptionOfPolicyOnAccruedSabbatical": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"DescriptionOfChangeInAccountingPrincipleSFAS158": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DescriptionOfChangeInAverageTrancheLifeEstimate": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"DescriptionOfChangeInCashFlowProjectionsEstimate": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"DescriptionOfChangeInMeasurementDateSFAS158": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DescriptionOfChangeInReinvestmentRateOfReturnEstimate": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"DescriptionOfCreditRiskDerivativeActivities": [
+"2013-01-31",
+"Element was deprecated because it has a stringItemType attribute. Possible replacement is DisclosureOfCreditDerivativesTextBlock."
+],
+"DescriptionOfDerivativeInstrumentsByRiskExposure": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DerivativeUnderlyingRisk."
+],
+"DescriptionOfEmbeddedRegulatoryAsset": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"DescriptionOfHedgedFirmCommitmentNotQualifyingAsForeignCurrencyFairValueHedge": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"DescriptionOfHedgedFirmCommitmentNotQualifyingAsInterestRateFairValueHedge": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"DescriptionOfHedgedFirmCommitmentNotQualifyingAsPriceRiskFairValueHedge": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"DescriptionOfLocationOfForeignCurrencyFairValueHedgeDerivativeOnBalanceSheet": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ForeignCurrencyFairValueHedgeAssetAtFairValue and members of BalanceSheetLocationAxis."
+],
+"DescriptionOfLocationOfGainLossOnForeignCurrencyFairValueHedgeDerivativeInFinancialStatements": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is GainLossOnForeignCurrencyFairValueHedgeDerivatives and members of IncomeStatementLocationAxis."
+],
+"DescriptionOfLocationOfGainLossOnPriceRiskCashFlowHedgeDerivativesInFinancialStatements": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is UnrealizedGainLossOnPriceRiskCashFlowDerivativesBeforeTax and members of IncomeStatementLocationAxis."
+],
+"DescriptionOfLocationOfGainLossOnPriceRiskDerivativeOnIncomeStatement": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is GainLossOnPriceRiskDerivativesNet and members of IncomeStatementLocationAxis."
+],
+"DescriptionOfLocationOfHybridInstrumentsOnBalanceSheet": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is HybridInstrumentsAtFairValueNet and members of BalanceSheetLocationAxis."
+],
+"DescriptionOfLocationOfPriceRiskCashFlowHedgeDerivativesOnBalanceSheet": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are PriceRiskCashFlowHedgeAssetAtFairValue and PriceRiskCashFlowHedgeLiabilityAtFairValue and members of BalanceSheetLocationAxis."
+],
+"DescriptionOfLocationOfPriceRiskDerivativesOnBalanceSheet": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are PriceRiskDerivativeAssetsAtFairValue and PriceRiskDerivativeLiabilitiesAtFairValue and members of BalanceSheetLocationAxis."
+],
+"DescriptionOfLongTermIntercompanyTransactions": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"DescriptionOfMaterialAffectsOfNoncomplianceOfBranchesOfForeignFinancialInstitutions": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"DescriptionOfMaterialAffectsOfNoncomplianceWithCapitalRequirementsOnTrustAssets": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"DescriptionOfSubstantialDoubtAboutInstitutionsAbilityToContinueAsGoingConcernBankingOrSavingsInstitution": [
+"2015-01-31",
+"Element was deprecated due to issuance of new guidance."
+],
+"DetailsOfLongLivedAssetsToBeAbandonedByAssetTextBlock": [
+"2015-01-31",
+"Element deprecated due to redundancy. Possible replacement is ScheduleOfDisposalGroupsIncludingDiscontinuedOperationsIncomeStatementBalanceSheetAndAdditionalDisclosuresTextBlock."
+],
+"DevelopmentStageEnterpriseAdditionalInformationForStatementOfStockholdersEquityDisclosureAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"DevelopmentStageEnterpriseDeficitAccumulatedDuringDevelopmentStage": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DevelopmentStageEnterpriseDevelopmentStageExitStrategy": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DevelopmentStageEnterpriseGeneralDisclosuresTextBlock": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DevelopmentStageEnterpriseNatureOfActivities": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DevelopmentStageEnterprises": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DevelopmentStageEnterprisesAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"DirectPremiumsEarnedAccidentAndHealth": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"DirectPremiumsEarnedFinancialGuaranteeInsuranceContracts": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"DirectPremiumsEarnedLife": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"DirectPremiumsEarnedOtherInsurance": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"DirectPremiumsEarnedPropertyAndCasualty": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"DirectPremiumsLifeInsuranceInForce": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is LifeInsuranceInForceGross."
+],
+"DirectPremiumsWrittenAccidentAndHealth": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsWritten and members ofReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"DirectPremiumsWrittenFinancialGuaranteeInsuranceContracts": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"DirectPremiumsWrittenLife": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"DirectPremiumsWrittenOtherInsurance": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"DirectPremiumsWrittenPropertyAndCasualty": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"DiscontinuedOperationAmountOfOtherIncomeLossFromDispositionOfDiscontinuedOperationNetOfTax": [
+"2015-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"DiscontinuedOperationAmountOfOtherIncomeLossFromDispositionOfDiscontinuedOperationNetOfTaxAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"DiscontinuedOperationAmountOfOtherIncomeLossFromDispositionOfDiscontinuedOperationsBeforeIncomeTax": [
+"2015-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"DiscontinuedOperationIntercompanyAmountsWithDiscontinuedOperationBeforeDisposalTransactionCosts": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DiscontinuedOperationIntercompanyAmountsWithDiscontinuedOperationBeforeDisposalTransactionRevenue": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DiscontinuedOperationNatureOfActivitiesHavingContinuingCashFlowsAfterDisposal": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DiscontinuedOperationNatureOfOtherIncomeLossFromDispositionOfDiscontinuedOperation": [
+"2015-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"DiscontinuedOperationPeriodOfContinuingCashFlowsAfterDisposal": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DiscontinuedOperationTaxEffectOfOtherIncomeLossFromDispositionOfDiscontinuedOperation": [
+"2015-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReserves10PercentAnnualDiscountForEstimatedTimingOfCashFlows": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesTenPercentAnnualDiscountForEstimatedTimingOfCashFlows."
+],
+"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesEntitysShareOfEquityMethodInvesteesStandardizedDiscountedFutureNetCashFlows": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is StandardizedMeasureOfDiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReserves and EquityMethodInvesteeMember."
+],
+"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureCashInflows": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesCashInflows."
+],
+"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureDevelopmentCosts": [
+"2013-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesDevelopmentCosts."
+],
+"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureDevelopmentCosts1": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesDevelopmentCosts."
+],
+"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureIncomeTaxExpense": [
+"2013-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesIncomeTaxExpense."
+],
+"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureIncomeTaxExpense1": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesIncomeTaxExpense."
+],
+"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureNetCashFlows": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesNetCashFlows."
+],
+"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureProductionCosts": [
+"2013-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesProductionCosts."
+],
+"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureProductionCosts1": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesProductionCosts."
+],
+"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesStandardizedMeasure": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is StandardizedMeasureOfDiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReserves."
+],
+"DiscussionOfCreditRiskDerivativeRiskManagementPolicy": [
+"2013-01-31",
+"Element was deprecated because it has a stringItemType attribute. Possible replacement is DerivativesPolicyTextBlock."
+],
+"DiscussionOfEarningsEffectOfHybridInstrumentFairValueChanges": [
+"2015-01-31",
+"Element deprecated due to redundancy. Possible replacement is DescriptionOfHybridInstrumentsAccountedForAtFairValue."
+],
+"DiscussionOfMethodOfMeasuringFairValueOfCreditRiskDerivatives": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are members of ValuationTechniqueAxis."
+],
+"DisposalGroupAssetsOfBusinessTransferredUnderContractualArrangement": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssetsOfDisposalGroupIncludingDiscontinuedOperation and members of DisposalGroupClassificationAxis."
+],
+"DisposalGroupIncludingDiscontinuedOperationAssetsOfDisposalGroup": [
+"2015-01-31",
+"Element was deprecated because it has a stringItemType attribute. Possible replacement is AssetsOfDisposalGroupIncludingDiscontinuedOperation."
+],
+"DisposalGroupIncludingDiscontinuedOperationCashFlowsOfDisposalGroup": [
+"2015-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"DisposalGroupIncludingDiscontinuedOperationGoodwill": [
+"2014-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DisposalGroupIncludingDiscontinuedOperationGoodwillNoncurrent, DisposalGroupIncludingDiscontinuedOperationGoodwillCurrent or DisposalGroupIncludingDiscontinuedOperationGoodwill1."
+],
+"DisposalGroupIncludingDiscontinuedOperationIntangibleAssetsNet": [
+"2014-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DisposalGroupIncludingDiscontinuedOperationIntangibleAssetsNoncurrent, DisposalGroupIncludingDiscontinuedOperationIntangibleAssetsCurrent or DisposalGroupIncludingDiscontinuedOperationIntangibleAssets."
+],
+"DisposalGroupIncludingDiscontinuedOperationInventory": [
+"2014-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DisposalGroupIncludingDiscontinuedOperationInventoryCurrent, DisposalGroupIncludingDiscontinuedOperationInventoryNoncurrent or DisposalGroupIncludingDiscontinuedOperationInventory1."
+],
+"DisposalGroupIncludingDiscontinuedOperationLiabilitiesOfDisposalGroup": [
+"2015-01-31",
+"Element was deprecated because it has a stringItemType attribute. Possible replacement is LiabilitiesOfDisposalGroupIncludingDiscontinuedOperation."
+],
+"DisposalGroupIncludingDiscontinuedOperationLongLivedAssets": [
+"2015-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"DisposalGroupIncludingDiscontinuedOperationLongLivedAssetsAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"DisposalGroupIncludingDiscontinuedOperationLongLivedAssetsCurrent": [
+"2015-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"DisposalGroupIncludingDiscontinuedOperationLongLivedAssetsCurrentAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"DisposalGroupIncludingDiscontinuedOperationLongLivedAssetsNoncurrent": [
+"2015-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"DisposalGroupIncludingDiscontinuedOperationLongLivedAssetsNoncurrentAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipmentNet": [
+"2014-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipmentNoncurrent, DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipmentCurrent or DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipment."
+],
+"DisposalGroupIncludingDiscontinuedOperationStatusOfDisposalGroupAtLatestBalanceSheetDate": [
+"2015-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is DisposalGroupIncludingDiscontinuedOperationDescriptionAndTimingOfDisposal."
+],
+"DisposalGroupLiabilitiesOfBusinessTransferredUnderContractualArrangement": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LiabilitiesOfDisposalGroupIncludingDiscontinuedOperation and members of DisposalGroupClassificationAxis."
+],
+"DisposalGroupNotDiscontinuedOperationGainLossOnDisposalIncomeStatementCaption": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DisposalGroupNotDiscontinuedOperationGainLossOnDisposal and members of IncomeStatementLocationAxis."
+],
+"DisposalGroupNotDiscontinuedOperationLossGainOnWriteDownIncomeStatementCaption": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DisposalGroupNotDiscontinuedOperationLossGainOnWriteDown and members of IncomeStatementLocationAxis."
+],
+"DisposalGroupSpecialTransactionClassificationsAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"DistributionMadeToMemberOrLimitedPartnerCashDistributionsDeclared": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberCashDistributionsDeclared or DistributionMadeToLimitedPartnerCashDistributionsDeclared."
+],
+"DistributionMadeToMemberOrLimitedPartnerCashDistributionsPaid": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberCashDistributionsPaid or DistributionMadeToLimitedPartnerCashDistributionsPaid."
+],
+"DistributionMadeToMemberOrLimitedPartnerDateOfRecord1": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberDateOfRecord or DistributionMadeToLimitedPartnerDateOfRecord."
+],
+"DistributionMadeToMemberOrLimitedPartnerDeclarationDate1": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberDeclarationDate or DistributionMadeToLimitedPartnerDeclarationDate."
+],
+"DistributionMadeToMemberOrLimitedPartnerDistributionDate1": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberDistributionDate or DistributionMadeToLimitedPartnerDistributionDate."
+],
+"DistributionMadeToMemberOrLimitedPartnerDistributionsDeclaredPerUnit": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberDistributionsDeclaredPerUnit or DistributionMadeToLimitedPartnerDistributionsDeclaredPerUnit."
+],
+"DistributionMadeToMemberOrLimitedPartnerDistributionsPaidPerUnit": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberDistributionsPaidPerUnit or DistributionMadeToLimitedPartnerDistributionsPaidPerUnit."
+],
+"DistributionMadeToMemberOrLimitedPartnerLineItems": [
+"2013-01-31",
+"Element was deprecated."
+],
+"DistributionMadeToMemberOrLimitedPartnerShareDistribution": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberUnitDistribution or DistributionMadeToLimitedPartnerUnitDistribution."
+],
+"DistributionMadeToMemberOrLimitedPartnerShareDistributionDilutionPerShare": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberUnitDistributionDilutionPerUnit or DistributionMadeToLimitedPartnerUnitDistributionDilutionPerUnit."
+],
+"DistributionPaymentFormsOtherThanCashOrStockDescription": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionPaymentMadeToLimitedLiabilityCompanyLLCMemberFormsOtherThanCashOrStockDescription or DistributionPaymentMadeToLimitedPartnerFormsOtherThanCashOrStockDescription."
+],
+"DividendIncomeMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is InvestmentIncomeDividend."
+],
+"DividendPaymentRestrictionsScheduleAmountsPaid": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is PaymentsOfDividends."
+],
+"EITF064Member": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"EITF083Member": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"EarningsPerShareBasicMember": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"EarningsPerShareDilutedMember": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"EffectOfChangeInAverageTrancheLifeEstimate": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"EffectOfChangeInCashFlowProjectionEstimate": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"EffectOfChangeInReinvestmentRateOfReturnEstimate": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"EffectOfIllegalActsOnFinancialStatementsAmountMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"EffectOfIllegalActsOnFinancialStatementsDisclosureMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"EffectsOfChangesInPrepaymentEstimateAssumptionsForCMOsAndREMICsAffectedItemDomain": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"EffectsOfChangesInPrepaymentEstimateAssumptionsForCMOsAndREMICsByAffectedItemAxis": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"EffectsOfChangesInPrepaymentEstimateAssumptionsForCMOsAndREMICsTable": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"EffectsOfReinsuranceAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"EmbeddedDerivativeDescriptionOfLocationOfGainLossInFinancialStatements": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are EmbeddedDerivativeGainOnEmbeddedDerivative, EmbeddedDerivativeLossOnEmbeddedDerivative, and EmbeddedDerivativeGainLossOnEmbeddedDerivativeNet and members of IncomeStatementLocationAxis."
+],
+"EmbeddedDerivativeLineItemOnBalanceSheet": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are EmbeddedDerivativeFairValueOfEmbeddedDerivativeAsset, EmbeddedDerivativeFairValueOfEmbeddedDerivativeLiability, EmbeddedDerivativeFairValueOfEmbeddedDerivativeNet and members of BalanceSheetLocationAxis."
+],
+"EmployeeServiceShareBasedCompensationAllocationOfRecognizedPeriodCostsReportLineDomain": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is IncomeStatementLocationDomain."
+],
+"EmployeeServiceShareBasedCompensationPolicyForIssuingSharesUponExercise": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardPolicyForIssuingSharesUponExercise."
+],
+"EntityWideDisclosureOnGeographicAreasLongLivedAssetsInEntitysCountryOfDomicile": [
+"2013-01-31",
+"Element was deprecated due to remodeling of Segment area. Possible replacement is NoncurrentAssets and members of StatementGeographicalAxis."
+],
+"EntityWideDisclosureOnGeographicAreasLongLivedAssetsInForeignCountries": [
+"2013-01-31",
+"Element was deprecated due to remodeling of Segment area. Possible replacement is NoncurrentAssets and members of StatementGeographicalAxis."
+],
+"EntityWideDisclosureOnGeographicAreasRevenueFromExternalCustomersAttributedToEntitysCountryOfDomicile": [
+"2013-01-31",
+"Element was deprecated due to remodeling of Segment area. Possible replacement is Revenues and members of StatementGeographicalAxis."
+],
+"EntityWideDisclosureOnGeographicAreasRevenueFromExternalCustomersAttributedToForeignCountries": [
+"2013-01-31",
+"Element was deprecated due to remodeling of Segment area. Possible replacement is Revenues and members of StatementGeographicalAxis."
+],
+"EntityWideRevenueMajorCustomerAmount": [
+"2013-01-31",
+"Element was deprecated due to remodeling of Segment area. Possible replacement is Revenues and members of MajorCustomersAxis."
+],
+"EntityWideRevenueMajorCustomerPercentage": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ConcentrationRiskPercentage1 and members of ConcentrationRiskByBenchmarkAxis."
+],
+"EnvironmentalCostsOfPropertyForSaleDisposalOrAbandonmentAccruedExitCosts": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is EnvironmentalExitCostsCostsAccruedToDate."
+],
+"EnvironmentalCostsOfPropertyForSaleDisposalOrAbandonmentAnticipatedExitCosts": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is EnvironmentalExitCostsAnticipatedCost."
+],
+"EnvironmentalCostsOfPropertyForSaleDisposalOrAbandonmentBalanceSheetCaption": [
+"2014-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is EnvironmentalExitCostsCostsAccruedToDate and members of BalanceSheetLocationAxis."
+],
+"EnvironmentalCostsOfPropertyForSaleDisposalOrAbandonmentDisclosures": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is EnvironmentalExitCostsNatureOfCosts."
+],
+"EnvironmentalRemediationExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is EnvironmentalRemediationExpense."
+],
+"EquityContributionsToFinanceLeveragedBuyout": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"EquityFinancingForLeveragedBuyout": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"EquityFinancingForLeveragedBuyoutAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"EquityForwardAgreementsMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ForwardContractsMember."
+],
+"EquityIssuanceDates": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"EquityIssuanceNoncashConsiderationsDetails": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"EquityIssuancePerShareAmount": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"EquitySecuritiesOtherMember": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"EscrowDepositDisbursementsRelatedToPropertyAcquisition": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is EscrowDepositDisbursementsRelatedToPropertyAcquisition1."
+],
+"ExchangeFeesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ExchangeFees."
+],
+"ExecutiveCompensationContractsMember": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"ExpenseRelatedToDistributionOrServicingAndUnderwritingFeesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ExpenseRelatedtoDistributionorServicingandUnderwritingFees."
+],
+"ExperienceRatedRefundsPayable": [
+"2013-01-31",
+"Element was deprecated due to remodeling of reinsurance topic area."
+],
+"ExperienceRatedRefundsReceivable": [
+"2013-01-31",
+"Element was deprecated due to remodeling of reinsurance topic area."
+],
+"ExplanationDifferencesBetweenBookAndTaxBasis": [
+"2013-01-31",
+"Element was deprecated because it is an invalid concept."
+],
+"ExplanationOfChangeInCumulativeTranslationAdjustment": [
+"2015-01-31",
+"Element deprecated due to redundancy. Possible replacement is ForeignCurrencyTranslationAdjustmentDescription."
+],
+"ExplanationOfNecessaryInformationNotAvailableAndDevelopmentCostExcessive": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"ExpropriationOfAssetsAxis": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"ExpropriationOfAssetsDomain": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"ExtendedProductWarrantyAccrualBalanceSheetCaption": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are ExtendedProductWarrantyAccrualCurrent, ExtendedProductWarrantyAccrualNoncurrent, and ExtendedProductWarrantyAccrual and members of BalanceSheetLocationAxis."
+],
+"FAS156Member": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"FAS158Member": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"FAS159Member": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"FAS160Member": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"FAS163Member": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"FDICPremiumExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is FederalDepositInsuranceCorporationPremiumExpense."
+],
+"FSPFAS1152AndFAS1242Member": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"FactorsOtherThanDistributionPolicyAffectingDistributionPayments": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"FairValueAdjustmentsOnHedgesAndDerivativeContractsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is UnrealizedGainLossOnDerivatives."
+],
+"FairValueAssetsAndLiabilitiesMeasuredOnRecurringBasisGainLossIncludedInEarningsDescription": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisAssetGainLossIncludedInEarnings1, FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisLiabilityGainLossIncludedInEarnings, and FairValueAssetsAndLiabilitiesMeasuredOnRecurringBasisGainLossIncludedInEarnings and members of IncomeStatementLocationAxis."
+],
+"FairValueAssetsMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInInvestmentIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueAssetsMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
+],
+"FairValueAssetsMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInOtherIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueAssetsMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
+],
+"FairValueAssetsMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInTradingRevenue": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueAssetsMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
+],
+"FairValueAssetsMeasuredOnRecurringBasisGainLossIncludedInEarningsAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"FairValueAssetsMeasuredOnRecurringBasisGainLossIncludedInInvestmentIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisAssetGainLossIncludedInEarnings1 and members of IncomeStatementLocationAxis."
+],
+"FairValueAssetsMeasuredOnRecurringBasisGainLossIncludedInOtherIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisAssetGainLossIncludedInEarnings1 and members of IncomeStatementLocationAxis."
+],
+"FairValueAssetsMeasuredOnRecurringBasisGainLossIncludedInTradingRevenue": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisAssetGainLossIncludedInEarnings1 and members of IncomeStatementLocationAxis."
+],
+"FairValueByBalanceSheetGroupingDisclosureItemAmountsAxis": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is FairValueByMeasurementBasisAxis."
+],
+"FairValueDisclosureOffBalanceSheetRisksMethodology": [
+"2015-01-31",
+"Element was deprecated and replaced with a more encompassing element. Possible replacement is FairValueDisclosureOffBalanceSheetRisksDescription."
+],
+"FairValueDisclosureOffBalanceSheetRisksSignificantAssumptions": [
+"2015-01-31",
+"Element was deprecated and replaced with a more encompassing element. Possible replacement is FairValueDisclosureOffBalanceSheetRisksDescription."
+],
+"FairValueEstimateNotPracticableCashSurrenderValue": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"FairValueEstimateNotPracticableFinancialAssetsReasonsAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"FairValueEstimateNotPracticableFinancialLiabilitiesReasonsAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"FairValueEstimateNotPracticableReasonsAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"FairValueEstimateNotPracticableReasonsAccountsPayable": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+],
+"FairValueEstimateNotPracticableReasonsAccountsReceivable": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+],
+"FairValueEstimateNotPracticableReasonsAccruedLiabilities": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+],
+"FairValueEstimateNotPracticableReasonsBorrowings": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+],
+"FairValueEstimateNotPracticableReasonsCashAndCashEquivalents": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+],
+"FairValueEstimateNotPracticableReasonsCashSurrenderValue": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+],
+"FairValueEstimateNotPracticableReasonsCommitments": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+],
+"FairValueEstimateNotPracticableReasonsCostMethodInvestments": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+],
+"FairValueEstimateNotPracticableReasonsDebtInstrument": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+],
+"FairValueEstimateNotPracticableReasonsDeposits": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+],
+"FairValueEstimateNotPracticableReasonsEquityMethodInvestments": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+],
+"FairValueEstimateNotPracticableReasonsFederalFundsPurchased": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+],
+"FairValueEstimateNotPracticableReasonsFederalFundsSoldAndSecuritiesBorrowedOrPurchasedUnderAgreementsToResell": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+],
+"FairValueEstimateNotPracticableReasonsFederalHomeLoanBankBorrowings": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+],
+"FairValueEstimateNotPracticableReasonsGuarantees": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+],
+"FairValueEstimateNotPracticableReasonsInvestmentInFederalHomeLoanBankStock": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+],
+"FairValueEstimateNotPracticableReasonsInvestments": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+],
+"FairValueEstimateNotPracticableReasonsLiabilitiesRelatedToInvestmentContracts": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+],
+"FairValueEstimateNotPracticableReasonsLoansReceivable": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+],
+"FairValueEstimateNotPracticableReasonsMandatorilyRedeemablePreferredStock": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+],
+"FairValueEstimateNotPracticableReasonsMortgageBackedSecuritiesAvailableForSale": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+],
+"FairValueEstimateNotPracticableReasonsMortgageBackedSecuritiesHeldToMaturity": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+],
+"FairValueEstimateNotPracticableReasonsNotesReceivable": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+],
+"FairValueEstimateNotPracticableReasonsPremiumsReceivable": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+],
+"FairValueEstimateNotPracticableReasonsRetainedInterest": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"FairValueEstimateNotPracticableReasonsSecuritiesLoanedOrSoldUnderAgreementsToRepurchase": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+],
+"FairValueEstimateNotPracticableReasonsSecuritiesSoldNotYetPurchased": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+],
+"FairValueEstimateNotPracticableReasonsSeniorDebtObligations": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+],
+"FairValueEstimateNotPracticableReasonsSubordinatedDebtObligations": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+],
+"FairValueEstimateNotPracticableReasonsTradingAccountAssets": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+],
+"FairValueEstimateNotPracticableReasonsTradingLiabilities": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
+],
+"FairValueEstimateNotPracticableRetainedInterest": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInInvestmentIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
+],
+"FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInOtherIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
+],
+"FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInTradingRevenue": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
+],
+"FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisGainLossIncludedInEarningsAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisGainLossIncludedInInvestmentIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisInstrumentsClassifiedInShareholdersEquityGainLossIncludedInEarnings and members of IncomeStatementLocationAxis."
+],
+"FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisGainLossIncludedInOtherIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisInstrumentsClassifiedInShareholdersEquityGainLossIncludedInEarnings and members of IncomeStatementLocationAxis."
+],
+"FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisGainLossIncludedInTradingRevenue": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisInstrumentsClassifiedInShareholdersEquityGainLossIncludedInEarnings and members of IncomeStatementLocationAxis."
+],
+"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareInvestmentRedemptionNoticePeriod": [
+"2014-01-31",
+"Element was deprecated because it has a stringItemType attribute. Possible replacement is FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareInvestmentRedemptionNoticePeriod1."
+],
+"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionFlag": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionFlag1."
+],
+"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionLapseDateNotEstimatableFlag": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionLapseDateNotEstimableFlag."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInInvestmentIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueLiabilitiesMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInOtherIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueLiabilitiesMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInTradingRevenue": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueLiabilitiesMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisGainLossIncludedInEarningsAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisGainLossIncludedInInvestmentIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisLiabilityGainLossIncludedInEarnings and members of IncomeStatementLocationAxis."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisGainLossIncludedInOtherIncome": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisLiabilityGainLossIncludedInEarnings and members of IncomeStatementLocationAxis."
+],
+"FairValueLiabilitiesMeasuredOnRecurringBasisGainLossIncludedInTradingRevenue": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisLiabilityGainLossIncludedInEarnings and members of IncomeStatementLocationAxis."
+],
+"FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisAssetGainLossIncludedInOtherComprehensiveIncomeDescription": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisAssetGainLossIncludedInOtherComprehensiveIncomeLoss and members of OtherComprehensiveIncomeLocationAxis."
+],
+"FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisLiabilityGainLossIncludedInOtherComprehensiveIncomeDescription": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisLiabilityGainLossIncludedInOtherComprehensiveIncome and members of OtherComprehensiveIncomeLocationAxis."
+],
+"FairValueOptionEventsTriggeringElectionEffectOnEarnings": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"FederalHomeLoanBankAdvancesMaturitiesSummary": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is AdvancesFromFederalHomeLoanBanks."
+],
+"FederalHomeLoanBankAdvancesShortTerm": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is FederalHomeLoanBankAdvancesMaturitiesSummaryDueWithinOneYearOfBalanceSheetDate."
+],
+"FinanceLeasesFinancingReceivableMember": [
+"2015-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacement is FinanceLeasesPortfolioSegmentMember."
+],
+"FinancialGuaranteeInsuranceContractsClaimLiabilitySignificantComponentsOfChangeAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"FinancialGuaranteeInsuranceContractsClaimLiabilitySignificantComponentsOfChangeAccretionOfDiscountAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"FinancialGuaranteeInsuranceContractsClaimLiabilitySignificantComponentsOfChangeAccretionOfDiscountIfNotPresentedSeparatelyFinancialStatementCaption": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FinancialGuaranteeInsuranceContractsClaimLiabilitySignificantComponentsOfChangeAccretionOfDiscount and members of IncomeStatementLocationAxis."
+],
+"FinancialGuaranteeInsuranceContractsClaimLiabilitySignificantComponentsOfChangeEffectOfChangeInDiscountRateAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"FinancialGuaranteeInsuranceContractsClaimLiabilitySignificantComponentsOfChangeEffectOfChangeInDiscountRateIfNotPresentedSeparatelyFinancialStatementCaption": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FinancialGuaranteeInsuranceContractsClaimLiabilitySignificantComponentsOfChangeEffectOfChangeInDiscountRate and members of IncomeStatementLocationAxis."
+],
+"FinancialGuaranteeInsuranceContractsClaimLiabilitySignificantComponentsOfChangeLikelihoodOfDefaultAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"FinancialGuaranteeInsuranceContractsClaimLiabilitySignificantComponentsOfChangeLikelihoodOfDefaultIfNotPresentedSeparatelyFinancialStatementCaption": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FinancialGuaranteeInsuranceContractsClaimLiabilitySignificantComponentsOfChangeLikelihoodOfDefault and members of IncomeStatementLocationAxis."
+],
+"FinancialGuaranteeInsuranceContractsClaimLiabilitySignificantComponentsOfChangeTimingAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"FinancialGuaranteeInsuranceContractsClaimLiabilitySignificantComponentsOfChangeTimingIfNotPresentedSeparatelyFinancialStatementCaption": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FinancialGuaranteeInsuranceContractsClaimLiabilitySignificantComponentsOfChangeTiming and members of IncomeStatementLocationAxis."
+],
+"FinancialGuaranteeInsuranceContractsPremiumReceivedOverContractPeriodAccretionOfPremiumReceivableIsNotSeparatelyFinancialStatementCaption": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FinancialGuaranteeInsuranceContractsPremiumReceivedOverContractPeriodPremiumReceivableAccretion and members of IncomeStatementLocationAxis."
+],
+"FinancialGuaranteeInsuranceContractsPremiumReceivedOverContractPeriodPremiumReceivableAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"FinancialGuaranteeInsuranceContractsPremiumReceivedOverContractPeriodPremiumReceivableAccretionAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"FinancialGuaranteeInsuranceContractsPremiumReceivedOverContractPeriodPremiumReceivableIfNotPresentedSeparatelyFinancialStatementCaption": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FinancialGuaranteeInsuranceContractsPremiumReceivedOverContractPeriodPremiumReceivable and members of BalanceSheetLocationAxis."
+],
+"FinancialGuaranteeInsuranceContractsPremiumReceivedOverContractPeriodUnearnedPremiumRevenueAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"FinancialGuaranteeInsuranceContractsPremiumReceivedOverContractPeriodUnearnedPremiumRevenueIfNotPresentedSeparatelyFinancialStatementCaption": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FinancialGuaranteeInsuranceContractsPremiumReceivedOverContractPeriodUnearnedPremiumRevenue and members of IncomeStatementLocationAxis."
+],
+"FinancialGuaranteeInsuranceContractsPremiumsReceivableNewBusinessWritten": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is FinancialGuaranteeInsuranceContractsPremiumReceivableNewBusinessWritten."
+],
+"FinancialGuaranteeInsuranceContractsRiskManagementActivitiesMitigatingClaimLiabilitiesAccruedLiabilitiesAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"FinancialGuaranteeInsuranceContractsRiskManagementActivitiesMitigatingClaimLiabilitiesAccruedLiabilitiesFinancialStatementCaption": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FinancialGuaranteeInsuranceContractsRiskManagementActivitiesMitigatingClaimLiabilitiesAccruedLiabilities and members of BalanceSheetLocationAxis."
+],
+"FinancialGuaranteeInsuranceContractsRiskManagementActivitiesMitigatingClaimLiabilitiesExpenseAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"FinancialGuaranteeInsuranceContractsRiskManagementActivitiesMitigatingClaimLiabilitiesExpenseFinancialStatementCaption": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FinancialGuaranteeInsuranceContractsRiskManagementActivitiesMitigatingClaimLiabilitiesExpense and members of IncomeStatementLocationAxis."
+],
+"FinancialInstrumentsOwnedAndPledgedAsCollateralAssociatedLiabilitiesCaption": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is SecurityOwnedAndPledgedAsCollateralAssociatedLiabilitiesFairValue and members of BalanceSheetLocationAxis."
+],
+"FinancialInstrumentsOwnedAndPledgedAsCollateralCaption": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is SecurityOwnedAndPledgedAsCollateralFairValue and members of BalanceSheetLocationAxis."
+],
+"FinancingAxis": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"FinancingDomain": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"FinancingReceivableAcquiredWithDeterioratedCreditQuality": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are NotesReceivableNet and ReceivablesAcquiredWithDeterioratedCreditQualityMember."
+],
+"FinancingReceivableAllowanceDomain": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is FinancingReceivableRecordedInvestmentClassOfFinancingReceivableDomain."
+],
+"FinancingReceivableAllowanceForCreditLossesAcquiredWithDeterioratedCreditQuality": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FinancingReceivableAllowanceForCreditLosses and ReceivablesAcquiredWithDeterioratedCreditQualityMember."
+],
+"FinancingReceivableByCreditQualityIndicatorDomain": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are CreditRatingAMBestDomain, InternalCreditAssessmentDomain, ExternalCreditRatingFitchMember, ExternalCreditRatingStandardPoorsMember, ExternalCreditRatingMoodysMember, ExternalCreditRatingByGroupingDomain."
+],
+"FinancingReceivableInformationByCreditQualityIndicatorAxis": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are CreditRatingAMBestAxis, CreditRatingMoodysAxis, CreditRatingStandardPoorsAxis, CreditRatingFitchAxis, ExternalCreditRatingByGroupingAxis, InternalCreditAssessmentAxis."
+],
+"FinancingReceivableInformationByPortfolioSegmentAxis": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is FinancingReceivableRecordedInvestmentByClassOfFinancingReceivableAxis."
+],
+"FinancingReceivableModificationsNumberOfContracts1": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is FinancingReceivableModificationsNumberOfContracts2."
+],
+"FinancingReceivableModificationsPostModificationRecordedInvestment1": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is FinancingReceivableModificationsPostModificationRecordedInvestment2."
+],
+"FinancingReceivableModificationsPreModificationRecordedInvestment1": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is FinancingReceivableModificationsPreModificationRecordedInvestment2."
+],
+"FinancingReceivableModificationsSubsequentDefaultNumberOfContracts": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is FinancingReceivableModificationsSubsequentDefaultNumberOfContracts1."
+],
+"FinancingReceivableModificationsSubsequentDefaultRecordedInvestment": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is FinancingReceivableModificationsSubsequentDefaultRecordedInvestment1."
+],
+"FinancingReceivableRecordedInvestment1To29DaysPastDue": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FinancingReceivableRecordedInvestmentPastDue and FinancingReceivables1To29DaysPastDueMember."
+],
+"FinancingReceivableRecordedInvestment30To59DaysPastDue": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FinancingReceivableRecordedInvestmentPastDue and FinancingReceivables30To59DaysPastDueMember."
+],
+"FinancingReceivableRecordedInvestment60To89DaysPastDue": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FinancingReceivableRecordedInvestmentPastDue and FinancingReceivables60To89DaysPastDueMember."
+],
+"FinancingReceivableRecordedInvestmentEqualToGreaterThan90DaysPastDue": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FinancingReceivableRecordedInvestmentPastDue and FinancingReceivablesEqualToGreaterThan90DaysPastDueMember."
+],
+"FinancingReceivableRecordedInvestmentPastDueAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"FinancingReceivableTroubledDebtRestructuringAxis": [
+"2015-01-31",
+"Element was deprecated due to remodeling of the topic area. Possible replacements are FinancingReceivablePortfolioSegmentAxis, FinancingReceivableRecordedInvestmentByClassOfFinancingReceivableAxis, ClassOfFinancingReceivableTypeOfBorrowerAxis, EquitySecuritiesByIndustryAxis, CollateralAxis, GeographicDistributionAxis."
+],
+"FinancingReceivableTroubledDebtRestructuringDomain": [
+"2015-01-31",
+"Element was deprecated due to remodeling of the topic area. Possible replacements are FinancingReceivablePortfolioSegmentDomain, FinancingReceivableRecordedInvestmentClassOfFinancingReceivableDomain, ClassOfFinancingReceivableTypeOfBorrowerDomain, EquitySecuritiesIndustryMember, CollateralDomain, GeographicDistributionDomain."
+],
+"FiniteLivedComputerSoftwareGross": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is CapitalizedComputerSoftwareGross."
+],
+"FiniteLivedIntangibleAssetsAcquired": [
+"2013-01-31",
+"Element was deprecated because it was incorrectly defined.  Possible replacement element is FiniteLivedIntangibleAssetsAcquired1."
+],
+"FiniteLivedIntangibleAssetsRemainingAmortizationPeriod": [
+"2013-01-31",
+"Element was deprecated because it is has a stringItemType attribute. Possible replacement is FiniteLivedIntangibleAssetsRemainingAmortizationPeriod1."
+],
+"FiveYearScheduleOfMaturitiesOfDebtOfParentCompanyAbstract": [
+"2014-01-31",
+"Element was deprecated."
+],
+"FiveYearScheduleOfMaturitiesOfParentCompanyRepaymentOfPrincipleInYearThree": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInYearThree."
+],
+"FiveYearScheduleOfMaturitiesOfParentCompanyRepaymentsOfPrincipalAfterYearFive": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalAfterYearFive."
+],
+"FiveYearScheduleOfMaturitiesOfParentCompanyRepaymentsOfPrincipleInYearFive": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInYearFive."
+],
+"FiveYearScheduleOfMaturitiesOfParentCompanyRepaymentsOfPrincipleInYearFour": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInYearFour."
+],
+"FiveYearScheduleOfMaturitiesOfParentCompanyRepaymentsOfPrincipleInYearTwo": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInYearTwo."
+],
+"FiveYearScheduleOfMaturitiesOfParentCompanyRepaymentsOfPrincipleWithinOneYear": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInNextTwelveMonths."
+],
+"FloorBrokerageExchangeClearanceFeesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is FloorBrokerageExchangeAndClearanceFees."
+],
+"FloorBrokerageMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is FloorBrokerage."
+],
+"ForeignCurrencyDerivativeAssetsAtFairValue": [
+"2014-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeFairValueOfDerivativeAsset and ForeignExchangeContractMember."
+],
+"ForeignCurrencyDerivativeLiabilitiesAtFairValue": [
+"2014-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeFairValueOfDerivativeLiability and ForeignExchangeContractMember."
+],
+"ForeignCurrencyDerivativesAtFairValueNet": [
+"2014-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeFairValueOfDerivativeNet and ForeignExchangeContractMember."
+],
+"ForeignCurrencyDerivativesAtFairValueNetAbstract": [
+"2014-01-31",
+"Element was deprecated."
+],
+"ForeignEarningsRepatriatedUnderAmericanJobsCreationActOf2004Abstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"ForeignEarningsRepatriatedUnderAmericanJobsCreationActOf2004Description": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"ForeignEarningsRepatriatedUnderAmericanJobsCreationActOf2004RepatriatedEarnings": [
+"2013-01-31",
+"Element was deprecated because the guidance related to this element is no longer effective.  Possible replacement is ForeignEarningsRepatriated."
+],
+"ForeignReinsuranceTransactionsAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"ForeignReinsuranceUnderOpenYearMethodAdditions": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"ForeignReinsuranceUnderOpenYearMethodPremiumsClaimsAndExpense": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"ForeignReinsuranceUnderOpenYearMethodPremiumsInUnderwritingAccount": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ForeignReinsuranceUnderOpenYearMethodPremiums."
+],
+"ForwardContractIndexedToIssuersEquityRedeemableStockRedemptionRequirementsAmount": [
+"2013-01-31",
+"Element was deprecated because it has debit balance and duration period type attributes. Possible replacement is OptionIndexedToIssuersEquityRedeemableStockRedemptionRequirementsAmount1."
+],
+"FuelTransportationMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is FuelMember."
+],
+"FurnitureAndEquipmentRentalExpenseOperatingLeaseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is LeaseAndRentalExpense."
+],
+"GainLossFromPriceRiskManagementActivityMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossFromPriceRiskManagementActivity."
+],
+"GainLossFromSaleOfFinancialAssetsInSecuritizationsOrAssetBackedFinancingArrangement": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is SecuritizationFinancialAssetForWhichTransferIsAccountedAsSaleGainLossOnSale."
+],
+"GainLossOnCondemnationNetOfTaxMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"GainLossOnCreditRiskDerivativesNet": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeGainLossOnDerivativeNet and members of CreditDerivativesByContractTypeAxis."
+],
+"GainLossOnCreditRiskHedgeIneffectiveness": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeNetHedgeIneffectivenessGainLoss and members of CreditDerivativesByContractTypeAxis."
+],
+"GainLossOnDerivativesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is UnrealizedGainLossOnDerivatives."
+],
+"GainLossOnDispositionOfAssetsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnDispositionOfAssets."
+],
+"GainLossOnDispositionOfOtherAssetsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnSaleOfOtherAssets."
+],
+"GainLossOnDispositionOfProperty": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is GainLossOnDispositionOfAssets."
+],
+"GainLossOnDispositionOfPropertyMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnDispositionOfAssets1."
+],
+"GainLossOnInvestmentsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnInvestments."
+],
+"GainLossOnOilAndGasHedgingActivityMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"GainLossOnSaleOfInterestInProjectsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"GainLossOnSaleOfLeasedAssetsNetOperatingLeasesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"GainLossOnSaleOfLoansReceivableMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"GainLossOnSaleOfOilAndGasPropertiesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnSaleOfProperty."
+],
+"GainLossOnSaleOfSubsidiarysStockMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"GainLossOnSaleOfTradeReceivablesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnSaleOfAccountsReceivable."
+],
+"GainLossOnSettlementOfDerivativeInstrumentMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnSaleOfDerivatives."
+],
+"GainOnPurchaseOfBusiness": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is BusinessCombinationBargainPurchaseGainRecognizedAmount."
+],
+"GainOnPurchaseOfBusinessMember": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"GainsLossesOnSalesOfAssetsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnDispositionOfAssets1."
+],
+"GainsLossesOnSalesOfOtherAssets": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is GainLossOnSaleOfOtherAssets."
+],
+"GeographicalIntersegmentEliminationsMember": [
+"2013-01-31",
+"Element was deprecated due to remodeling of Segment area. Possible replacements are members of ConsolidationItemsAxis."
+],
+"GoodwillAllocationAdjustment": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is GoodwillPurchaseAccountingAdjustments."
+],
+"GoodwillImpairedIncomeStatementClassification": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is GoodwillImpairmentLoss and members of IncomeStatementLocationAxis."
+],
+"GovernmentInvestigationIntoIllegalOrUnethicalActivityInGovernmentContracts": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"GuaranteeObligationsCaptionForRecordedLiabilities": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is GuaranteeObligationsCurrentCarryingValue and members of BalanceSheetLocationAxis."
+],
+"GuaranteedBenefitLiabilityGross": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LiabilitiesForGuaranteesOnLongDurationContractsGuaranteedBenefitLiabilityGross."
+],
+"GuaranteedBenefitsIncurred": [
+"2013-01-31",
+"Element was deprecated because it has a stringItemType attribute. Possible replacement is LiabilitiesForGuaranteesOnLongDurationContractsIncurredBenefits1."
+],
+"GuaranteedBenefitsPaid": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LiabilitiesForGuaranteesOnLongDurationContractsBenefitsPaid."
+],
+"GuaranteedInsuranceBenefitTypeDomain": [
+"2015-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are GuaranteedInsuranceContractTypeofBenefitDomain or GuaranteedInsuranceContractTypeOfGuaranteeDomain."
+],
+"HealthCareOrganizationAmountOfWriteOffsOfAllowanceForDoubtfulAccounts": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is AllowanceForDoubtfulAccountsReceivableWriteOffs."
+],
+"HealthCareOrganizationChangeInWriteOffs": [
+"2014-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is AllowanceForDoubtfulAccountsReceivableWriteOffs."
+],
+"HedgeDesignationsUsedForCreditRiskDerivatives": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
+],
+"HedgingStrategyByGuaranteeType": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LongDurationContractsHedgingStrategies and members of GuaranteedInsuranceContractTypeOfGuaranteeAxis."
+],
+"HeldToMaturitySecuritiesContinuousUnrealizedLossPosition12MonthsOrLongerAggregateLosses": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is HeldToMaturitySecuritiesContinuousUnrealizedLossPosition12MonthsOrLongerAggregateLoss."
+],
+"HeldToMaturitySecuritiesContinuousUnrealizedLossPositionAggregateLosses": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is HeldToMaturitySecuritiesContinuousUnrealizedLossPositionAggregateLoss."
+],
+"HeldToMaturitySecuritiesContinuousUnrealizedLossPositionLessThan12MonthsAggregateLosses": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is HeldToMaturitySecuritiesContinuousUnrealizedLossPositionLessThan12MonthsAggregateLoss."
+],
+"HeldToMaturitySecuritiesDebtMaturitiesFairValue": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is HeldToMaturitySecuritiesFairValue."
+],
+"HeldToMaturitySecuritiesDebtMaturitiesNetCarryingAmount": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is HeldToMaturitySecurities."
+],
+"HeldToMaturitySecuritiesFairValueDisclosure": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is HeldToMaturitySecuritiesFairValue."
+],
+"HeldToMaturitySecuritiesRestrictionsAdditionalInformation": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"HeldToMaturitySecuritiesUnrecognizedHoldingLoss": [
+"2013-01-31",
+"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is HeldToMaturitySecuritiesUnrecognizedHoldingLosses."
+],
+"HeldtomaturitySecuritiesInUnrealizedLossPositionsQualitativeDisclosureOtherThirdPartyGuaranteesDescription": [
+"2013-01-31",
+"Element was deprecated."
+],
+"HeldtomaturitySecuritiesRestrictedDisclosureAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"HeldtomaturitySecuritiesUnrecognizedHoldingGain": [
+"2013-01-31",
+"Element was deprecated because it has debit balance and instant period type attributes. Possible replacement is HeldtomaturitySecuritiesUnrecognizedHoldingGains."
+],
+"ImpactOfForeignCurrencyDerivativesOnEarningsIsImmaterial": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"ImpairedAssetsToBeDisposedOfByMethodOtherThanSaleIncomeStatementClassification": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ImpairedAssetsToBeDisposedOfByMethodOtherThanSaleAmountOfImpairmentLoss and members of IncomeStatementLocationAxis."
+],
+"ImpairedLongLivedAssetsHeldAndUsedSegmentClassification": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ImpairmentOfLongLivedAssetsHeldForUse and members of StatementBusinessSegmentsAxis and SubsegmentsAxis."
+],
+"ImpairmentInValueOfAssetAxis": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"ImpairmentInValueOfAssetDomain": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"ImpairmentOfGoodwillMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GoodwillImpairmentLoss."
+],
+"ImpairmentOfIntangibleAssetsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ImpairmentOfIntangibleAssetsExcludingGoodwill."
+],
+"IncentiveFeeAmountPaid": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is PaymentForIncentiveFee."
+],
+"IncomeBeforeExtraordinaryItemsMember": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"IncomeDepositSecuritiesAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"IncomeDepositSecuritiesDividendPolicy": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"IncomeDepositSecuritiesForwardLookingCashFlows": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"IncomeDepositSecuritiesRisksAndLimitations": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"IncomeLossBeforeExtraordinaryItemsAndCumulativeEffectOfChangeInAccountingPrinciplePerOutstandingGeneralPartnershipUnit": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromOperationsBeforeExtraordinaryItemsPerOutstandingGeneralPartnershipUnitNetOfTax."
+],
+"IncomeLossBeforeExtraordinaryItemsAndCumulativeEffectOfChangeInAccountingPrinciplePerOutstandingLimitedPartnershipUnit": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromOperationsBeforeExtraordinaryItemsPerOutstandingLimitedPartnershipUnitBasicNetOfTax."
 ],
 "IncomeLossBeforeExtraordinaryItemsAndCumulativeEffectOfChangeInAccountingPrinciplePerOutstandingLimitedPartnershipUnitDiluted": [
 "2013-01-31",
 "Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromOperationsBeforeExtraordinaryItemsNetOfTaxPerOutstandingLimitedPartnershipUnitDiluted."
+],
+"IncomeLossFromContinuingOperationsPerOutstandingGeneralPartnershipUnit": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromContinuingOperationsPerOutstandingGeneralPartnershipUnitNetOfTax."
+],
+"IncomeLossFromContinuingOperationsPerOutstandingLimitedPartnershipUnit": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromContinuingOperationsPerOutstandingLimitedPartnershipUnitBasicNetOfTax."
+],
+"IncomeLossFromContinuingOperationsPerOutstandingLimitedPartnershipUnitDiluted": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromContinuingOperationsNetOfTaxPerOutstandingLimitedPartnershipUnitDiluted."
+],
+"IncomeLossFromDiscontinuedOperationsNetOfTaxPerOutstandingGeneralPartnershipUnit": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromDiscontinuedOperationsNetOfTaxPerOutstandingGeneralPartnershipUnit1."
+],
+"IncomeLossFromDiscontinuedOperationsNetOfTaxPerOutstandingLimitedPartnershipUnit": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromDiscontinuedOperationsNetOfTaxPerOutstandingLimitedPartnershipUnitBasic."
+],
+"IncomeLossFromDiscontinuedOperationsNetOfTaxPerOutstandingLimitedPartnershipUnitDiluted": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromDiscontinuedOperationsNetOfTaxPerOutstandingLimitedPartnershipUnitDiluted1."
+],
+"IncomeLossFromDispositionOfDiscontinuedOperationsForOtherStockPerBasicShare": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is IncomeLossFromDiscontinuedOperationsNetOfTaxPerBasicShare."
+],
+"IncomeLossFromEquityMethodInvestmentsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is IncomeLossFromEquityMethodInvestments."
+],
+"IncomeLossFromEquityMethodInvestmentsNetOfDistributionsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is IncomeLossFromEquityMethodInvestmentsNetOfDividendsOrDistributions."
+],
+"IncomeLossFromEquityRealEstatePartnershipsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is RealEstatePartnershipInvestmentSubsidiariesNetIncomeLossBeforeTax."
+],
+"IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingGeneralPartnershipUnit": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingGeneralPartnershipUnit1."
+],
+"IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingLimitedPartnershipAndGeneralPartnershipUnitBasic": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingLimitedPartnershipAndGeneralPartnershipUnitBasic1."
+],
+"IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingLimitedPartnershipUnit": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingLimitedPartnershipUnitBasic."
+],
+"IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingLimitedPartnershipUnitDiluted": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingLimitedPartnershipUnitDiluted1."
+],
+"IncomeTaxExaminationInterestFromExamination": [
+"2013-01-31",
+"Element was deprecated because of redundancy.  Possible replacement is IncomeTaxExaminationInterestExpense."
+],
+"IncomeTaxExaminationLiabilityRecorded": [
+"2013-01-31",
+"Element was deprecated due to redundancy.  Possible replacement is IncomeTaxExaminationPenaltiesAndInterestAccrued."
+],
+"IncomeTaxExaminationPenaltiesFromExamination": [
+"2013-01-31",
+"Element was deprecated due to redundancy.  Possible replacement is IncomeTaxExaminationPenaltiesExpense."
+],
+"IncomeTaxExaminationRangeOfPossibleLosses": [
+"2013-01-31",
+"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is IncomeTaxExaminationEstimateOfPossibleLoss and members of RangeAxis."
+],
+"IncomeTaxExpenseBenefitAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"IncomeTaxExpenseBenefitContinuingOperations": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is IncomeTaxExpenseBenefit."
+],
+"IncomeTaxPenaltiesAndInterestAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"IncreaseDecreaseInBorrowedSecurities": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is IncreaseDecreaseInSecuritiesBorrowed."
+],
+"IncreaseDecreaseInCarryingValueOfAssetsReceivedAsConsiderationInDisposalOfBusiness": [
+"2013-01-31",
+"Element was deprecated."
+],
+"IncreaseDecreaseInFairValueOfUnhedgedDerivativeInstruments": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DerivativeInstrumentsNotDesignatedAsHedgingInstrumentsGainLossNet."
+],
+"IncreaseDecreaseInFilmCosts": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is IncreaseDecreaseInFilmCosts1."
+],
+"IncreaseDecreaseInIndustryFundObligation": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"IncreaseDecreaseInLossAndLossAdjustmentExpenseReserve": [
+"2015-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is IncreaseDecreaseInLiabilityForClaimsAndClaimsAdjustmentExpenseReserve."
+],
+"IncreaseDecreaseInPrepaidGasDelivery": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"IncreaseDecreaseInRetainedInterestInSecuritizedReceivables": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"IncreaseDecreaseInSpotCommodities": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"IncreaseDecreaseInTimeDepositsForeign": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"IndefiniteLivedIntangibleAssetsAcquiredDuringPeriod": [
+"2013-01-31",
+"Element was deprecated because it was incorrectly defined.  Possible replacement element is IndefiniteLivedIntangibleAssetsAcquired."
+],
+"IndefiniteLivedIntangibleAssetsImpairmentLosses": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is ImpairmentOfIntangibleAssetsIndefinitelivedExcludingGoodwill."
+],
+"IndicationThatEntityWasInDevelopmentStageInPriorYears": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"IndicationThatFinancialStatementsAreThoseOfDevelopmentStageEnterprise": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"IneffectivenessOnCreditRiskHedgesIsImmaterial": [
+"2013-01-31",
+"Element was deprecated because it is an invalid concept."
+],
+"InstrumentAxis": [
+"2013-01-31",
+"Element was deprecated because it was incorrectly defined. Possible replacement is EnergyAxis."
+],
+"InstrumentTypeMember": [
+"2013-01-31",
+"Element was deprecated because it was incorrectly defined. Possible replacement is EnergyDomain."
+],
+"InsuranceRatiosComment": [
+"2013-01-31",
+"Element was deprecated."
+],
+"IntercompanyForeignCurrencyBalanceForeignCurrency": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"InterestAndDividendIncomeMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is InvestmentIncomeInterestAndDividend."
+],
+"IntermediateLifePlantsEstimatedUsefulLife": [
+"2013-01-31",
+"Element was deprecated because it is has a stringItemType attribute. Possible replacement is IntermediateLifePlantsUsefulLife."
+],
+"InternalCreditRatingMember": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is InternalCreditAssessmentDomain."
+],
+"InternallyAssignedGradeMember": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is InternalCreditAssessmentDomain."
+],
+"InventoriesPropertyHeldForSaleCurrent": [
+"2015-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacements are DisposalGroupIncludingDiscontinuedOperationInventoryCurrent, DisposalGroupIncludingDiscontinuedOperationInventoryNoncurrent or DisposalGroupIncludingDiscontinuedOperationInventory1."
+],
+"InvestmentIncomeCategoriesDomain": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is InvestmentTypeCategorizationMember."
+],
+"InvestmentOwnedOtherThanSecuritiesLoanedForShortSalesAtFairValue": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"InvestmentOwnedValuedByTrusteesFlag": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is InvestmentOwnedValuedByTrusteesFlag1."
+],
+"InvestmentOwnedZeroBalanceMayReflectAmountRoundedToZeroFlag": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is InvestmentOwnedZeroBalanceMayReflectAmountRoundedToZeroFlag1."
+],
+"InvestmentsImpairmentChargeMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ImpairmentOfInvestments."
+],
+"InvestmentsInAndAdvancesToAffiliatesBalanceContracts": [
+"2013-01-31",
+"Element was deprecated because it has a decimalItemType attribute. Possible replacement is InvestmentsInAndAdvancesToAffiliatesBalanceContracts1."
+],
+"InvestmentsInForeignSubsidiariesAndForeignCorporateJointVenturesThatAreEssentiallyPermanentInDurationMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are UndistributedEarningsOfForeignSubsidiaries,  DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferenceUndistributedEarningsOfForeignSubsidiaries, DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxableUndistributedEarningsOfForeignSubsidiaries, DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityUndistributedEarningsOfForeignSubsidiaries, DeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticableUndistributedEarningsOfForeignSubsidiaries."
+],
+"IssuanceOfDebtMember": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"IssuanceOfEquityMember": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"LateFeeIncomeGeneratedByServicingFinancialAssetsDescriptionOfWhereReportedOnStatementOfIncome": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LateFeeIncomeGeneratedByServicingFinancialAssetsAmount and members of IncomeStatementLocationAxis."
+],
+"LeaseConcessions": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is AmortizationOfLeaseIncentives."
+],
+"LeveragedBuyoutClosingFeesAndExpense": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutConsiderationPaidForOutstandingShares": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutContinuingOwnershipInterestByContinuingStockholders": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutCostOfTransactionChargedToExpense": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutCostOfTransactionChargedToExpenseAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"LeveragedBuyoutCostOfTransactionDescription": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutDescriptionOfEquityDebitResultingFromCarryoverBasis": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutMethodologyAndAssumptions": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutOptionCostChargedToExpense": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutOptionCostPreviouslyRecognized": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutOwnershipInterestOfNewInvestors": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutPercentageOfPurchasePriceAllocatedToAssetsAndLiabilitiesAcquiredAtCarryoverBasis": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutPercentageOfPurchasePriceAllocatedToAssetsAndLiabilitiesAcquiredAtFairValue": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutPredecessorBasisAdjustment": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutPrepaymentPenaltiesOnRetiredDebt": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutProfessionalFeesAndOther": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutRedemptionOfShareBasedAwards": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutRepaymentOfExistingDebt": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"LeveragedBuyoutTransactionDisclosureTextBlock": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
 "LeveragedBuyoutUsesOfCashInLeveragedBuyoutTransaction": [
 "2013-01-31",
@@ -739,259 +3723,1743 @@
 "2013-01-31",
 "Element was deprecated."
 ],
-"SignificantAcquisitionsAndDisposalsType": [
-"2015-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"BusinessAcquisitionPurchasePriceAllocationNoncurrentLiabilities": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"PremiumsWrittenNetLifeAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"LiquidityDisclosureGoingConcernNote": [
-"2015-01-31",
-"Element was deprecated due to issuance of new guidance. Possible replacement is SubstantialDoubtAboutGoingConcernTextBlock and its children elements."
-],
-"ComponentOfOtherOperatingCostAndExpenseTable": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"CompetitiveTransitionChargeMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is StrandedCostsMember."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssets": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"SaleLeasebackTransactionGrossProceeds": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are SaleLeasebackTransactionGrossProceedsInvestingActivities or SaleLeasebackTransactionGrossProceedsFinancingActivities."
-],
-"RepaymentsOfSecuredTaxExemptDebt": [
+"LiabilitiesForGuaranteesOnLongDurationContractsDesignationAsNontraditional": [
 "2015-01-31",
 "Element was deprecated because of low usage."
 ],
-"NonmonetaryNotionalAmountOfPriceRiskDerivativeInstrumentsNotDesignatedAsHedgingInstruments": [
-"2013-01-31",
-"Element was deprecated because the intended concept conveyed is the underlying. Possible replacements are UnderlyingDerivativeAsset, UnderlyingDerivativeLiability, UnderlyingDerivative and members of HedgingDesignationAxis and DerivativeInstrumentRiskAxis."
-],
-"BusinessAcquisitionPreacquisitionContingencyDescriptionOfSettlement": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FinancialGuaranteeInsuranceContractsPremiumReceivedOverContractPeriodAccretionOfPremiumReceivableIsNotSeparatelyFinancialStatementCaption": [
+"LiabilitiesForGuaranteesOnLongDurationContractsGuaranteeTypeAxis": [
 "2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FinancialGuaranteeInsuranceContractsPremiumReceivedOverContractPeriodPremiumReceivableAccretion and members of IncomeStatementLocationAxis."
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are GuaranteedInsuranceContractTypeOfBenefitAxis or GuaranteedInsuranceContractTypeOfGuaranteeAxis."
 ],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAdjustmentOfOpeningBalanceLineItems": [
-"2014-01-31",
-"Element was deprecated."
-],
-"HeldToMaturitySecuritiesDebtMaturitiesNetCarryingAmount": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is HeldToMaturitySecurities."
-],
-"AvailableforsaleSecuritiesContinuousUnrealizedLossPositionAggregateLosses2": [
-"2013-01-31",
-"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is AvailableForSaleSecuritiesContinuousUnrealizedLossPositionAggregateLosses."
-],
-"DescriptionOfLocationOfForeignCurrencyFairValueHedgeDerivativeOnBalanceSheet": [
+"LiabilitiesForGuaranteesOnLongDurationContractsGuaranteedBenefitType": [
 "2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ForeignCurrencyFairValueHedgeAssetAtFairValue and members of BalanceSheetLocationAxis."
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are the children of LiabilitiesForGuaranteesOnLongDurationContractsLineItems and members of GuaranteedInsuranceContractTypeOfBenefitAxis."
+],
+"LiabilitiesForGuaranteesOnLongDurationContractsIncurredBenefits": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is LiabilitiesForGuaranteesOnLongDurationContractsIncurredBenefits1."
+],
+"LiabilitiesOfAssetsHeldForSale": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LiabilitiesOfDisposalGroupIncludingDiscontinuedOperation."
+],
+"LiabilitiesSubjectToCompromiseBalanceAtBankruptcyEffectiveDate": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LiabilitiesSubjectToCompromise."
+],
+"LiabilitiesSubjectToCompromiseDescriptionOfAsbestosObligations": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"LiabilitiesSubjectToCompromiseDescriptionOfCashDisbursementsAndReclassificationsUnderBankruptcyCourtOrders": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"LiabilitiesSubjectToCompromiseDescriptionOfEmployeeRelatedAccruals": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"LiabilitiesSubjectToCompromiseDescriptionOfEnvironmentalContingencies": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"LiabilitiesSubjectToCompromiseDescriptionOfInterestOnPrepetitionLiabilities": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"LiabilitiesSubjectToCompromiseDescriptionOfOtherLiabilities": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"LiabilitiesSubjectToCompromiseDescriptionOfPensionAndOtherPostretirementObligations": [
+"2015-01-31",
+"Element was deprecated because of low usage."
 ],
 "LiabilitiesSubjectToCompromiseEndOfPeriod": [
 "2013-01-31",
 "Element was deprecated because it has a duration period type attribute. Possible replacement is LiabilitiesSubjectToCompromise."
 ],
-"OtherInvestmentsOfLimitedLiabilityCompanyLLCOrLimitedPartnershipLP": [
+"LiabilitiesSubjectToCompromiseIncomeTaxContingenciesDescription": [
 "2015-01-31",
 "Element was deprecated because of low usage."
 ],
-"LeveragedBuyoutDescriptionOfEquityDebitResultingFromCarryoverBasis": [
+"LiabilityForFuturePolicyBenefitByProductSegmentAxis": [
 "2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+"Element was deprecated due to redundancy. Possible replacement is ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
 ],
-"UnrecordedUnconditionalPurchaseObligationContractQuantityReceived": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"CertainLoansAcquiredInTransferAccountedForAsHeldToMaturityDebtSecuritiesAccretableYield": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesAccretableYield and members of InformationByCategoryOfDebtSecurityAxis."
-],
-"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInRollingYearThree": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInRollingYearThree."
-],
-"ClosedBlockAssetsAndLiabilitiesTableTextBlock": [
+"LiabilityForFuturePolicyBenefitByProductSegmentDomain": [
 "2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ScheduleOfClosedBlockAssetsAndLiabilities."
+"Element was deprecated due to redundancy. Possible replacement is ReinsurancePremiumsForInsuranceCompaniesByProductSegmentDomain."
 ],
-"FinancingReceivableAcquiredWithDeterioratedCreditQuality": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are NotesReceivableNet and ReceivablesAcquiredWithDeterioratedCreditQualityMember."
+"LiabilityForFuturePolicyBenefitsLiabilitiesAssumed": [
+"2013-01-31",
+"Element was deprecated because it has credit balance attribute. Possible replacement is LiabilityForFuturePolicyBenefitsPeriodExpense."
 ],
-"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureDevelopmentCosts1": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesDevelopmentCosts."
-],
-"ForeignCurrencyDerivativesAtFairValueNetAbstract": [
+"LiabilityForTitleClaimsAndClaimsAdjustmentExpenseAbstract": [
 "2014-01-31",
 "Element was deprecated."
 ],
-"ComponentOfOtherOperatingCostAndExpenseGeneralAxis": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"PublicUtilitiesPropertyPlantAndEquipmentCommonEstimatedUsefulLife": [
-"2013-01-31",
-"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentCommonUsefulLife."
+"LiabilityForTitleClaimsAndClaimsAdjustmentExpenseIncurredButNotReportedIBNR": [
+"2014-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseIncurredButNotReportedIBNRClaimsAmount and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
 ],
 "LiabilityForTitleClaimsAndClaimsAdjustmentExpenseKnownClaims": [
 "2014-01-31",
 "Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseReportedClaimsAmount and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
 ],
-"PremiumsEarnedNetAccidentAndHealthAbstract": [
-"2013-01-31",
+"LiabilityForUnpaidClaimsAdjustmentExpenseByExpenseTypeTextBlock": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ScheduleOfLiabilityForUnpaidClaimsAndClaimsAdjustmentExpense."
+],
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAdjustmentOfOpeningBalanceAmount": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseOpeningBalanceAdjustments."
+],
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAdjustmentOfOpeningBalanceAxis": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacements are AdjustmentsForChangeInAccountingPrincipleAxis and ErrorCorrectionsAndPriorPeriodAdjustmentsRestatementByRestatementPeriodAndAmountAxis."
+],
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAdjustmentOfOpeningBalanceLineItems": [
+"2014-01-31",
 "Element was deprecated."
 ],
-"OtherTaxCarryforwardGrossAmount": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TaxCreditCarryforwardAmount."
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAdjustmentOfOpeningBalanceTable": [
+"2014-01-31",
+"Element was deprecated due to remodeling of topic area."
 ],
-"OtherComprehensiveIncomeLossForeignCurrencyTransactionAndTranslationReclassificationAdjustmentRealizedUponSaleOrLiquidationBeforeTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossForeignCurrencyTransactionAndTranslationReclassificationAdjustmentFromAOCIRealizedUponSaleOrLiquidationBeforeTax."
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAdjustmentOfOpeningBalanceTypeDomain": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacements are ChangeInAccountingPrincipleMember and AdjustmentsForErrorCorrectionDomain."
 ],
-"OtherTaxCarryforwardLimitationsOnUse": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TaxCreditCarryforwardLimitationsOnUse."
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseClaimsPaid": [
+"2014-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is PaymentsForLossesAndLossAdjustmentExpense."
 ],
-"PremiumsEarnedNetFinancialGuaranteeInsuranceContractsAbstract": [
-"2013-01-31",
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseClaimsPaidCurrentYear": [
+"2014-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseClaimsPaidCurrentYear1."
+],
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseClaimsPaidPriorYears": [
+"2014-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseClaimsPaidPriorYears1."
+],
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseGross": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LiabilityForClaimsAndClaimsAdjustmentExpense."
+],
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseIncurredButNotReportedIBNRClaimsCommentary": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LiabilityForClaimsAndClaimsAdjustmentExpenseMethodologiesAndAssumptions."
+],
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseIncurredClaims": [
+"2014-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseIncurredClaims1."
+],
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseIncurredClaimsCurrentYear": [
+"2014-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is SupplementalInformationForPropertyCasualtyInsuranceUnderwritersCurrentYearClaimsAndClaimsAdjustmentExpense."
+],
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseIncurredClaimsPriorYears": [
+"2014-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is SupplementalInformationForPropertyCasualtyInsuranceUnderwritersPriorYearClaimsAndClaimsAdjustmentExpense."
+],
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseReportedAndIncurredButNotReportedIBNRClaims": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LiabilityForClaimsAndClaimsAdjustmentExpense."
+],
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseReportedAndIncurredButNotReportedIBNRClaimsAbstract": [
+"2014-01-31",
 "Element was deprecated."
 ],
-"CollaborativeArrangementsAndNoncollaborativeArrangementTransactionsAxis": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TypeOfArrangementAxis."
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseReportedAndIncurredButNotReportedIBNRClaimsCommentary": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LiabilityForClaimsAndClaimsAdjustmentExpenseMethodologiesAndAssumptions."
 ],
-"DescriptionOfLocationOfPriceRiskDerivativesOnBalanceSheet": [
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseReportedAndIncurredButNotReportedIBNRClaimsDisclosureAbstract": [
+"2014-01-31",
+"Element was deprecated."
+],
+"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseReportedClaimsCommentary": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LiabilityForClaimsAndClaimsAdjustmentExpenseMethodologiesAndAssumptions."
+],
+"LifeInsuranceInForceMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are LifeInsuranceInForceGross, LifeInsuranceInForceCeded, LifeInsuranceInForceAssumed, LifeInsuranceInForceNet, or LifeInsuranceInForcePercentageAssumedToNet."
+],
+"LifeInsuranceInForcePremiumsPercentageAssumedToNet": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is LifeInsuranceInForcePercentageAssumedToNet."
+],
+"LimitedLiabilityCompanyLLCOrLimitedPartnershipLPAssetsAndLiabilitiesPreviouslyHeldByPredecessorEntityIesToBusinessCombination": [
 "2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are PriceRiskDerivativeAssetsAtFairValue and PriceRiskDerivativeLiabilitiesAtFairValue and members of BalanceSheetLocationAxis."
+"Element was deprecated because of low usage."
 ],
-"TradingSecuritiesDebtCurrent": [
+"LimitedLiabilityCompanyOrLimitedPartnershipBusinessAndType": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"LimitedLiabilityCompanyOrLimitedPartnershipManagingMemberOrGeneralPartnerAdministrator": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"LimitedLiabilityCompanyOrLimitedPartnershipManagingMemberOrGeneralPartnerRole": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"LineItemForCreditRiskDerivativesOnBalanceSheet": [
 "2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TradingSecuritiesDebt."
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are members of BalanceSheetLocationAxis."
 ],
-"FairValueEstimateNotPracticableRetainedInterest": [
+"LineItemForGainLossOnCreditRiskDerivativeOnIncomeStatement": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are members of IncomeStatementLocationAxis."
+],
+"LineItemForGainLossOnPriceRiskDerivativeInstrumentsNotDesignatedAsHedgingInstrumentsInFinancialStatements": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is GainLossOnPriceRiskDerivativeInstrumentsNotDesignatedAsHedgingInstruments and members of IncomeStatementLocationAxis."
+],
+"LineItemForPriceRiskDerivativeInstrumentsNotDesignatedAsHedgingInstrumentsOnBalanceSheet": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are PriceRiskDerivativeInstrumentsNotDesignatedAsHedgingInstrumentsAssetAtFairValue, PriceRiskDerivativeInstrumentsNotDesignatedAsHedgingInstrumentsLiabilityAtFairValue, and PriceRiskDerivativeInstrumentsNotDesignatedAsHedgingInstrumentsAtFairValueNet and members of BalanceSheetLocationAxis."
+],
+"LineItemForPriceRiskFairValueHedgeDerivativeOnBalanceSheet": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are PriceRiskFairValueHedgeAssetAtFairValue, PriceRiskFairValueHedgeLiabilityAtFairValue, and PriceRiskFairValueHedgeDerivativeAtFairValueNet and members of BalanceSheetLocationAxis."
+],
+"LineItemInFinancialStatementsForGainLossOnHybridInstruments": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is UnrealizedGainLossOnHybridInstrumentNet and members of IncomeStatementLocationAxis."
+],
+"LineOfCreditFacilityAmountOutstanding": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LineofCredit."
+],
+"LineOfCreditFacilityDecreaseForgiveness": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is LineOfCreditFacilityDecreaseForgiveness1."
+],
+"LineOfCreditFacilityDecreaseRepayments": [
+"2013-01-31",
+"Element was deprecated due to redundancy.  Possible replacement is RepaymentsOfLinesOfCredit."
+],
+"LineOfCreditFacilityIncreaseAdditionalBorrowings": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is ProceedsFromLinesOfCredit."
+],
+"LiquidityDisclosureFutureObligationsNotExpectedToBeRepaidAmount": [
+"2015-01-31",
+"Element was deprecated due to issuance of new guidance."
+],
+"LiquidityDisclosureFutureObligationsNotExpectedToBeRepaidParentCompanyInformation": [
+"2015-01-31",
+"Element was deprecated due to issuance of new guidance."
+],
+"LiquidityDisclosureGoingConcernNote": [
+"2015-01-31",
+"Element was deprecated due to issuance of new guidance. Possible replacement is SubstantialDoubtAboutGoingConcernTextBlock and its children elements."
+],
+"LiquidityDisclosureSufficientCashAndWaiversNote": [
+"2015-01-31",
+"Element was deprecated due to issuance of new guidance. Possible replacements are SubstantialDoubtAboutGoingConcernManagementsPlansSubstantialDoubtAlleviated or SubstantialDoubtAboutGoingConcernManagementsPlansSubstantialDoubtNotAlleviated."
+],
+"LiquidityDisclosureTextBlock": [
+"2015-01-31",
+"Element was deprecated due to issuance of new guidance."
+],
+"ListedOptionsMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ExchangeTradedOptionsMember."
+],
+"LitigationSettlementGross": [
+"2013-01-31",
+"Element was deprecated. Possible replacement is LitigationSettlementAmount."
+],
+"LoanPortfolioExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is LoanPortfolioExpense."
+],
+"LoanProcessingFeeMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is LoanProcessingFee."
+],
+"LoansAndLeasesReceivableCommercialDescription": [
+"2015-01-31",
+"Element was deprecated and replaced with a more encompassing element. Possible replacement is LoansAndLeasesReceivableDescription."
+],
+"LoansAndLeasesReceivableConsumerDescription": [
+"2015-01-31",
+"Element was deprecated and replaced with a more encompassing element. Possible replacement is LoansAndLeasesReceivableDescription."
+],
+"LoansAndLeasesReceivableForeignDescription": [
+"2015-01-31",
+"Element was deprecated and replaced with a more encompassing element. Possible replacement is LoansAndLeasesReceivableDescription."
+],
+"LoansAndLeasesReceivableMortgageAndMortgageBackedSecuritiesValuationPolicy": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LoansAndLeasesReceivableValuationPolicy."
+],
+"LoansHeldForSaleCommercialAndIndustrial": [
+"2015-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is LoansReceivableHeldForSaleNetNotPartOfDisposalGroupCommercialAndIndustrial."
+],
+"LoansHeldForSaleCommercialRealEstate": [
+"2015-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is LoansReceivableHeldForSaleNetNotPartOfDisposalGroupCommercialRealEstate."
+],
+"LoansHeldForSaleConsumerCreditCard": [
+"2015-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is LoansReceivableHeldForSaleNetNotPartOfDisposalGroupConsumerCreditCard."
+],
+"LoansHeldForSaleConsumerHomeEquity": [
+"2015-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is LoansReceivableHeldForSaleNetNotPartOfDisposalGroupConsumerHomeEquity."
+],
+"LoansHeldForSaleConsumerInstallmentStudent": [
+"2015-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is LoansReceivableHeldForSaleNetNotPartOfDisposalGroupConsumerStudent."
+],
+"LoansHeldForSaleMortgages": [
+"2015-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is LoansReceivableHeldForSaleNetNotPartOfDisposalGroupMortgage."
+],
+"LoansHeldForSaleOther": [
+"2015-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is LoansReceivableHeldForSaleNetNotPartOfDisposalGroupOther."
+],
+"LoansReceivableHeldForSaleNet": [
+"2015-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is LoansReceivableHeldForSaleNetNotPartOfDisposalGroup."
+],
+"LoansReceivableHeldForSaleNetBankPresentationAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"LoansReceivableWithFixedRatesOfInterest": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is LoansReceivableWithFixedRatesOfInterest1."
+],
+"LoansReceivableWithVariableRatesOfInterest": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is LoansReceivableWithVariableRatesOfInterest1."
+],
+"LoansToFinanceLeveragedBuyout": [
 "2013-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"CumulativeEffectAdjustmentApplicationOfFairValueOptionGrossLosses": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+"LongDurationContractsAssumptionsByProductAndGuaranteeDiscountRateHighEnd": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LongDurationContractsAssumptionsByProductAndGuaranteeDiscountRate, RangeAxis and MaximumMember."
 ],
-"ClassOfWarrantOrRightExercisePriceOfWarrantsOrRights": [
-"2014-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is ClassOfWarrantOrRightExercisePriceOfWarrantsOrRights1."
+"LongDurationContractsAssumptionsByProductAndGuaranteeDiscountRateLowEnd": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LongDurationContractsAssumptionsByProductAndGuaranteeDiscountRate, RangeAxis and MinimumMember."
 ],
-"EmployeeServiceShareBasedCompensationAllocationOfRecognizedPeriodCostsReportLineDomain": [
+"LongDurationContractsAssumptionsByProductAndGuaranteeEstimatedInvestmentYieldHighEnd": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LongDurationContractsAssumptionsByProductAndGuaranteeEstimatedAverageInvestmentYield, RangeAxis and MaximumMember."
+],
+"LongDurationContractsAssumptionsByProductAndGuaranteeEstimatedInvestmentYieldLowEnd": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LongDurationContractsAssumptionsByProductAndGuaranteeEstimatedAverageInvestmentYield, RangeAxis and MinimumMember."
+],
+"LongDurationContractsAssumptionsByProductAndGuaranteeGuaranteeTypeAxis": [
+"2015-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are GuaranteedInsuranceContractTypeOfBenefitAxis or GuaranteedInsuranceContractTypeOfGuaranteeAxis."
+],
+"LongDurationContractsAssumptionsByProductAndGuaranteeLapseRateHighEnd": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are LongDurationContractsAssumptionsByProductAndGuaranteeLapseRate, RangeAxis and MaximumMember."
+],
+"LongDurationContractsAssumptionsByProductAndGuaranteeLapseRateLowEnd": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are LongDurationContractsAssumptionsByProductAndGuaranteeLapseRate, RangeAxis and MinimumMember."
+],
+"LongDurationContractsAssumptionsByProductAndGuaranteeMortalityRateHighEnd": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are LongDurationContractsAssumptionsByProductAndGuaranteeMortalityRate, RangeAxis and MaximumMember."
+],
+"LongDurationContractsAssumptionsByProductAndGuaranteeMortalityRateLowEnd": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are LongDurationContractsAssumptionsByProductAndGuaranteeMortalityRate, RangeAxis and MinimumMember."
+],
+"LongDurationContractsAssumptionsByProductAndGuaranteeVolatilityRateHighEnd": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are LongDurationContractsAssumptionsByProductAndGuaranteeVolatilityRate, RangeAxis and MaximumMember."
+],
+"LongDurationContractsAssumptionsByProductAndGuaranteeVolatilityRateLowEnd": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are LongDurationContractsAssumptionsByProductAndGuaranteeVolatilityRate, RangeAxis and MinimumMember."
+],
+"LongDurationContractsHedgingStrategyAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"LongLivedAssetsHeldForSaleGainLossOnSale": [
 "2013-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is IncomeStatementLocationDomain."
+"Element was deprecated because it has an instant period type attribute. Possible replacement is GainLossOnSaleOfPropertyPlantEquipment."
+],
+"LongLivedAssetsHeldForSaleImpairmentCharge": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is ImpairmentOfLongLivedAssetsToBeDisposedOf."
+],
+"LongLivedAssetsHeldForSaleProceedsFromSale": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is ProceedsFromSaleOfPropertyPlantAndEquipment."
+],
+"LongLivedAssetsToBeAbandonedAssetNameDomain": [
+"2015-01-31",
+"Element deprecated due to redundancy. Possible replacement is PropertyPlantAndEquipmentTypeDomain or DisposalGroupsIncludingDiscontinuedOperationsNameDomain."
+],
+"LongLivedAssetsToBeAbandonedByAssetAxis": [
+"2015-01-31",
+"Element deprecated due to redundancy. Possible replacement is PropertyPlantAndEquipmentByTypeAxis and IncomeStatementBalanceSheetAndAdditionalDisclosuresByDisposalGroupsIncludingDiscontinuedOperationsAxis."
+],
+"LongLivedAssetsToBeAbandonedCarryingValueOfAsset": [
+"2015-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"LongLivedAssetsToBeAbandonedCircumstancesLeadingToPlannedAbandonment": [
+"2015-01-31",
+"Element deprecated due to redundancy. Possible replacement is DisposalGroupIncludingDiscontinuedOperationDescriptionAndTimingOfDisposal."
+],
+"LongLivedAssetsToBeAbandonedLineItems": [
+"2015-01-31",
+"Element was deprecated."
+],
+"LongLivedAssetsToBeAbandonedTimingOfExpectedDisposition": [
+"2015-01-31",
+"Element deprecated due to redundancy. Possible replacement is DisposalGroupIncludingDiscontinuedOperationDescriptionAndTimingOfDisposal."
+],
+"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInNextRollingTwelveMonths": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInNextRollingTwelveMonths."
+],
+"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInRemainderOfFiscalYear": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalRemainderOfFiscalYear."
+],
+"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInRollingAfterYearFive": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInRollingAfterYearFive."
+],
+"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInRollingYearFive": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInRollingYearFive."
+],
+"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInRollingYearFour": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInRollingYearFour."
+],
+"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInRollingYearThree": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInRollingYearThree."
+],
+"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInRollingYearTwo": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInRollingYearTwo."
+],
+"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalRollingMaturityAbstract": [
+"2014-01-31",
+"Element was deprecated."
 ],
 "LongTermPurchaseCommitmentPotentialAdverseConsequences": [
 "2015-01-31",
 "Element was deprecated because of low usage."
 ],
-"BusinessAcquisitionEntityAcquiredAndReasonForAcquisitionAbstract": [
+"LongTermPurchaseCommitmentTimePeriod": [
+"2014-01-31",
+"Element was deprecated because it has a stringItemType attribute. Possible replacement is LongtermPurchaseCommitmentPeriod."
+],
+"LossContingencyAccrualCarryingValueProvision": [
 "2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is LossContingencyAccrualProvision."
+],
+"LossContingencyIncomeStatementCaption": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LossContingencyLossInPeriod and members of IncomeStatementLocationAxis."
+],
+"LossContingencyRangeOfPossibleLoss": [
+"2015-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are LossContingencyRangeOfPossibleLossMinimum and LossContingencyRangeOfPossibleLossMaximum."
+],
+"LossContingencyRelatedReceivableCaption": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are LossContingencyReceivableCurrent, LossContingencyReceivableNoncurrent, and LossContingencyReceivable and members of BalanceSheetLocationAxis."
+],
+"LossContingencyRelatedReceivableCarryingValue": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is LossContingencyReceivable."
+],
+"LossContingencyRelatedReceivableCarryingValueCurrent": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is LossContingencyReceivableCurrent."
+],
+"LossContingencyRelatedReceivableCarryingValueNoncurrent": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is LossContingencyReceivableNoncurrent."
+],
+"LossContingencySettlementAgreementConsideration1": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is LitigationSettlementAmount."
+],
+"LossOnReceivablesAxis": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"LossOnReceivablesDomain": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"MalpracticeInsuranceCountryOfCaptiveInsurer": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"MalpracticeInsuranceDeductible": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is MalpracticeInsuranceDeductible1."
+],
+"MalpracticeInsuranceEntityRating": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is MalpracticeInsuranceThirdPartyCoverage and members of CreditRatingMoodysAxis, CreditRatingStandardPoorsAxis, CreditRatingFitchAxis, and CreditRatingAMBestAxis."
+],
+"MalpracticeInsuranceTailCoverage": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"MalpracticeInsuranceThirdPartyInsuranceCompany": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"MalpracticeLossContingencyAccrualAdjustment": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"MalpracticeLossContingencySettlementOfClaims": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is MalpracticeLossContingencyPeriodCost."
+],
+"ManagementFeeAmountPaid": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is PaymentForManagementFee."
+],
+"ManagementsAssertionOfAdequacyOfInsuranceReserves": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"MarketingAndAdvertisingExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is MarketingAndAdvertisingExpense."
+],
+"MarketingExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is MarketingExpense."
+],
+"MaterialComponentsOfRecordedThirdPartyEnvironmentalRecoveriesAbstract": [
+"2015-01-31",
 "Element was deprecated."
 ],
-"FinancialGuaranteeInsuranceContractsClaimLiabilitySignificantComponentsOfChangeAccretionOfDiscountIfNotPresentedSeparatelyFinancialStatementCaption": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FinancialGuaranteeInsuranceContractsClaimLiabilitySignificantComponentsOfChangeAccretionOfDiscount and members of IncomeStatementLocationAxis."
+"MaterialEffectOnLiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseFromChangeInAccountingPrincipleMember": [
+"2014-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are members of AdjustmentsForChangeInAccountingPrincipleAxis."
 ],
-"AssumedPremiumsWrittenFinancialGuaranteeInsuranceContracts": [
+"MaterialErrorInLiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseMember": [
+"2014-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are members of ErrorCorrectionsAndPriorPeriodAdjustmentsRestatementByRestatementPeriodAndAmountAxis."
+],
+"MaximumFutureEarningsFromClosedBlockAssetsAndLiabilities1": [
 "2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+"Element was deprecated due to redundancy. Possible replacement is ClosedBlockAssetsAndLiabilitiesMaximumFutureEarningsToBeRecognized."
 ],
-"IncomeLossFromContinuingOperationsPerOutstandingLimitedPartnershipUnitDiluted": [
+"MaximumLengthOfTimeHedgedInForeignCurrencyCashFlowHedge": [
 "2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromContinuingOperationsNetOfTaxPerOutstandingLimitedPartnershipUnitDiluted."
+"Element was deprecated because it is has a stringItemType attribute. Possible replacement is MaximumLengthOfTimeForeignCurrencyCashFlowHedge."
 ],
-"PutOptionsWrittenMember": [
+"MaximumPotentialFutureExposureOnCreditRiskDerivatives": [
 "2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PutOptionMember with ShortMember."
+"Element was deprecated because it has a debit balance attribute. Possible replacement is CreditDerivativeMaximumExposureUndiscounted."
 ],
-"BusinessAcquisitionPurchasePriceAllocationPreacquisitionContingencyAccrual": [
+"MembersOrLimitedPartnersSubsequentDistributionAmount": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberCashDistributionsPaid and members of SubsequentEventTypeAxis or DistributionMadeToLimitedPartnerCashDistributionsPaid and members of SubsequentEventTypeAxis."
+],
+"MembersOrLimitedPartnersSubsequentDistributionDate": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberDistributionDate and members of SubsequentEventTypeAxis or DistributionMadeToLimitedPartnerDistributionDate and members of SubsequentEventTypeAxis."
+],
+"MergerAndAcquisitionCosts": [
 "2013-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"LeaseConcessions": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AmortizationOfLeaseIncentives."
-],
-"ClosedBlockOperationsChangeInPolicyholderDividendObligation": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ClosedBlockDividendObligationPeriodIncreaseDecrease."
-],
-"ReorganizationItemsDescriptionOfProvisionForExpectedAllowedClaims": [
+"MileageCreditPrice": [
 "2015-01-31",
 "Element was deprecated because of low usage."
 ],
-"FairValueLiabilitiesMeasuredOnRecurringBasisGainLossIncludedInEarningsAbstract": [
+"MinorRestatementOfOpeningLiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseSAB108Member": [
+"2014-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are members of ErrorCorrectionsAndPriorPeriodAdjustmentsRestatementByRestatementPeriodAndAmountAxis."
+],
+"MinorityInterestAndEarningsLossesEquityInvestmentsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is IncomeLossFromEquityMethodInvestments."
+],
+"MinorityInterestExpenseIncomeRealEstateInvestments": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is NetIncomeLossFromRealEstateInvestmentPartnershipAttributableToParent."
+],
+"MinorityInterestExpenseIncomeRealEstateInvestmentsAbstract": [
 "2013-01-31",
 "Element was deprecated."
 ],
-"WeightedAverageRateDomesticDepositLiabilitiesDescription": [
-"2015-01-31",
-"Element was deprecated because of low usage."
+"MinorityInterestInNetIncomeLossJointVenturePartners": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacement is NoncontrollingInterestInNetIncomeLossJointVenturePartnersNonredeemable or NoncontrollingInterestInNetIncomeLossJointVenturePartnersRedeemable."
 ],
-"AgingOfCapitalizedExploratoryWellCostsNumberOfProjectsAbstract": [
+"MinorityInterestInNetIncomeLossLimitedPartnerships": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacement is NoncontrollingInterestInNetIncomeLossLimitedPartnershipsNonredeemable or NoncontrollingInterestInNetIncomeLossLimitedPartnershipsRedeemable."
+],
+"MinorityInterestInNetIncomeLossOperatingPartnerships": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacement is NoncontrollingInterestInNetIncomeLossOperatingPartnershipsNonredeemable or NoncontrollingInterestInNetIncomeLossOperatingPartnershipsRedeemable."
+],
+"MinorityInterestInNetIncomeLossOtherMinorityInterests": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacement is NoncontrollingInterestInNetIncomeLossOtherNoncontrollingInterestsNonredeemable or NoncontrollingInterestInNetIncomeLossOtherNoncontrollingInterestsRedeemable."
+],
+"MinorityInterestInNetIncomeLossPreferredUnitHolders": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacement is NoncontrollingInterestInNetIncomeLossPreferredUnitHoldersRedeemable or NoncontrollingInterestInNetIncomeLossPreferredUnitHoldersNonredeemable."
+],
+"MinorityInterestIncreaseFromStockIssuance": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacement is NoncontrollingInterestIncreaseFromSubsidiaryEquityIssuance or NoncontrollingInterestIncreaseFromSaleOfParentEquityInterest."
+],
+"MortgageLoansOnRealEstateFederalIncomeTaxBasis": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is MortgageLoansOnRealEstateFederalIncomeTaxBasis1."
+],
+"MortgageLoansOnRealEstateMember": [
+"2015-01-31",
+"Element deprecated due to redundancy. Possible replacement is MortgagesMember."
+],
+"MortgageLoansOnRealEstatePeriodicPaymentTermsBalloonPaymentAmount": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are MortgageLoansOnRealEstatePeriodicPaymentTermsBalloonPaymentToBeReceived or DebtInstrumentPeriodicPaymentTermsBalloonPaymentToBePaid."
+],
+"MortgageLoansOnRealEstatePriorLiens": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is MortgageLoansOnRealEstatePriorLiens1."
+],
+"MortgageLoansOnRealEstateRenewedAndExtendedAmount": [
+"2013-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is MortgageLoansOnRealEstateRenewedAndExtendedAmount1."
+],
+"MortgageLoansOnRealEstateWriteDownOrReserveAmount": [
+"2013-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is MortgageLoansOnRealEstateWriteDownOrReserveAmount1."
+],
+"MultiemployerPlansCollectiveBargainingArrangementDescription": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is MultiemployerPlansCollectiveBargainingArrangementExpirationDateDescription."
+],
+"NetAmountAtRiskByProductAndGuaranteeGuaranteeTypeAxis": [
+"2015-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are GuaranteedInsuranceContractTypeOfBenefitAxis or GuaranteedInsuranceContractTypeOfGuaranteeAxis."
+],
+"NetAmountAtRiskByProductAndGuaranteeNetAmountAtRiskAtAnnuitization": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are NetAmountAtRiskByProductAndGuaranteeNetAmountAtRisk, GuaranteedInsuranceContractTypeOfBenefitAxis and AnnuitizationBenefitMember."
+],
+"NetAmountAtRiskByProductAndGuaranteeNetAmountAtRiskInEventOfDeath": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are NetAmountAtRiskByProductAndGuaranteeNetAmountAtRisk, GuaranteedInsuranceContractTypeOfBenefitAxis and GuaranteedMinimumDeathBenefitMember."
+],
+"NetAmountAtRiskByProductAndGuaranteeRangeOfGuaranteedMinimumReturnRates": [
+"2015-01-31",
+"Element was deprecated because it has a stringItemType attribute and the financial reporting concept can be conveyed dimensionally. Possible replacement is NetAmountAtRiskByProductAndGuaranteeGuaranteedMinimumReturnRate and members of RangeAxis."
+],
+"NetAmountAtRiskByProductAndGuaranteeSeparateAccountValueAtAnnuitization": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are NetAmountAtRiskByProductAndGuaranteeSeparateAccountValue, GuaranteedInsuranceContractTypeOfBenefitAxis and AnnuitizationBenefitMember."
+],
+"NetAmountAtRiskByProductAndGuaranteeSeparateAccountValueInEventOfDeath": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are NetAmountAtRiskByProductAndGuaranteeSeparateAccountValue, GuaranteedInsuranceContractTypeOfBenefitAxis and GuaranteedMinimumDeathBenefitMember."
+],
+"NetAmountAtRiskByProductAndGuaranteeSubcategory": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are the children of NetAmountAtRiskByProductAndGuaranteeLineItems and members of GuaranteedInsuranceContractTypeOfGuaranteeAxis."
+],
+"NetCreditLossesDuringPeriodOnLoansManagedOrSecuritized": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is NetCreditLossOnLoansManagedOrSecuritizedOrAssetbackedFinancingArrangement."
+],
+"NetIncomeLossPerOutstandingGeneralPartnershipUnit": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is NetIncomeLossPerOutstandingGeneralPartnershipUnitNetOfTax."
+],
+"NetIncomeLossPerOutstandingLimitedPartnershipUnit": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is NetIncomeLossPerOutstandingLimitedPartnershipUnitBasicNetOfTax."
+],
+"NetIncomeLossPerOutstandingLimitedPartnershipUnitDiluted": [
+"2013-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is NetIncomeLossNetOfTaxPerOutstandingLimitedPartnershipUnitDiluted."
+],
+"NetIncomeMember": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"NetIncreaseDecreaseInAdvancePaymentsByBorrowersForTaxesAndInsurance": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is IncreaseDecreaseInAdvancePaymentsByBorrowersForTaxesAndInsurance."
+],
+"NetInterestIncomeLossAfterProvisionForLoanLosses": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is InterestIncomeExpenseAfterProvisionForLoanLoss."
+],
+"NetInvestmentIncomeInsuranceEntity": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is NetInvestmentIncome."
+],
+"NetInvestmentIncomeInsuranceEntityEquitySecurities": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NetInvestmentIncome and members of InvestmentTypeAxis."
+],
+"NetInvestmentIncomeInsuranceEntityFixedMaturities": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NetInvestmentIncome and members of InvestmentTypeAxis."
+],
+"NetInvestmentIncomeInsuranceEntityInvestmentRealEstate": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NetInvestmentIncome and members of InvestmentTypeAxis."
+],
+"NetInvestmentIncomeInsuranceEntityMortgageLoansOnRealEstate": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NetInvestmentIncome and members of InvestmentTypeAxis."
+],
+"NetInvestmentIncomeInsuranceEntityOtherLongTermInvestments": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NetInvestmentIncome and members of InvestmentTypeAxis."
+],
+"NetInvestmentIncomeInsuranceEntityPolicyLoans": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NetInvestmentIncome and members of InvestmentTypeAxis."
+],
+"NetInvestmentIncomeInsuranceEntityShortTermInvestments": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NetInvestmentIncome and members of InvestmentTypeAxis."
+],
+"NettingAndCollateralMember": [
+"2014-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are DerivativeAssetFairValueGrossLiability, DerivativeAssetCollateralObligationToReturnCashOffset, DerivativeAssetFairValueGrossLiabilityAndObligationToReturnCashOffset, SecuritiesPurchasedUnderAgreementsToResellLiability, SecuritiesBorrowedLiability, DerivativeAssetSecuritiesPurchasedUnderAgreementsToResellSecuritiesBorrowedLiability, DerivativeLiabilityFairValueGrossAsset, DerivativeLiabilityCollateralRightToReclaimCashOffset, DerivativeLiabilityFairValueGrossAssetAndRightToReclaimCashOffset, SecuritiesSoldUnderAgreementsToRepurchaseAsset, SecuritiesLoanedAsset, or DerivativeLiabilitySecuritiesSoldUnderAgreementsToResellSecuritiesLoanedAsset."
+],
+"NewAccountingPronouncementOrChangeInAccountingPrincipleProFormaDisclosuresRevenueRecognizedAmount": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"NewContractAxis": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"NewContractDomain": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"NoninterestExpenseCommissionExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpenseCommissionExpense."
+],
+"NoninterestExpenseDirectorsFeesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpenseDirectorsFees."
+],
+"NoninterestExpenseInvestmentAdvisoryFeesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpenseInvestmentAdvisoryFees."
+],
+"NoninterestExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpense."
+],
+"NoninterestExpenseOfferingCostMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpenseOfferingCost."
+],
+"NoninterestExpensePrintingAndFulfillmentMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpensePrintingandFulfillment."
+],
+"NoninterestExpenseRelatedToPerformanceFeesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpenseRelatedtoPerformanceFees."
+],
+"NoninterestExpenseTransferAgentAndCustodianFeesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpenseTransferAgentandCustodianFees."
+],
+"NonmonetaryNotionalAmountOfPriceRiskCashFlowHedgeDerivatives": [
+"2013-01-31",
+"Element was deprecated because the intended concept conveyed is the underlying. Possible replacements are UnderlyingDerivativeAsset, UnderlyingDerivativeLiability, UnderlyingDerivative and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis and DerivativeInstrumentRiskAxis."
+],
+"NonmonetaryNotionalAmountOfPriceRiskDerivativeInstrumentsNotDesignatedAsHedgingInstruments": [
+"2013-01-31",
+"Element was deprecated because the intended concept conveyed is the underlying. Possible replacements are UnderlyingDerivativeAsset, UnderlyingDerivativeLiability, UnderlyingDerivative and members of HedgingDesignationAxis and DerivativeInstrumentRiskAxis."
+],
+"NonmonetaryNotionalAmountOfPriceRiskDerivatives": [
+"2013-01-31",
+"Element was deprecated because the intended concept conveyed is the underlying. Possible replacements are UnderlyingDerivativeAsset, UnderlyingDerivativeLiability, UnderlyingDerivative and members of DerivativeInstrumentRiskAxis."
+],
+"NonmonetaryNotionalAmountOfPriceRiskFairValueHedgeDerivatives": [
+"2013-01-31",
+"Element was deprecated because the intended concept conveyed is the underlying. Possible replacements are UnderlyingDerivativeAsset, UnderlyingDerivativeLiability, UnderlyingDerivative and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis and DerivativeInstrumentRiskAxis."
+],
+"NotionalAmountOfCashFlowHedgeInstruments": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
+],
+"NotionalAmountOfCreditRiskDerivatives": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of CreditDerivativesByContractTypeAxis."
+],
+"NotionalAmountOfDerivativeInstrumentsDesignatedAsNetInvestmentHedges": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
+],
+"NotionalAmountOfDerivativesAdditionalCategoriesOfDerivativesAbstract": [
 "2013-01-31",
 "Element was deprecated."
-],
-"FairValueEstimateNotPracticableReasonsMortgageBackedSecuritiesAvailableForSale": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
-],
-"PublicUtilitiesPropertyPlantAndEquipmentAmountOfDisallowedCostsForRecentlyCompletedPlantCostRecoveryPeriod": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"PhaseInPlanNetChangeInAmountOfCostsDeferredForRateMakingPurposesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"OtherResearchAndDevelopmentExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OtherResearchAndDevelopmentExpense."
-],
-"CededPremiumsWrittenAccidentAndHealth": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"ContractsInForceSubjectToParticipationThroughReinsuranceValue": [
-"2013-01-31",
-"Element was deprecated."
-],
-"PurchasedCallOptionMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CallOptionMember with LongMember."
-],
-"CertainLoansAcquiredInTransferAccountedForAsAvailableForSaleDebtSecuritiesAccretableYieldReclassificationsToNonaccretableDifference": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesAccretableYieldReclassificationsToNonaccretableDifference and members of InformationByCategoryOfDebtSecurityAxis."
 ],
 "NotionalAmountOfDerivativesTotalAbstract": [
 "2013-01-31",
 "Element was deprecated."
 ],
-"DescriptionOfAdoptionOfPolicyOnAccruedSabbatical": [
+"NotionalAmountOfFairValueHedgeInstruments": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
+],
+"NotionalAmountOfForeignCurrencyCashFlowHedgeDerivatives": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
+],
+"NotionalAmountOfForeignCurrencyDerivativeInstrumentsNotDesignatedAsHedgingInstruments": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and HedgingDesignationAxis."
+],
+"NotionalAmountOfForeignCurrencyDerivativePurchaseContracts": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and PositionAxis."
+],
+"NotionalAmountOfForeignCurrencyDerivativeSaleContracts": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and PositionAxis."
+],
+"NotionalAmountOfForeignCurrencyDerivatives": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis."
+],
+"NotionalAmountOfForeignCurrencyFairValueHedgeDerivatives": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis and DerivativeInstrumentRiskAxis."
+],
+"NotionalAmountOfInterestRateCashFlowHedgeDerivatives": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis and DerivativeInstrumentRiskAxis."
+],
+"NotionalAmountOfInterestRateDerivativeInstrumentsNotDesignatedAsHedgingInstruments": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and HedgingDesignationAxis."
+],
+"NotionalAmountOfInterestRateDerivatives": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis."
+],
+"NotionalAmountOfInterestRateFairValueHedgeDerivatives": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
+],
+"NotionalAmountOfNetInvestmentHedgingInstruments": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount,  DerivativeNotionalAmount or NotionalAmountOfNonderivativeInstruments and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
+],
+"NotionalAmountOfNetInvestmentHedgingInstrumentsTotalAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"NotionalAmountOfNonderivativeInstrumentsDesignatedAsNetInvestmentHedges": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NotionalAmountOfNonderivativeInstruments and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
+],
+"NotionalAmountOfOtherDerivativesNotDesignatedAsHedgingInstruments": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of HedgingDesignationAxis."
+],
+"NotionalAmountOfPriceRiskCashFlowHedgeDerivatives": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis and DerivativeInstrumentRiskAxis."
+],
+"NotionalAmountOfPriceRiskDerivativeInstrumentsNotDesignatedAsHedgingInstruments": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and HedgingDesignationAxis."
+],
+"NotionalAmountOfPriceRiskDerivatives": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis."
+],
+"NotionalAmountOfPriceRiskFairValueHedgeDerivatives": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
+],
+"OccupancyNetMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OccupancyNet."
+],
+"OperatingLeaseExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is LeaseAndRentalExpense."
+],
+"OperatingLeaseExpenseOtherExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is LeaseAndRentalExpense."
+],
+"OperatingLossCarryforwardsExpirationDates": [
+"2013-01-31",
+"Element was deprecated because it has a stringItemtype attribute. Possible replacement is OperatingLossCarryforwardsExpirationDate."
+],
+"OptionIndexedToIssuersEquityRedeemableStockRedemptionRequirementsAmount": [
+"2013-01-31",
+"Element was deprecated because it has debit balance and duration period type attributes. Possible replacement is OptionIndexedToIssuersEquityRedeemableStockRedemptionRequirementsAmount1."
+],
+"OptionIndexedToIssuersEquityStrikePrice": [
+"2014-01-31",
+"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is OptionIndexedToIssuersEquityStrikePrice1."
+],
+"OrderFlowFeesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OrderFlowFees."
+],
+"OriginationAndPurchasesOfMortgageBankingAssets": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is PaymentsForOriginationAndPurchasesOfLoansHeldForSale."
+],
+"OriginationOfMortgageServicingRightsMSRs": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ServicingAssetAtFairValueAdditions."
+],
+"OtherAmortizationMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OtherAmortizationOfDeferredCharges."
+],
+"OtherAssetsHeldForSale": [
+"2014-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DisposalGroupIncludingDiscontinuedOperationOtherAsset or AssetsHeldForSaleNotPartOfDisposalGroupOther."
+],
+"OtherAssetsHeldForSaleCurrent": [
+"2014-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DisposalGroupIncludingDiscontinuedOperationOtherCurrentAssets or AssetsHeldForSaleNotPartOfDisposalGroupCurrentOther."
+],
+"OtherComprehensiveIncomeAmortizationOfDefinedBenefitPlanNetPriorServiceCostRecognizedInNetPeriodicPensionCostTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossAmortizationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetPriorServiceCostCreditTax."
+],
+"OtherComprehensiveIncomeLossAmortizationPensionAndOtherPostretirementBenefitPlansNetPriorServiceCostRecognizedInNetPeriodicBenefitCostBeforeTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossAmortizationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetPriorServiceCostCreditBeforeTax."
+],
+"OtherComprehensiveIncomeLossAmortizationPensionAndOtherPostretirementBenefitPlansNetPriorServiceCostRecognizedInNetPeriodicPensionCostNetOfTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossAmortizationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetPriorServiceCostCreditNetOfTax."
+],
+"OtherComprehensiveIncomeLossForeignCurrencyTransactionAndTranslationReclassificationAdjustmentRealizedUponSaleOrLiquidationBeforeTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossForeignCurrencyTransactionAndTranslationReclassificationAdjustmentFromAOCIRealizedUponSaleOrLiquidationBeforeTax."
+],
+"OtherComprehensiveIncomeLossForeignCurrencyTransactionAndTranslationReclassificationAdjustmentRealizedUponSaleOrLiquidationNetOfTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossForeignCurrencyTransactionAndTranslationReclassificationAdjustmentFromAOCIRealizedUponSaleOrLiquidationNetOfTax."
+],
+"OtherComprehensiveIncomeLossForeignCurrencyTranslationReclassificationAdjustmentRealizedUponSaleOrLiquidationTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossForeignCurrencyTransactionAndTranslationReclassificationAdjustmentFromAOCIRealizedUponSaleOrLiquidationTax."
+],
+"OtherComprehensiveIncomeLossReclassificationAdjustmentForSaleOfSecuritiesIncludedInNetIncomeBeforeTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForSaleOfSecuritiesBeforeTax."
+],
+"OtherComprehensiveIncomeLossReclassificationAdjustmentForSaleOfSecuritiesIncludedInNetIncomeNetOfTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForSaleOfSecuritiesNetOfTax."
+],
+"OtherComprehensiveIncomeLossReclassificationAdjustmentForSaleOfSecuritiesIncludedInNetIncomeTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForSaleOfSecuritiesTax."
+],
+"OtherComprehensiveIncomeLossReclassificationAdjustmentForWriteDownOfSecuritiesIncludedInNetIncomeTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForWritedownOfSecuritiesTax."
+],
+"OtherComprehensiveIncomeLossReclassificationAdjustmentForWritedownOfSecuritiesIncludedInNetIncomeBeforeTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForWritedownOfSecuritiesBeforeTax."
+],
+"OtherComprehensiveIncomeLossReclassificationAdjustmentForWritedownOfSecuritiesIncludedInNetIncomeNetOfTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForWritedownOfSecuritiesNetOfTax."
+],
+"OtherComprehensiveIncomeLossReclassificationAdjustmentOnDerivativesIncludedInNetIncomeBeforeTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIOnDerivativesBeforeTax."
+],
+"OtherComprehensiveIncomeLossReclassificationAdjustmentOnDerivativesIncludedInNetIncomeNetOfTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIOnDerivativesNetOfTax."
+],
+"OtherComprehensiveIncomeLossReclassificationAdjustmentOnDerivativesIncludedInNetIncomeTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIOnDerivativesTax."
+],
+"OtherComprehensiveIncomeLossReclassificationPensionAndOtherPostretirementBenefitPlansNetGainLossRecognizedInNetPeriodicBenefitCostTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetGainLossTax."
+],
+"OtherComprehensiveIncomeLossReclassificationPensionAndOtherPostretirementBenefitPlansNetTransitionAssetObligationRecognizedInNetPeriodicBenefitCostTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetTransitionAssetObligationTax."
+],
+"OtherComprehensiveIncomeReclassificationOfDefinedBenefitPlanNetTransitionAssetObligationRecognizedInNetPeriodicBenefitCostBeforeTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetTransitionAssetObligationBeforeTax."
+],
+"OtherComprehensiveIncomeReclassificationOfDefinedBenefitPlanNetTransitionAssetObligationRecognizedInNetPeriodicBenefitCostNetOfTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetTransitionAssetObligationNetOfTax."
+],
+"OtherComprehensiveIncomeReclassificationOfDefinedBenefitPlansNetGainLossRecognizedInNetPeriodicBenefitCostBeforeTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetGainLossBeforeTax."
+],
+"OtherComprehensiveIncomeReclassificationOfDefinedBenefitPlansNetGainLossRecognizedInNetPeriodicBenefitCostNetOfTax": [
+"2013-01-31",
+"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetGainLossNetOfTax."
+],
+"OtherCostAndExpenseDisclosureOperatingAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"OtherDeferredCostAmortizationExpense": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is OtherAmortizationOfDeferredCharges."
+],
+"OtherDeferredCostsDisclosures": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"OtherDerivativesNotDesignatedAsHedgingInstrumentsAssetsAtFairValue": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DerivativeInstrumentsNotDesignatedAsHedgingInstrumentsAssetAtFairValue."
+],
+"OtherExpenseCapitalizationToDeferredAcquisitionCostDAC": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is DeferredPolicyAcquisitionCostsAdditions."
+],
+"OtherExpenseOfInsuranceEntities": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is OtherExpenses."
+],
+"OtherExpenseOfInsuranceEntitiesAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"OtherInsuranceIndustryDisclosures": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"OtherInterestIncomeMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is InterestIncomeOther."
+],
+"OtherInvestmentsOfLimitedLiabilityCompanyLLCOrLimitedPartnershipLP": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"OtherMaterialNoncashItems": [
+"2013-01-31",
+"Element was deprecated due to remodeling of Segment area. Possible replacement is corresponding primary line items and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
+],
+"OtherNoninterestExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OtherNoninterestExpense."
+],
+"OtherNonrecurringExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OtherNonrecurringExpense."
+],
+"OtherNonrecurringGainMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OtherNonrecurringGain."
+],
+"OtherOperatingExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OtherCostAndExpenseOperating."
+],
+"OtherPremiumRevenueNet": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is PremiumsEarnedNetOtherInsurance."
+],
+"OtherResearchAndDevelopmentExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OtherResearchAndDevelopmentExpense."
+],
+"OtherSellingAndMarketingExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OtherSellingAndMarketingExpense."
+],
+"OtherTaxCarryforwardDataByItemAxis": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TaxCreditCarryforwardAxis."
+],
+"OtherTaxCarryforwardDeferredTaxAsset": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is DeferredTaxAssetsTaxCreditCarryforwards."
+],
+"OtherTaxCarryforwardDescription": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TaxCreditCarryforwardDescription."
+],
+"OtherTaxCarryforwardExpirationDates": [
+"2013-01-31",
+"Element was deprecated because it is has a stringItemType attribute. Possible replacement is TaxCreditCarryforwardExpirationDate."
+],
+"OtherTaxCarryforwardGrossAmount": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TaxCreditCarryforwardAmount."
+],
+"OtherTaxCarryforwardLimitationsOnUse": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TaxCreditCarryforwardLimitationsOnUse."
+],
+"OtherTaxCarryforwardLineItems": [
+"2013-01-31",
+"Element was deprecated."
+],
+"OtherTaxCarryforwardNameDomain": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TaxCreditCarryforwardNameDomain."
+],
+"OtherTaxCarryforwardTable": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TaxCreditCarryforwardTable."
+],
+"OtherTaxCarryforwardValuationAllowance": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TaxCreditCarryforwardValuationAllowance."
+],
+"OtherThanTemporaryImpairmentLossesInvestmentsAvailableforsaleSecuritiesPortionRecognizedInEarningsNetQualitativeDisclosuresThirdPartyGuaranteesDescription": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is AvailableforsaleSecuritiesInUnrealizedLossPositionsQualitativeDisclosureOtherThirdPartyGuaranteesDescription."
+],
+"OtherThanTemporaryImpairmentLossesInvestmentsHeldtomaturitySecuritiesPortionRecognizedInEarningsNetQualitativeDisclosuresThirdPartyGuaranteesDescription": [
+"2013-01-31",
+"Element was deprecated."
+],
+"OutstandingStockAwardsMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is StockCompensationPlanMember."
+],
+"ParticipatingMortgageLoansResultsOfOperations": [
+"2015-01-31",
+"Element deprecated due to redundancy. Possible replacement is ParticipatingMortgageLoanDescription."
+],
+"ParticipatingSecuritiesDistributedAndUndistributedEarnings": [
+"2014-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are ParticipatingSecuritiesDistributedAndUndistributedEarningsLossBasic or ParticipatingSecuritiesDistributedAndUndistributedEarningsLossDiluted."
+],
+"PartiesToContractualArrangementAxis": [
+"2014-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is LeaseArrangementTypeAxis."
+],
+"PartiesToContractualArrangementMember": [
+"2014-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is LeaseArrangementTypeDomain."
+],
+"PartnersCapitalAdjustedBalance": [
+"2015-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is PartnersCapitalAdjustedBalance1."
+],
+"PaymentAndPerformanceRiskCreditRatingAxis": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are CreditRatingAMBestAxis, CreditRatingMoodysAxis, CreditRatingStandardPoorsAxis, CreditRatingFitchAxis, ExternalCreditRatingByGroupingAxis, InternalCreditAssessmentAxis."
+],
+"PaymentsForPurchaseOfOtherAssets": [
+"2013-01-31",
+"Element was deprecated because it was being used for either operating or investing activities. Possible replacements are PaymentsForPurchaseOfOtherAssets1, PaymentsForProceedsFromOtherInvestingActivities or PaymentsToAcquireOtherProductiveAssets."
+],
+"PaymentsForRepurchaseOfCommonStockForEmployeeTaxWithholdingObligations": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is PaymentsRelatedToTaxWithholdingForShareBasedCompensation."
+],
+"PaymentsToDevelopLiquefiedNaturalGasSites": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"PensionCostMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is PensionCostsMember."
+],
+"PercentageOfInterestBearingDomesticDepositLiabilitiesToDepositLiabilitiesDescription": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"PersonalLinesMember": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is PropertyAndCasualtyPersonalInsuranceProductLineMember."
+],
+"PhaseInPlanNetChangeInAmountOfCostsDeferredForRateMakingPurposesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"PolicyChargesInsurance": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is InsuranceCommissionsAndFees."
+],
+"PolicyholdersSurplusOfLifeInsuranceEntityMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are PolicyHoldersSurplus, DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferencePolicyHoldersSurplus, DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxablePolicyHoldersSurplus, DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityPolicyHoldersSurplus, and DeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticablePolicyHoldersSurplus."
+],
+"PostageExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is PostageExpense."
+],
+"PreOpeningCostsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is PreOpeningCosts."
+],
+"PreferredStockSubjectToMandatoryRedemptionMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is MandatorilyRedeemablePreferredStockMember."
+],
+"PremiumIncomeSubjectToParticipationThroughReinsurancePercentage": [
+"2013-01-31",
+"Element was deprecated."
+],
+"PremiumIncomeSubjectToParticipationThroughReinsuranceValue": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is AssumedPremiumsEarned."
+],
+"PremiumsEarnedNetAccidentAndHealthAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"PremiumsEarnedNetByProductSegmentAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"PremiumsEarnedNetFinancialGuaranteeInsuranceContractsAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"PremiumsEarnedNetLifeAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"PremiumsEarnedNetOtherInsuranceAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"PremiumsEarnedNetPropertyAndCasualtyAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"PremiumsNetLifeInsuranceInForce": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is LifeInsuranceInForceNet."
+],
+"PremiumsNetLifeInsuranceInForceAbstract": [
+"2014-01-31",
+"Element was deprecated."
+],
+"PremiumsReceivableAllowanceForDoubtfulAccountsProvisionChargedToExpense": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is PremiumsReceivableAllowanceForDoubtfulAccountsProvisionChargedToExpense1."
+],
+"PremiumsWrittenAssumedCededAndEarnedAndIndustryRatiosAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"PremiumsWrittenNetAccidentAndHealth": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PremiumsWrittenNet and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"PremiumsWrittenNetAccidentAndHealthAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"PremiumsWrittenNetFinancialGuaranteeInsuranceContracts": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PremiumsWrittenNet and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"PremiumsWrittenNetFinancialGuaranteeInsuranceContractsAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"PremiumsWrittenNetLife": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PremiumsWrittenNet and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"PremiumsWrittenNetLifeAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"PremiumsWrittenNetOtherInsurance": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PremiumsWrittenNet and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"PremiumsWrittenNetOtherInsuranceAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"PremiumsWrittenNetPropertyAndCasualty": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PremiumsWrittenNet and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+],
+"PremiumsWrittenNetPropertyAndCasualtyAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"PrepaidCongressionallyMandatedAssessments": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"PrepaidReinsurancePremiumsAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"PrepaidReinsurancePremiumsMethodologyAndAssumptions": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is NaturePurposeAndEffectOfReinsuranceTransactions."
+],
+"PresentValueOfFutureInsuranceProfits": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ValueOfBusinessAcquiredVOBA."
+],
+"PresentValueOfFutureInsuranceProfitsAmortizationExpense": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsAmortizationExpense1."
+],
+"PresentValueOfFutureInsuranceProfitsDecrease": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"PresentValueOfFutureInsuranceProfitsDecreases": [
+"2013-01-31",
+"Element was deprecated."
+],
+"PresentValueOfFutureInsuranceProfitsDecreasesAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"PresentValueOfFutureInsuranceProfitsImpairmentWriteDown": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsImpairmentWriteDown1."
+],
+"PresentValueOfFutureInsuranceProfitsIncreases": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"PresentValueOfFutureInsuranceProfitsIncreasesAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"PresentValueOfFutureInsuranceProfitsInterestAccrued": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsInterestAccrued1."
+],
+"PresentValueOfFutureInsuranceProfitsUnrealizedInvestmentGains": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsUnrealizedInvestmentGains1."
+],
+"PresentValueOfFutureInsuranceProfitsUnrealizedInvestmentLosses": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsUnrealizedInvestmentLosses1."
+],
+"PreviouslyEstimatedDevelopmentCostsIncurredDuringPeriod": [
+"2015-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is PreviouslyEstimatedDevelopmentCostsIncurred."
+],
+"ProceedsFromSaleOfOtherAssets": [
+"2013-01-31",
+"Element was deprecated because it was being used for either operating or investing activities. Possible replacements are ProceedsFromSaleOfOtherAssets1 and ProceedsFromSaleOfOtherAssetsInvestingActivities."
+],
+"ProceedsFromSaleOfWasteWaterSystems": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"ProceedsFromSaleOfWaterAndWasteWaterSystems": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"ProceedsFromSaleOfWaterAndWasteWaterSystemsAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"ProductLiabilityAccrualPeriodExpenseCaption": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProductLiabilityAccrualPeriodExpense and members of IncomeStatementLocationAxis."
+],
+"ProductRecallAxis": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"ProductRecallDomain": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"ProductionAndDistributionCostsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ProductionAndDistributionCosts."
+],
+"ProductionAndPropertyTaxExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ProductionTaxExpense or RealEstateTaxExpense."
+],
+"ProductionBarrelsOfOilEquivalents": [
+"2013-01-31",
+"Element was deprecated because it has a boeItemType attribute. Possible replacement is ProductionBarrelsOfOilEquivalents1."
+],
+"ProfessionalFeesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ProfessionalFees."
+],
+"ProjectWithExploratoryWellCostsCapitalizedForMoreThanOneYearNameDomain": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is ProjectMember."
+],
+"ProjectsWithExploratoryWellCostsCapitalizedForMoreThanOneYearByProjectAxis": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is CapitalizedCostsOfUnprovedPropertiesExcludedFromAmortizationByPropertyOrProjectAxis."
+],
+"PropertyPlantAndEquipmentNumberOfAirframesSold": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"PropertyPlantAndEquipmentScheduleOfSignificantAcquisitionsAndDisposalsTextBlock": [
+"2015-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are ScheduleOfBusinessAcquisitionsByAcquisitionTextBlock or ScheduleOfDisposalGroupsIncludingDiscontinuedOperationsIncomeStatementBalanceSheetAndAdditionalDisclosuresTextBlock."
+],
+"ProvedDevelopedReservesBOE": [
+"2013-01-31",
+"Element was deprecated because it has a boeItemType attribute. Possible replacement is ProvedDevelopedReservesBOE1."
+],
+"ProvedUndevelopedReserveBOE": [
+"2013-01-31",
+"Element was deprecated because it has a boeItemType attribute. Possible replacement is ProvedUndevelopedReserveBOE1."
+],
+"ProvisionForLossesOnOperatingAndOrDevelopmentPropertyMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"PublicUtilitiesDecommissioningContributionAmounts": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"PublicUtilitiesDisclosureOfImpactOfMergers": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"PublicUtilitiesPlantAndEquipmentDescriptionOfAcquisitionAdjustmentsAndRelatedAccumulatedDepreciation": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"PublicUtilitiesPropertyPlantAndEquipmentAmountOfDisallowedCostsForRecentlyCompletedPlantCostRecoveryPeriod": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"PublicUtilitiesPropertyPlantAndEquipmentCommonEstimatedUsefulLife": [
+"2013-01-31",
+"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentCommonUsefulLife."
+],
+"PublicUtilitiesPropertyPlantAndEquipmentDistributionEstimatedUsefulLife": [
+"2013-01-31",
+"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentDistributionUsefulLife."
+],
+"PublicUtilitiesPropertyPlantAndEquipmentEquipmentEstimatedUsefulLife": [
+"2013-01-31",
+"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentEquipmentUsefulLife."
+],
+"PublicUtilitiesPropertyPlantAndEquipmentFuelEstimatedUsefulLife": [
+"2013-01-31",
+"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentFuelUsefulLife."
+],
+"PublicUtilitiesPropertyPlantAndEquipmentGenerationEstimatedUsefulLife": [
+"2013-01-31",
+"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentGenerationUsefulLife."
+],
+"PublicUtilitiesPropertyPlantAndEquipmentOtherPropertyPlantAndEquipmentEstimatedUsefulLife": [
+"2013-01-31",
+"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentOtherPropertyPlantAndEquipmentUsefulLife."
+],
+"PublicUtilitiesPropertyPlantAndEquipmentTransmissionAndDistributionEstimatedUsefulLife": [
+"2013-01-31",
+"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentTransmissionAndDistributionUsefulLife."
+],
+"PublicUtilitiesPropertyPlantAndEquipmentTransmissionEstimatedUsefulLife": [
+"2013-01-31",
+"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentTransmissionUsefulLife."
+],
+"PublicUtilitiesPropertyPlantAndEquipmentVehiclesEstimatedUsefulLife": [
+"2013-01-31",
+"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentVehiclesUsefulLife."
+],
+"PublicUtilitiesRateOfReturnsBelowRateCase": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"PurchasePriceAllocationAdjustmentsMember": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"PurchasedCallOptionMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CallOptionMember with LongMember."
+],
+"PurchasedPutOptionMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PutOptionMember with LongMember."
+],
+"PutOptionsPurchasedMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PutOptionMember with LongMember."
+],
+"PutOptionsWrittenMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PutOptionMember with ShortMember."
+],
+"QualitativeAndQuantitativeInformationAssetOrLiabilityTransferorsContinuingInvolvementSecuritizationOrAssetbackedFinancingPrincipalAmountOutstandingContinuedRecognitionAmount": [
+"2014-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is SecuritizedAssetsAndAnyOtherFinancialAssetsManagedTogetherPrincipalAmountOutstanding."
+],
+"QualitativeAndQuantitativeInformationAssetOrLiabilityTransferorsContinuingInvolvementSecuritizationOrAssetbackedFinancingPrincipalAmountOutstandingDerecognizedAmount": [
+"2014-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is DerecognizedAssetsSecuritizedOrAssetbackedFinancingArrangementAssetsAndAnyOtherFinancialAssetsManagedTogetherPrincipalAmountOutstanding."
+],
+"QualitativeAndQuantitativeInformationAssetsOrLiabilitiesForTransferorsContinuingInvolvementInSecuritizationOrAssetbackedFinancingArrangementPrincipalAmountsOutstanding": [
+"2014-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is ContinuingInvolvementWithTransferredFinancialAssetsPrincipalAmountOutstanding."
+],
+"QualitativeAndQuantitativeInformationAssetsOrLiabilitiesForTransferorsContinuingInvolvementInSecuritizationOrAssetbackedFinancingArrangementSize": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"QuantitativeInformationAboutAssetQualityOfSecuritizedOrAssetbackedFinancingArrangementAssetsAndAnyOtherFinancialAssetsManagedTogetherTextBlock": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"RealEstateAccumulatedDepreciationDepreciationExpense": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is SECScheduleIIIRealEstateAccumulatedDepreciationDepreciationExpense."
+],
+"RealEstateAndAccumulatedDepreciationAccumulatedDepreciation": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is RealEstateAccumulatedDepreciation."
+],
+"RealEstateAndAccumulatedDepreciationCarryingAmountOfLandAndBuildingsAndImprovements": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is RealEstateGrossAtCarryingValue."
+],
+"RealEstateAndAccumulatedDepreciationDescriptionOfProperty": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are corresponding primary line items and members of StatementGeographicalAxis and MortgageLoansOnRealEstateDescriptionTypeOfPropertyAxis."
+],
+"RealEstateInsuranceMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is RealEstateInsurance."
+],
+"RealEstateOwnedAmountOfLossAtAcquisition": [
+"2013-01-31",
+"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is RealEstateOwnedAmountOfLossAtAcquisition1."
+],
+"RealEstateOwnedValuationAllowanceProvision": [
+"2014-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is RealEstateOwnedValuationAllowanceProvision1."
+],
+"RealEstateTaxesAndInsuranceMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is RealEstateTaxesAndInsurance."
+],
+"RealEstateTaxesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is RealEstateTaxExpense."
+],
+"RealEstateWriteDownOrReserveAmount": [
+"2013-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is SECScheduleIIIRealEstateWriteDownOrReserveAmount."
+],
+"RealEstateWriteDownOrReserveByPropertyAxis": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is RealEstateAndAccumulatedDepreciationDescriptionOfPropertyAxis."
+],
+"RealEstateWriteDownOrReservePropertyDomain": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is RealEstateAndAccumulatedDepreciationNameOfPropertyDomain."
+],
+"RealizedGainLossOnSaleOfInvestmentsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is RealizedInvestmentGainsLosses."
+],
+"RealizedLossesOnSaleOfInvestmentsMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is MarketableSecuritiesRealizedGainLoss."
+],
+"ReceivablesHeldForSaleNetAmount": [
+"2014-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are TradeAndLoansReceivablesHeldForSaleNetNotPartOfDisposalGroup or DisposalGroupIncludingDiscontinuedOperationAccountsNotesAndLoansReceivableNet."
+],
+"ReceivablesWithImputedInterestAmortizationDescription": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"ReclassificationFromAccumulatedOtherComprehensiveIncomeCurrentPeriodBeforeTaxAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"RecordedThirdPartyEnvironmentalRecoveriesCaption": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are RecordedThirdPartyEnvironmentalRecoveriesCurrent, RecordedThirdPartyEnvironmentalRecoveriesNoncurrent, and RecordedThirdPartyEnvironmentalRecoveriesNet and members of BalanceSheetLocationAxis."
+],
+"RecordedThirdPartyEnvironmentalRecoveriesComponents": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"RecordedUnconditionalPurchaseObligationDescription": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"RefinancingOfDebtMember": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"RefundsReceivedRelatedToRevenueFromDifferentYearMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+],
+"RegistrationPaymentArrangementBalanceSheetCaption": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is RegistrationPaymentArrangementAccrualCarryingValue and members of BalanceSheetLocationAxis."
+],
+"RegistrationPaymentArrangementGainsAndLossesClassification": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is RegistrationPaymentArrangementGainsAndLosses and members of IncomeStatementLocationAxis."
+],
+"RegulatoryCapitalDisclosuresForBusinessCombinations": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"RegulatoryCurrentLiabilityEndDateForRecovery": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"RegulatoryNoncurrentAssetAmortizationPeriod": [
+"2015-01-31",
+"Element was deprecated because it has a stringItemType attribute. Possible replacement is RegulatoryAssetAmortizationPeriod."
+],
+"RegulatoryNoncurrentLiabilityAmortizationPeriod": [
+"2015-01-31",
+"Element was deprecated because it has a stringItemType attribute. Possible replacement is RegulatoryLiabilityAmortizationPeriod."
+],
+"RegulatoryNoncurrentLiabilityEndDateForRecovery": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"ReinsuranceEffectOnClaimsAndBenefitsIncurredNetAmount": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is PolicyholderBenefitsAndClaimsIncurredNet."
+],
+"ReinsuranceEffectOnClaimsAndBenefitsIncurredNetAmountAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"ReinsuranceEffectOnClaimsAndBenefitsIncurredPoliciesAcquiredInPeriod": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is PolicyholderBenefitsAndClaimsIncurredGross."
+],
+"ReinsuranceEffectOnOperations": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is NaturePurposeAndEffectOfReinsuranceTransactions."
+],
+"ReinsuranceLiabilitiesMethodologiesAndAssumptions": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is NaturePurposeAndEffectOfReinsuranceTransactions."
+],
+"ReinsuranceLossOnUncollectibleAccountsInPeriodDescription": [
+"2013-01-31",
+"Element was deprecated due to remodeling of reinsurance topic area."
+],
+"ReinsuranceNote": [
+"2013-01-31",
+"Element was deprecated due to remodeling of reinsurance topic area."
+],
+"ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAmountAssumedFromOtherCompanies": [
+"2013-01-31",
+"Element was deprecated. Possible replacement is AssumedPremiumsEarned."
+],
+"ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAmountCededToOtherCompanies": [
+"2013-01-31",
+"Element was deprecated. Possible replacement is CededPremiumsEarned."
+],
+"ReinsurancePremiumsForInsuranceCompaniesByProductSegmentGrossAmount": [
+"2013-01-31",
+"Element was deprecated. Possible replacement is DirectPremiumsEarned."
+],
+"ReinsurancePremiumsForInsuranceCompaniesByProductSegmentNetAmount": [
+"2013-01-31",
+"Element was deprecated. Possible replacement is PremiumsEarnedNet."
+],
+"ReinsurancePremiumsForInsuranceCompaniesByProductSegmentPercentageOfAmountAssumedToNet": [
+"2013-01-31",
+"Element was deprecated. Possible replacement is PremiumsPercentageAssumedToNet."
+],
+"ReinsuranceRecoverablesPercentageOfTotal": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ConcentrationRiskPercentage1 with members of ConcentrationRiskByBenchmarkAxis and ConcentrationRiskByTypeAxis."
+],
+"ReinsurerOtherAssetsAndLiabilitiesAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"ReorganizationItemsDescriptionAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"ReorganizationItemsDescriptionOfDebtorInPossessionFacilityFinancingCosts": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"ReorganizationItemsDescriptionOfDischargeOfClaimsAndLiabilities": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"ReorganizationItemsDescriptionOfEmployeeRelatedCharges": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"ReorganizationItemsDescriptionOfGainLossOnRejectionOfLeasesAndOtherContractsNet": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"ReorganizationItemsDescriptionOfGainLossOnSettlementOfOtherClaimsNet": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"ReorganizationItemsDescriptionOfImpairmentLoss": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"ReorganizationItemsDescriptionOfInterestIncomeOnAccumulatedCash": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"ReorganizationItemsDescriptionOfLegalAndAdvisoryProfessionalFees": [
 "2015-01-31",
 "Element was deprecated because of low usage."
 ],
@@ -999,585 +5467,581 @@
 "2015-01-31",
 "Element was deprecated because of low usage."
 ],
-"ReinsuranceNote": [
-"2013-01-31",
-"Element was deprecated due to remodeling of reinsurance topic area."
-],
-"NoninterestExpenseRelatedToPerformanceFeesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpenseRelatedtoPerformanceFees."
-],
-"AccumulatedDepreciationDepletionAndAmortizationSaleOfPropertyPlantAndEquipment": [
-"2015-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is AccumulatedDepreciationDepletionAndAmortizationSaleOfPropertyPlantAndEquipment1."
-],
-"BusinessAcquisitionPurchasePriceAllocationDeferredTaxAssetsNoncurrent": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"ReorganizationItemsDescriptionAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"AccumulatedOtherComprehensiveIncomeLossNetOfTaxRollForward": [
-"2015-01-31",
-"Element was deprecated."
-],
-"PresentValueOfFutureInsuranceProfitsUnrealizedInvestmentGains": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsUnrealizedInvestmentGains1."
-],
-"BusinessAcquisitionPurchasePriceAllocationAmortizableIntangibleAssets": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CategoriesOfInvestmentsMarketableSecuritiesTradingSecuritiesMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TradingAccountAssetsMember."
-],
-"TypeOfDeferredCompensationDomain": [
-"2014-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacements are DeferredBonusAndProfitSharingArrangementIndividualContractTypeOfDeferredCompensationDomain, OtherPostretirementBenefitsIndividualContractsTypeOfDeferredCompensationDomain, or EquityBasedArrangementsIndividualContractsTypeOfDeferredCompensationDomain."
-],
-"AverageBalanceDuringPeriodOfLoansHeldForSaleOrSecuritization": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DefinedContributionPensionMember": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is PensionPlansDefinedBenefitMember."
-],
-"SuppliesAndPostageExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is SuppliesAndPostageExpense."
-],
-"ImpairmentInValueOfAssetAxis": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"BusinessAcquisitionPreacquisitionContingencyAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"NotionalAmountOfInterestRateDerivativeInstrumentsNotDesignatedAsHedgingInstruments": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and HedgingDesignationAxis."
-],
-"DisposalGroupIncludingDiscontinuedOperationLongLivedAssetsAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"BusinessAcquisitionPurchasePriceAllocationPlant": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FinancingReceivableInformationByPortfolioSegmentAxis": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is FinancingReceivableRecordedInvestmentByClassOfFinancingReceivableAxis."
-],
-"FairValueAssetsMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInInvestmentIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueAssetsMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
-],
-"LiabilitiesSubjectToCompromiseDescriptionOfAsbestosObligations": [
+"ReorganizationItemsDescriptionOfNondebtorReorganizationItemsGainLossOnSettlementOfOtherClaimsNet": [
 "2015-01-31",
 "Element was deprecated because of low usage."
 ],
-"SecuritiesSoldNotYetPurchasedOffBalanceSheetRisk": [
+"ReorganizationItemsDescriptionOfNondebtorReorganizationItemsLegalAndAdvisoryProfessionalFees": [
 "2015-01-31",
 "Element was deprecated because of low usage."
-],
-"BusinessAcquisitionPreexistingRelationshipGainLossRecognized": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is BusinessCombinationSeparatelyRecognizedTransactionsNetGainsAndLosses and members of BusinessCombinationSeparatelyRecognizedTransactionsAxis."
-],
-"DeferredCompensationArrangementWithIndividualShareBasedPaymentsByTitleOfIndividualAxis": [
-"2013-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is TitleofIndividualAxis."
-],
-"AvailableForSaleSecuritiesDebtMaturitiesAmortizedCost": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AvailableForSaleDebtSecuritiesAmortizedCostBasis."
-],
-"CompensatingBalancesCashAndCashEquivalentsAxis": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is CashAndCashEquivalentsAxis."
-],
-"AssetsOfDisposalGroupIncludingDiscontinuedOperationNoncurrent": [
-"2014-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacement is DisposalGroupIncludingDiscontinuedOperationAssetsNoncurrent."
-],
-"DividendIncomeMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is InvestmentIncomeDividend."
-],
-"DiscontinuedOperationNatureOfOtherIncomeLossFromDispositionOfDiscontinuedOperation": [
-"2015-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"IncreaseDecreaseInTimeDepositsForeign": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"CertainLoansAcquiredInTransferAccountedForAsHeldToMaturityDebtSecuritiesOtherThanTemporaryImpairmentCharges": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsHeldtomaturityDebtSecuritiesOtherthanTemporaryImpairmentChargesCreditLoss."
-],
-"FinancialGuaranteeInsuranceContractsPremiumReceivedOverContractPeriodUnearnedPremiumRevenueIfNotPresentedSeparatelyFinancialStatementCaption": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FinancialGuaranteeInsuranceContractsPremiumReceivedOverContractPeriodUnearnedPremiumRevenue and members of IncomeStatementLocationAxis."
-],
-"AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionMethodOfDisposal": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are members of DisposalGroupClassificationAxis."
-],
-"AssetManagementMember": [
-"2013-01-31",
-"Element was deprecated due to rationalization of dimensions."
-],
-"GainLossOnDispositionOfOtherAssetsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnSaleOfOtherAssets."
-],
-"BusinessAcquisitionPurchasePriceAllocationAssetsAcquired": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"RefinancingOfDebtMember": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"NetAmountAtRiskByProductAndGuaranteeSubcategory": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are the children of NetAmountAtRiskByProductAndGuaranteeLineItems and members of GuaranteedInsuranceContractTypeOfGuaranteeAxis."
-],
-"BusinessCombinationAssetsAndLiabilitiesArisingFromContingenciesNoAmountRecognized": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAmountCededToOtherCompanies": [
-"2013-01-31",
-"Element was deprecated. Possible replacement is CededPremiumsEarned."
-],
-"EntityWideDisclosureOnGeographicAreasRevenueFromExternalCustomersAttributedToEntitysCountryOfDomicile": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Possible replacement is Revenues and members of StatementGeographicalAxis."
-],
-"RevenueFromAdministrativeServicesOther": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AdministrativeServicesRevenue and members of LegalEntityAxis."
-],
-"NetIncomeLossPerOutstandingGeneralPartnershipUnit": [
-"2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is NetIncomeLossPerOutstandingGeneralPartnershipUnitNetOfTax."
-],
-"RevenueFromAdministrativeServicesAffiliated": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AdministrativeServicesRevenue and members of LegalEntityAxis."
-],
-"RevenuesFromExternalCustomers": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Possible replacement is Revenues and members of ProductOrServiceAxis or MajorCustomersAxis."
-],
-"ResidentialPrimeFinancingReceivableMember": [
-"2015-01-31",
-"Element was deprecated due to remodeling of topic area. Possible replacements are PrimeMember and ResidentialPortfolioSegmentMember."
-],
-"PolicyChargesInsurance": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is InsuranceCommissionsAndFees."
-],
-"RevenueRecognitionNewAccountingPronouncementMaterialEffectRevenueRecognizedUnderAmendedGuidance": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LeveragedBuyoutOptionCostPreviouslyRecognized": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DebtInstrumentCommitteeForUniformSecuritiesIdentificationProceduresCUSIP": [
-"2013-01-31",
-"Element was deprecated because it is has a stringItemType attribute. Possible replacement is CommitteeForUniformSecuritiesIdentificationProceduresCUSIP."
-],
-"LeveragedBuyoutCostOfTransactionChargedToExpense": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"ResidentialSubprimeFinancingReceivableMember": [
-"2015-01-31",
-"Element was deprecated due to remodeling of topic area. Possible replacements are SubprimeMember and ResidentialPortfolioSegmentMember."
-],
-"LiabilitiesForGuaranteesOnLongDurationContractsGuaranteeTypeAxis": [
-"2015-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are GuaranteedInsuranceContractTypeOfBenefitAxis or GuaranteedInsuranceContractTypeOfGuaranteeAxis."
-],
-"BusinessCombinationSeparatelyRecognizedTransactionsExpensesAndLossesFinancialStatementCaption": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is BusinessCombinationSeparatelyRecognizedTransactionsExpensesAndLossesRecognized and members of IncomeStatementLocationAxis."
-],
-"NetInvestmentIncomeInsuranceEntityMortgageLoansOnRealEstate": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NetInvestmentIncome and members of InvestmentTypeAxis."
-],
-"GainLossOnSaleOfInterestInProjectsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"PaymentAndPerformanceRiskCreditRatingAxis": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are CreditRatingAMBestAxis, CreditRatingMoodysAxis, CreditRatingStandardPoorsAxis, CreditRatingFitchAxis, ExternalCreditRatingByGroupingAxis, InternalCreditAssessmentAxis."
-],
-"IncreaseDecreaseInRetainedInterestInSecuritizedReceivables": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"LiabilitiesSubjectToCompromiseIncomeTaxContingenciesDescription": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"DistributionMadeToMemberOrLimitedPartnerDateOfRecord1": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberDateOfRecord or DistributionMadeToLimitedPartnerDateOfRecord."
-],
-"AssetsHeldForSalePropertyPlantAndEquipment": [
-"2014-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacements are DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipmentNoncurrent, DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipmentCurrent or DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipment."
-],
-"ReinsurancePremiumsForInsuranceCompaniesByProductSegmentPercentageOfAmountAssumedToNet": [
-"2013-01-31",
-"Element was deprecated. Possible replacement is PremiumsPercentageAssumedToNet."
-],
-"DistributionMadeToMemberOrLimitedPartnerShareDistribution": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberUnitDistribution or DistributionMadeToLimitedPartnerUnitDistribution."
-],
-"PremiumsWrittenNetFinancialGuaranteeInsuranceContracts": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PremiumsWrittenNet and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"PersonalLinesMember": [
-"2013-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is PropertyAndCasualtyPersonalInsuranceProductLineMember."
-],
-"FinancingReceivableRecordedInvestmentEqualToGreaterThan90DaysPastDue": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FinancingReceivableRecordedInvestmentPastDue and FinancingReceivablesEqualToGreaterThan90DaysPastDueMember."
-],
-"CededPremiumsEarnedOtherInsurance": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsFinishedGoods": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"RealizedGainLossOnSaleOfInvestmentsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is RealizedInvestmentGainsLosses."
-],
-"ContractHolderReceivables": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is PremiumsReceivableGross."
-],
-"LoansHeldForSaleMortgages": [
-"2015-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacement is LoansReceivableHeldForSaleNetNotPartOfDisposalGroupMortgage."
-],
-"HeldToMaturitySecuritiesContinuousUnrealizedLossPositionAggregateLosses": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is HeldToMaturitySecuritiesContinuousUnrealizedLossPositionAggregateLoss."
-],
-"BankruptcyProceedingsDescriptionOfManagementForEntitiesInBankruptcy": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"SubsequentEventDateFinancialStatementsIssued1": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"GainLossOnDispositionOfProperty": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is GainLossOnDispositionOfAssets."
-],
-"EffectOfChangeInCashFlowProjectionEstimate": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseReportedClaimsCommentary": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilityForClaimsAndClaimsAdjustmentExpenseMethodologiesAndAssumptions."
-],
-"ComponentOfOtherIncomeNonoperatingAxis": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"SecuritiesSoldNotYetPurchasedFairValueDisclosure": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is FinancialInstrumentsSoldNotYetPurchasedAtFairValue."
-],
-"AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionLineItems": [
-"2015-01-31",
-"Element was deprecated."
-],
-"DisposalGroupIncludingDiscontinuedOperationStatusOfDisposalGroupAtLatestBalanceSheetDate": [
-"2015-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacement is DisposalGroupIncludingDiscontinuedOperationDescriptionAndTimingOfDisposal."
-],
-"BadDebtReserveForTaxPurposesOfUSSavingsAndLoanAssociationsOrOtherQualifiedThriftLenderMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are BadDebtReserveForTaxPurposesOfQualifiedLender, DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferenceBadDebtReserveForTaxPurposesOfQualifiedLender, DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxableBadDebtReserveForTaxPurposesOfQualifiedLender, DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityBadDebtReserveForTaxPurposesOfQualifiedLender,  and DeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticableBadDebtReserveForTaxPurposesOfQualifiedLender."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentLiabilitiesAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"SaleDomain": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"DiscontinuedOperationAmountOfOtherIncomeLossFromDispositionOfDiscontinuedOperationNetOfTax": [
-"2015-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"FairValueAssetsMeasuredOnRecurringBasisGainLossIncludedInEarningsAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"AccountingStandardsUpdate200915Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"ExpropriationOfAssetsDomain": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"NotionalAmountOfPriceRiskCashFlowHedgeDerivatives": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis and DerivativeInstrumentRiskAxis."
-],
-"LongDurationContractsAssumptionsByProductAndGuaranteeDiscountRateLowEnd": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LongDurationContractsAssumptionsByProductAndGuaranteeDiscountRate, RangeAxis and MinimumMember."
-],
-"TaxBenefitFromStockOptionsExercised1": [
-"2013-01-31",
-"Element was deprecated because it was incorrectly defined. Possible replacement is DeferredTaxExpenseFromStockOptionsExercised."
-],
-"AmortizationOfDeferredSalesCommissionsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"FinancingReceivableModificationsPreModificationRecordedInvestment1": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is FinancingReceivableModificationsPreModificationRecordedInvestment2."
-],
-"NotionalAmountOfPriceRiskFairValueHedgeDerivatives": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
-],
-"BusinessAcquisitionCostOfAcquiredEntityCashPaid": [
-"2013-01-31",
-"Element was deprecated because it has debit balance and instant period type attributes. Possible replacement is PaymentsToAcquireBusinessesGross."
-],
-"CededPremiumsEarnedLife": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"EnvironmentalRemediationExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is EnvironmentalRemediationExpense."
-],
-"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReserves10PercentAnnualDiscountForEstimatedTimingOfCashFlows": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesTenPercentAnnualDiscountForEstimatedTimingOfCashFlows."
-],
-"TaxesAndLicensesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is TaxesAndLicenses."
-],
-"AssumedPremiumsEarnedAccidentAndHealth": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"DistributionPaymentFormsOtherThanCashOrStockDescription": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionPaymentMadeToLimitedLiabilityCompanyLLCMemberFormsOtherThanCashOrStockDescription or DistributionPaymentMadeToLimitedPartnerFormsOtherThanCashOrStockDescription."
-],
-"CorporateCreditQualityIndicatorMember": [
-"2013-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is InternalCreditAssessmentDomain."
-],
-"CededCreditRiskAmountAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"FairValueByBalanceSheetGroupingDisclosureItemAmountsAxis": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is FairValueByMeasurementBasisAxis."
-],
-"InternallyAssignedGradeMember": [
-"2013-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is InternalCreditAssessmentDomain."
-],
-"HeldToMaturitySecuritiesDebtMaturitiesFairValue": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is HeldToMaturitySecuritiesFairValue."
-],
-"DescriptionOfLocationOfPriceRiskCashFlowHedgeDerivativesOnBalanceSheet": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are PriceRiskCashFlowHedgeAssetAtFairValue and PriceRiskCashFlowHedgeLiabilityAtFairValue and members of BalanceSheetLocationAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsInventoryAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"RegulatoryCurrentLiabilityEndDateForRecovery": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisGainLossIncludedInInvestmentIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisInstrumentsClassifiedInShareholdersEquityGainLossIncludedInEarnings and members of IncomeStatementLocationAxis."
-],
-"IncreaseDecreaseInFairValueOfUnhedgedDerivativeInstruments": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DerivativeInstrumentsNotDesignatedAsHedgingInstrumentsGainLossNet."
-],
-"OtherTaxCarryforwardTable": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TaxCreditCarryforwardTable."
-],
-"LoanProcessingFeeMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is LoanProcessingFee."
-],
-"CategoriesOfInvestmentsMarketableSecuritiesHeldToMaturitySecuritiesMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is HeldtomaturitySecuritiesMember."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseClaimsPaidPriorYears": [
-"2014-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseClaimsPaidPriorYears1."
-],
-"DevelopmentStageEnterpriseGeneralDisclosuresTextBlock": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"TradeReceivablesHeldForSaleNet": [
-"2015-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacement is TradeReceivablesHeldForSaleNetNotPartOfDisposalGroup."
-],
-"SignificantAcquisitionsAndDisposalsLineItems": [
-"2015-01-31",
-"Element was deprecated."
-],
-"CashFlowHedgeGainLossReclassifiedToInvestmentIncomeNet": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is InvestmentIncomeNet and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"IssuanceOfDebtMember": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"ShareholderLoansToFinanceLeveragedBuyout": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"PublicUtilitiesPropertyPlantAndEquipmentDistributionEstimatedUsefulLife": [
-"2013-01-31",
-"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentDistributionUsefulLife."
-],
-"BusinessAcquisitionPurchasePriceAllocationNotesPayableAndLongTermDebt": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"ImpactOfForeignCurrencyDerivativesOnEarningsIsImmaterial": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"UndistributedDomesticEarningsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are UndistributedEarningsOfDomesticSubsidiaries, DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferenceUndistributedEarningsOfDomesticSubsidiaries, DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxableUndistributedEarningsOfDomesticSubsidiaries, DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityUndistributedEarningsOfDomesticSubsidiaries, or DeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticableUndistributedEarningsOfDomesticSubsidiaries."
-],
-"DerivativeInstrumentsLossRecognizedInIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeLossOnDerivative and members of HedgingDesignationAxis."
 ],
 "ReorganizationItemsDescriptionOfOtherReorganizationItems": [
 "2015-01-31",
 "Element was deprecated because of low usage."
 ],
-"BusinessInterruptionInsuranceRecoveryStatementOfIncomeLineItems": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is GainOnBusinessInterruptionInsuranceRecovery and members of IncomeStatementLocationAxis."
+"ReorganizationItemsDescriptionOfPensionAndOtherPostretirementPlansRelatedCharges": [
+"2015-01-31",
+"Element was deprecated because of low usage."
 ],
-"BusinessAcquisitionPurchasePriceAllocationNegativeGoodwillDescription": [
+"ReorganizationItemsDescriptionOfProvisionForExpectedAllowedClaims": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"ReorganizationItemsDescriptionOfRetireeRelatedCharges": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"ReorganizationItemsDescriptionOfRevaluationOfAssetsAndLiabilitiesUponEmergenceFromBankruptcy": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"ReorganizationItemsDescriptionOfRevaluationOfCustomerRelatedObligations": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"ReorganizationItemsDescriptionOfWriteOffOfDeferredFinancingCostsAndDebtDiscounts": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"ReorganizationItemsDisclosuresAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"RepaymentOfDebtMember": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"RepaymentsOfSecuredTaxExemptDebt": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"ReportableSegmentsMember": [
+"2013-01-31",
+"Element was deprecated due to remodeling of Segment area. Create member element to identify specific segment."
+],
+"ReportingEntityMember": [
+"2014-01-31",
+"Element was deprecated because it is an invalid concept."
+],
+"RepurchaseOfEquityMember": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"ResaleAgreementsInterestIncomeAmount": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"ResearchAndDevelopmentAssetAcquiredOtherThanThroughBusinessCombinationWrittenOffIncomeStatementCaption": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ResearchAndDevelopmentAssetAcquiredOtherThanThroughBusinessCombinationWrittenOff and members of IncomeStatementLocationAxis."
+],
+"ReserveForLossesAndLossAdjustmentExpenses": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is LiabilityForClaimsAndClaimsAdjustmentExpense."
+],
+"ResidentialPrimeFinancingReceivableMember": [
+"2015-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacements are PrimeMember and ResidentialPortfolioSegmentMember."
+],
+"ResidentialSubprimeFinancingReceivableMember": [
+"2015-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacements are SubprimeMember and ResidentialPortfolioSegmentMember."
+],
+"RestructuringAndRelatedCostCostIncurredToDate": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is RestructuringAndRelatedCostCostIncurredToDate1."
+],
+"RestructuringAndRelatedCostExpectedCost": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is RestructuringAndRelatedCostExpectedCost1."
+],
+"RestructuringAndRelatedCostExpectedCostRemaining": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is RestructuringAndRelatedCostExpectedCostRemaining1."
+],
+"RestructuringReserveSettledWithCash": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is PaymentsForRestructuring."
+],
+"RestructuringReserveSettledWithoutCash": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is RestructuringReserveSettledWithoutCash1."
+],
+"RetailLandSalesDepositMethodSalesContractDisclosure": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"RetailLandSalesDepositMethodTermsOfSale": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"RetirementOfTangibleAssetsOtherDescriptors": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"RevenueFromAdministrativeServices": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AdministrativeServicesRevenue and members of LegalEntityAxis."
+],
+"RevenueFromAdministrativeServicesAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"RevenueFromAdministrativeServicesAffiliated": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AdministrativeServicesRevenue and members of LegalEntityAxis."
+],
+"RevenueFromAdministrativeServicesOther": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AdministrativeServicesRevenue and members of LegalEntityAxis."
+],
+"RevenueFromFranchisedOutlets": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is FranchiseRevenue."
+],
+"RevenueRecognitionNewAccountingPronouncementAllocation": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"RevenueRecognitionNewAccountingPronouncementMaterialEffectRevenueDeferredUnderAmendedGuidance": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"RevenueRecognitionNewAccountingPronouncementMaterialEffectRevenueRecognizedUnderAmendedGuidance": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"RevenueRecognitionNewAccountingPronouncementRevenueRecognizedUnderPriorGuidance": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"RevenueRecognitionNewAccountingPronouncementUnitOfAccounting": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"RevenuesFromExternalCustomers": [
+"2013-01-31",
+"Element was deprecated due to remodeling of Segment area. Possible replacement is Revenues and members of ProductOrServiceAxis or MajorCustomersAxis."
+],
+"RevenuesFromTransactionsWithOtherOperatingSegmentsOfSameEntity": [
+"2013-01-31",
+"Element was deprecated due to remodeling of Segment area. Possible replacement is Revenues and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
+],
+"RevolvingLoanFacilityToFinanceLeveragedBuyout": [
 "2013-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"RoyaltyPaymentsExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is RoyaltyExpense."
+],
+"SFAS141RElementsIncrementalToSFAS141Abstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"SaleAxis": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"SaleDomain": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"SaleLeasebackTransactionGrossProceeds": [
+"2014-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are SaleLeasebackTransactionGrossProceedsInvestingActivities or SaleLeasebackTransactionGrossProceedsFinancingActivities."
+],
+"SaleLeasebackTransactionNetProceeds": [
+"2014-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are SaleLeasebackTransactionNetProceedsInvestingActivities or SaleLeasebackTransactionNetProceedsFinancingActivities."
+],
+"SaleLeasebackTransactionRelatedPartyTransaction": [
+"2013-01-31",
+"Element was deprecated due to redundancy.  Possible replacement is RelatedPartyTransactionDescriptionOfTransaction."
+],
+"SaleOfStockReasonForOmittingDeferredIncomeTaxProvisionOnGainLossRecognized": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"SaleOfStockSubsidiary": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is SubsidiariesMember."
+],
+"SalesCommissionsAndFeesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is SalesCommissionsAndFees."
+],
+"SalesOfEquityToFinanceLeveragedBuyout": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"SalesRevenueGoodsNetPercentage": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ConcentrationRiskPercentage1 and members of ConcentrationRiskByBenchmarkAxis."
+],
+"ScheduleOfAssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionTable": [
+"2015-01-31",
+"Element deprecated due to redundancy. Possible replacement is IncomeStatementBalanceSheetAndAdditionalDisclosuresByDisposalGroupsIncludingDiscontinuedOperationsTable."
+],
+"ScheduleOfCalculationOfNumeratorAndDenominatorInEarningsPerShareTableTextBlock": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ScheduleOfEarningsPerShareBasicAndDilutedTableTextBlock."
+],
+"ScheduleOfClosedBlockSummarizedFinancialData": [
+"2013-01-31",
+"Element was deprecated."
+],
+"ScheduleOfCostMethodInvestmentsAxis": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is MajorTypesOfDebtAndEquitySecuritiesAxis."
+],
+"ScheduleOfDistributionsMadeToMemberOrLimitedPartnerTable": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacement is DistributionsMadeToLimitedLiabilityCompanyLLCMemberTable or DistributionsMadeToLimitedPartnerTable."
+],
+"ScheduleOfDistributionsMadeToMembersOrLimitedPartnersByDistributionTextBlock": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacement is  DistributionsMadeToLimitedLiabilityCompanyLlcMemberByDistributionTableTextBlock or DistributionsMadeToLimitedPartnerByDistributionTableTextBlock."
+],
+"ScheduleOfEarningsPerShareReconciliationTableTextBlock": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ScheduleOfEarningsPerShareBasicAndDilutedTableTextBlock."
+],
+"ScheduleOfEffectsOfChangesInPrepaymentEstimateAssumptionsForCollateralizedMortgageObligationsAndRealEstateMortgageInvestmentConduitsTextBlock": [
+"2013-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"ScheduleOfEmployeeServiceShareBasedCompensationAllocationOfRecognizedPeriodCostsByReportLineAxis": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is IncomeStatementLocationAxis."
+],
+"ScheduleOfExpectedAmortizationExpenseTableTextBlock": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ScheduleofFiniteLivedIntangibleAssetsFutureAmortizationExpenseTableTextBlock."
+],
+"ScheduleOfInvestmentIncomeReportedAmountsByCategoryAxis": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is InvestmentTypeAxis."
+],
+"ScheduleOfLongLivedAssetsToBeAbandonedTable": [
+"2015-01-31",
+"Element deprecated due to redundancy. Possible replacement is IncomeStatementBalanceSheetAndAdditionalDisclosuresByDisposalGroupsIncludingDiscontinuedOperationsTable."
+],
+"ScheduleOfPurchasePriceAllocationTableTextBlock": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"ScheduleOfSignificantAcquisitionsAndDisposalsTable": [
+"2015-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are ScheduleOfBusinessAcquisitionsByAcquisitionTable or IncomeStatementBalanceSheetAndAdditionalDisclosuresByDisposalGroupsIncludingDiscontinuedOperationsTable."
+],
+"ScheduleofLevelThreeDefinedBenefitPlanAssetsRollForwardTableTextBlock": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ScheduleOfEffectOfSignificantUnobservableInputsChangesInPlanAssetsTableTextBlock."
+],
+"SecuritiesOwnedAndSoldNotYetPurchasedAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"SecuritiesSoldNotYetPurchasedFairValueDisclosure": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is FinancialInstrumentsSoldNotYetPurchasedAtFairValue."
+],
+"SecuritiesSoldNotYetPurchasedOffBalanceSheetRisk": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"SecuritizedAssetsAndAnyOtherFinancialAssetsManagedTogetherAverageBalanceDuringPeriod": [
+"2014-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"SecuritizedAssetsAndAnyOtherFinancialAssetsManagedTogetherByTypeOfFinancialInstrumentAxis": [
+"2014-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is FinancialInstrumentAxis."
 ],
 "SegmentGeographicalGroupsOfCountriesGroupOneMember": [
 "2013-01-31",
 "Element deprecated because it was inappropriately modeled."
 ],
-"SignificantMattersUnresolvedSinceBankruptcyEmergenceProcessForResolutionOfRemainingClaims": [
-"2015-01-31",
-"Element was deprecated and replaced with a more encompassing element. Possible replacement is SignificantMattersUnresolvedSinceBankruptcyEmergence."
-],
-"FinancialGuaranteeInsuranceContractsPremiumReceivedOverContractPeriodPremiumReceivableAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"MalpracticeInsuranceCountryOfCaptiveInsurer": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"FairValueEstimateNotPracticableReasonsAccountsReceivable": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
-],
-"LiquidityDisclosureSufficientCashAndWaiversNote": [
-"2015-01-31",
-"Element was deprecated due to issuance of new guidance. Possible replacements are SubstantialDoubtAboutGoingConcernManagementsPlansSubstantialDoubtAlleviated or SubstantialDoubtAboutGoingConcernManagementsPlansSubstantialDoubtNotAlleviated."
-],
-"PutOptionsPurchasedMember": [
+"SegmentGeographicalGroupsOfCountriesGroupTwoMember": [
 "2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PutOptionMember with LongMember."
+"Element deprecated because it was inappropriately modeled."
+],
+"SegmentReportingInformationAverageAssets": [
+"2013-01-31",
+"Element was deprecated due to remodeling of Segment area. Possible replacement is Assets and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
+],
+"SegmentReportingInformationInventoryNet": [
+"2013-01-31",
+"Element was deprecated due to remodeling of Segment area. Possible replacement is corresponding primary line items and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
+],
+"SegmentReportingInformationInvestments": [
+"2013-01-31",
+"Element was deprecated due to remodeling of Segment area. Possible replacement is corresponding primary line items and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
+],
+"SegmentReportingInformationNetAssets": [
+"2013-01-31",
+"Element was deprecated due to remodeling of Segment area. Possible replacement is corresponding primary line items and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
+],
+"SegmentReportingInformationRevenue": [
+"2013-01-31",
+"Element was deprecated due to remodeling of Segment area. Possible replacement is Revenues and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
+],
+"SellingExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is SellingExpense."
+],
+"ServicingAssetAtAmortizedValueChangesInCarryingAmountLocationInIncomeStatementDescription": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ServicingAssetAtAmortizedValue and members of IncomeStatementLocationAxis."
+],
+"ServicingAssetAtAmortizedValueOtherThanTemporaryImpairments": [
+"2013-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is ServicingAssetAtAmortizedCostOtherThanTemporaryImpairments."
+],
+"ServicingAssetAtFairValueChangesInFairValueLocationInIncomeStatementDescription": [
+"2014-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionGainLossOnDisposition1 and members of IncomeStatementLocationAxis."
+],
+"ServicingLiabilityAtAmortizedValueAmortization": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance type. Possible replacement is ServicingLiabilityAtAmortizedCostAmortization."
+],
+"ServicingLiabilityAtAmortizedValueByTypesOfFinancialAssetsAxis": [
+"2013-01-31",
+"Element was deprecated due to rationalization of dimensions. Possible replacement is FinancialInstrumentAxis."
+],
+"ServicingLiabilityAtAmortizedValueIncreaseInObligation1": [
+"2015-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is ServicingLiabilityAtAmortizedCostOtherIncreaseDecreaseInObligation."
+],
+"SettlementOfDebtMember": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
 ],
 "SeveranceCosts": [
 "2013-01-31",
 "Element was deprecated due to remodeling of topic area. Possible replacement is SeveranceCosts1."
 ],
-"FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisGainLossIncludedInEarningsAbstract": [
+"ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsPeriodIncreaseDecreaseIntrinsicValue": [
 "2013-01-31",
-"Element was deprecated."
+"Element was deprecated due to rationalization."
 ],
-"DescriptionOfLocationOfGainLossOnForeignCurrencyFairValueHedgeDerivativeInFinancialStatements": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is GainLossOnForeignCurrencyFairValueHedgeDerivatives and members of IncomeStatementLocationAxis."
+"ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsTotalShareBasedLiabilitiesPaid": [
+"2014-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsShareBasedLiabilitiesPaid."
 ],
-"FinancialGuaranteeInsuranceContractsRiskManagementActivitiesMitigatingClaimLiabilitiesAccruedLiabilitiesFinancialStatementCaption": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FinancialGuaranteeInsuranceContractsRiskManagementActivitiesMitigatingClaimLiabilitiesAccruedLiabilities and members of BalanceSheetLocationAxis."
+"ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsWeightedAverageGrantDateFairValuePeriodIncreaseDecrease": [
+"2013-01-31",
+"Element was deprecated due to rationalization."
 ],
-"LeveragedBuyoutPercentageOfPurchasePriceAllocatedToAssetsAndLiabilitiesAcquiredAtFairValue": [
+"ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsVestedInPeriodFairValue": [
+"2013-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsVestedInPeriodFairValue1."
+],
+"ShareBasedGoodsAndNonemployeeServicesTransactionCashFlowEffects": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is IssuanceOfStockAndWarrantsForServicesOrClaims."
+],
+"ShareBasedGoodsAndNonemployeeServicesTransactionExpense": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is IssuanceOfStockAndWarrantsForServicesOrClaims."
+],
+"ShareholderLoansToFinanceLeveragedBuyout": [
 "2013-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"ComponentOfOtherIncomeNonoperatingTable": [
+"SharesSubjectToMandatoryRedemptionSettlementTermsForwardPriceOrOptionStrikePrice": [
+"2014-01-31",
+"Element was deprecated because it has a perUnitItemType attribute, it represents multiple distinct concepts and the financial reporting concept can be conveyed dimensionally. Possible replacements are OptionIndexedToIssuersEquityStrikePrice1 or ForwardContractIndexedToIssuersEquityForwardRate and members of ScheduleOfSharesSubjectToMandatoryRedemptionBySettlementTermsAxis."
+],
+"ShippingHandlingAndTransportationCostsMember": [
 "2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ShippingHandlingandTransportationCosts."
 ],
-"CertainLoansAcquiredInTransferAccountedForAsAvailableForSaleDebtSecuritiesAccretableYieldPeriodIncreaseDecrease": [
+"SignificantAcquisitionsAndDisposalsAcquisitionCostsOrSaleProceeds": [
 "2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesAccretableYieldPeriodIncreaseDecrease and members of InformationByCategoryOfDebtSecurityAxis."
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DisposalGroupIncludingDiscontinuedOperationConsideration or BusinessCombinationConsiderationTransferredIncludingEquityInterestInAcquireeHeldPriorToCombination1."
 ],
-"PropertyPlantAndEquipmentScheduleOfSignificantAcquisitionsAndDisposalsTextBlock": [
+"SignificantAcquisitionsAndDisposalsByTransactionAxis": [
 "2015-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are ScheduleOfBusinessAcquisitionsByAcquisitionTextBlock or ScheduleOfDisposalGroupsIncludingDiscontinuedOperationsIncomeStatementBalanceSheetAndAdditionalDisclosuresTextBlock."
+"Element deprecated due to redundancy. Possible replacement is PropertyPlantAndEquipmentByTypeAxis."
 ],
-"MortgageLoansOnRealEstateFederalIncomeTaxBasis": [
+"SignificantAcquisitionsAndDisposalsDateOfTransactionForAcquisitionsOrDisposals": [
+"2015-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are BusinessAcquisitionDateOfAcquisitionAgreement1, BusinessAcquisitionEffectiveDateOfAcquisition1 or DisposalDate1."
+],
+"SignificantAcquisitionsAndDisposalsDescription": [
+"2015-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacement is DisposalGroupIncludingDiscontinuedOperationDescriptionAndTimingOfDisposal."
+],
+"SignificantAcquisitionsAndDisposalsGainLossOnSaleOrDisposalNetOfTax": [
+"2015-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is DiscontinuedOperationGainLossOnDisposalOfDiscontinuedOperationNetOfTax."
+],
+"SignificantAcquisitionsAndDisposalsGainLossOnSaleOrDisposalPretax": [
+"2015-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacements are DiscontinuedOperationGainLossFromDisposalOfDiscontinuedOperationBeforeIncomeTax or DisposalGroupNotDiscontinuedOperationGainLossOnDisposal."
+],
+"SignificantAcquisitionsAndDisposalsLineItems": [
+"2015-01-31",
+"Element was deprecated."
+],
+"SignificantAcquisitionsAndDisposalsRestrictionOnAmountOfProceedsFromDonatedPropertyPlantAndEquipment": [
+"2015-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"SignificantAcquisitionsAndDisposalsTerms": [
+"2015-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"SignificantAcquisitionsAndDisposalsTransactionDomain": [
+"2015-01-31",
+"Element deprecated due to redundancy. Possible replacement is PropertyPlantAndEquipmentTypeDomain."
+],
+"SignificantAcquisitionsAndDisposalsType": [
+"2015-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"SignificantChangeInUnrecognizedTaxBenefitsIsReasonablyPossibleEstimatedRangeOfChangeLowerBound": [
+"2015-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are IncreaseInUnrecognizedTaxBenefitsIsReasonablyPossible or DecreaseInUnrecognizedTaxBenefitsIsReasonablyPossible."
+],
+"SignificantChangeInUnrecognizedTaxBenefitsIsReasonablyPossibleEstimatedRangeOfChangeUpperBound": [
+"2015-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are IncreaseInUnrecognizedTaxBenefitsIsReasonablyPossible or DecreaseInUnrecognizedTaxBenefitsIsReasonablyPossible."
+],
+"SignificantMattersUnresolvedSinceBankruptcyEmergenceDescriptionOfMatters": [
+"2015-01-31",
+"Element was deprecated and replaced with a more encompassing element. Possible replacement is SignificantMattersUnresolvedSinceBankruptcyEmergence."
+],
+"SignificantMattersUnresolvedSinceBankruptcyEmergenceProcessForResolutionOfRemainingClaims": [
+"2015-01-31",
+"Element was deprecated and replaced with a more encompassing element. Possible replacement is SignificantMattersUnresolvedSinceBankruptcyEmergence."
+],
+"SignificantPurchaseCommitmentRemainingMinimumAmountCommitted": [
 "2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is MortgageLoansOnRealEstateFederalIncomeTaxBasis1."
+"Element was deprecated because it has a debit balance attribute. Possible replacement is PurchaseCommitmentRemainingMinimumAmountCommitted."
+],
+"SiteContingencyAccrualCaption": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AccrualForEnvironmentalLossContingencies and members of BalanceSheetLocationAxis."
+],
+"SiteContingencyAccrualDiscountAmount": [
+"2013-01-31",
+"Element was deprecated due to redundancy.  Possible replacement is AccrualForEnvironmentalLossContingenciesDiscount."
+],
+"SiteContingencyAccrualDiscountRate": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is AccrualForEnvironmentalLossContingenciesDiscountRate."
+],
+"SiteContingencyAccrualPresentValue": [
+"2013-01-31",
+"Element was deprecated due to redundancy.  Possible replacement is AccrualForEnvironmentalLossContingencies."
+],
+"SiteContingencyAccrualUndiscountedAmount": [
+"2013-01-31",
+"Element was deprecated due to redundancy.  Possible replacement is AccrualForEnvironmentalLossContingenciesGross."
+],
+"SiteContingencyByNatureAxis": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are EnvironmentalRemediationSiteAxis or EnvironmentalRemediationContingencyAxis."
+],
+"SiteContingencyNatureOfContingencyDomain": [
+"2013-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are EnvironmentalRemediationSiteDomain or EnvironmentalRemediationContingencyDomain."
+],
+"SoftwareMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is ComputerSoftwareIntangibleAssetMember."
+],
+"SourcesAndUsesOfCashForLeveragedBuyoutAbstract": [
+"2013-01-31",
+"Element was deprecated."
+],
+"SourcesAndUsesOfCashForLeveragedBuyoutTextBlock": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"StandardProductWarrantyAccrualBalanceSheetCaption": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are StandardProductWarrantyAccrualCurrent, StandardProductWarrantyAccrualNoncurrent, and StandardProductWarrantyAccrual and members of BalanceSheetLocationAxis."
+],
+"StatutoryAccountingPracticesPortionOfExcessRetainedEarningsNotTaxedReason": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"StockIssuedDuringPeriodSharesIssuedForCash": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"StockIssuedDuringPeriodSharesIssuedForNoncashConsideration": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"StockIssuedDuringPeriodValueIssuedForCash": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"StockIssuedDuringPeriodValueIssuedForNoncashConsiderations": [
+"2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"StockOptionsMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is EmployeeStockOptionMember."
+],
+"StockRepurchaseProgramAuthorizedAmount": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is StockRepurchaseProgramAuthorizedAmount1."
+],
+"StockRepurchaseProgramRemainingAuthorizedRepurchaseAmount": [
+"2014-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is StockRepurchaseProgramRemainingAuthorizedRepurchaseAmount1."
+],
+"StockholdersEquityIncludingPortionAttributableToNoncontrollingInterestAdjustedBalance": [
+"2013-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is StockholdersEquityIncludingPortionAttributableToNoncontrollingInterestAdjustedBalance1."
+],
+"StockholdersEquityNoteStockSplitConversionRatio": [
+"2013-01-31",
+"Element was deprecated because it has a decimalItemType attribute. Possible replacement is StockholdersEquityNoteStockSplitConversionRatio1."
+],
+"SubordinatedBorrowingWithSixMonthNoticeOfIntentToWithdraw": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"SubordinatedNotesToFinanceLeveragedBuyout": [
+"2013-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"SubsequentEventAmount": [
+"2013-01-31",
+"Element was deprecated because it is an invalid concept."
+],
+"SubsequentEventAmountHigherRange": [
+"2013-01-31",
+"Element was deprecated because it is an invalid concept."
+],
+"SubsequentEventAmountLowerRange": [
+"2013-01-31",
+"Element was deprecated because it is an invalid concept."
+],
+"SubsequentEventDateEvaluatedDescription": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"SubsequentEventDateEvaluationEnded1": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"SubsequentEventDateFinancialStatementsAvailableForIssuance": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
+],
+"SubsequentEventDateFinancialStatementsIssued1": [
+"2013-01-31",
+"Element was deprecated due to remodeling of topic area."
 ],
 "SubsequentEventDateThroughWhichEvaluated": [
 "2013-01-31",
@@ -1587,2963 +6051,19 @@
 "2013-01-31",
 "Element was deprecated due to remodeling of topic area."
 ],
-"NetAmountAtRiskByProductAndGuaranteeNetAmountAtRiskAtAnnuitization": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are NetAmountAtRiskByProductAndGuaranteeNetAmountAtRisk, GuaranteedInsuranceContractTypeOfBenefitAxis and AnnuitizationBenefitMember."
-],
-"LoansAndLeasesReceivableMortgageAndMortgageBackedSecuritiesValuationPolicy": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LoansAndLeasesReceivableValuationPolicy."
-],
-"BusinessAcquisitionPurchasePriceAllocationOtherLiabilities": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LineItemForPriceRiskDerivativeInstrumentsNotDesignatedAsHedgingInstrumentsOnBalanceSheet": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are PriceRiskDerivativeInstrumentsNotDesignatedAsHedgingInstrumentsAssetAtFairValue, PriceRiskDerivativeInstrumentsNotDesignatedAsHedgingInstrumentsLiabilityAtFairValue, and PriceRiskDerivativeInstrumentsNotDesignatedAsHedgingInstrumentsAtFairValueNet and members of BalanceSheetLocationAxis."
-],
-"NewAccountingPronouncementOrChangeInAccountingPrincipleProFormaDisclosuresRevenueRecognizedAmount": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"RecordedThirdPartyEnvironmentalRecoveriesCaption": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are RecordedThirdPartyEnvironmentalRecoveriesCurrent, RecordedThirdPartyEnvironmentalRecoveriesNoncurrent, and RecordedThirdPartyEnvironmentalRecoveriesNet and members of BalanceSheetLocationAxis."
-],
-"AllowanceForLoanAndLeaseLossesProvisionForLossNet": [
-"2013-01-31",
-"Element was deprecated because it is an invalid concept. Possible replacement is ProvisionForLoanAndLeaseLosses."
-],
-"ChangeInUnrealizedGainLossOnHedgedItemInFairValueHedge": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is ChangeInUnrealizedGainLossOnHedgedItemInFairValueHedge1."
-],
-"ClassOfFinancingReceivableMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is FinancingReceivableRecordedInvestmentClassOfFinancingReceivableDomain."
-],
-"ReinsuranceLiabilitiesMethodologiesAndAssumptions": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is NaturePurposeAndEffectOfReinsuranceTransactions."
-],
-"RepaymentOfDebtMember": [
+"SubsequentEventRevisedFinancialStatementsDateEvaluatedDescription": [
 "2013-01-31",
 "Element was deprecated due to remodeling of topic area."
-],
-"BusinessAcquisitionPreexistingRelationshipDescription": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is BusinessCombinationSeparatelyRecognizedTransactionsDescription and members of BusinessCombinationSeparatelyRecognizedTransactionsAxis."
-],
-"ForeignEarningsRepatriatedUnderAmericanJobsCreationActOf2004RepatriatedEarnings": [
-"2013-01-31",
-"Element was deprecated because the guidance related to this element is no longer effective.  Possible replacement is ForeignEarningsRepatriated."
-],
-"FinancingReceivableTroubledDebtRestructuringAxis": [
-"2015-01-31",
-"Element was deprecated due to remodeling of the topic area. Possible replacements are FinancingReceivablePortfolioSegmentAxis, FinancingReceivableRecordedInvestmentByClassOfFinancingReceivableAxis, ClassOfFinancingReceivableTypeOfBorrowerAxis, EquitySecuritiesByIndustryAxis, CollateralAxis, GeographicDistributionAxis."
-],
-"CategoriesOfInvestmentsMarketableSecuritiesAvailableForSaleSecuritiesMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AvailableforsaleSecuritiesMember."
-],
-"OtherComprehensiveIncomeLossForeignCurrencyTranslationReclassificationAdjustmentRealizedUponSaleOrLiquidationTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossForeignCurrencyTransactionAndTranslationReclassificationAdjustmentFromAOCIRealizedUponSaleOrLiquidationTax."
-],
-"RetirementOfTangibleAssetsOtherDescriptors": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"FairValueEstimateNotPracticableReasonsMortgageBackedSecuritiesHeldToMaturity": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
-],
-"AccountingStandardsUpdate200916Member": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LoansHeldForSaleCommercialAndIndustrial": [
-"2015-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacement is LoansReceivableHeldForSaleNetNotPartOfDisposalGroupCommercialAndIndustrial."
-],
-"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureProductionCosts": [
-"2013-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesProductionCosts."
-],
-"ReorganizationItemsDisclosuresAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"EffectsOfChangesInPrepaymentEstimateAssumptionsForCMOsAndREMICsAffectedItemDomain": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"FAS160Member": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"MinorityInterestIncreaseFromStockIssuance": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacement is NoncontrollingInterestIncreaseFromSubsidiaryEquityIssuance or NoncontrollingInterestIncreaseFromSaleOfParentEquityInterest."
-],
-"OtherComprehensiveIncomeLossForeignCurrencyTransactionAndTranslationReclassificationAdjustmentRealizedUponSaleOrLiquidationNetOfTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossForeignCurrencyTransactionAndTranslationReclassificationAdjustmentFromAOCIRealizedUponSaleOrLiquidationNetOfTax."
-],
-"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsMinimumPensionLiabilityAdjustment": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"PremiumsWrittenNetFinancialGuaranteeInsuranceContractsAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"BusinessCombinationConsiderationTransferredIncludingEquityInterestInAcquireeHeldPriorToCombination": [
-"2013-01-31",
-"Element was deprecated because it has debit balance and instant period type attributes. Possible replacement is BusinessCombinationConsiderationTransferredIncludingEquityInterestInAcquireeHeldPriorToCombination1."
-],
-"NewContractAxis": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"ReinsuranceRecoverablesPercentageOfTotal": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ConcentrationRiskPercentage1 with members of ConcentrationRiskByBenchmarkAxis and ConcentrationRiskByTypeAxis."
-],
-"OtherInterestIncomeMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is InterestIncomeOther."
-],
-"LeveragedBuyoutCostOfTransactionChargedToExpenseAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"FairValueEstimateNotPracticableCashSurrenderValue": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"SalesCommissionsAndFeesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is SalesCommissionsAndFees."
-],
-"DeferredTaxLiabilitiesPrepaidPensionCosts": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"WeightedAverageRateForeignDepositNoticeOfWithdrawal": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"BusinessAcquisitionPurchasePriceAllocationNoncurrentLiabilitiesAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"DebtInstrumentInterestRateIncrease": [
-"2013-01-31",
-"Element was deprecated because it has a pureItemType attribute. Possible replacement is DebtInstrumentInterestRateIncreaseDecrease."
-],
-"HeldtomaturitySecuritiesUnrecognizedHoldingGain": [
-"2013-01-31",
-"Element was deprecated because it has debit balance and instant period type attributes. Possible replacement is HeldtomaturitySecuritiesUnrecognizedHoldingGains."
-],
-"NoninterestExpenseCommissionExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpenseCommissionExpense."
-],
-"FairValueEstimateNotPracticableReasonsSubordinatedDebtObligations": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
-],
-"FiveYearScheduleOfMaturitiesOfDebtOfParentCompanyAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"ReinsuranceEffectOnClaimsAndBenefitsIncurredNetAmount": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is PolicyholderBenefitsAndClaimsIncurredNet."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsDescription": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CashFlowHedgeGainLossReclassifiedToRevenueNet": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is Revenues and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"CashFlowHedgeGainLossReclassifiedToOtherExpenseNet": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is OtherCostAndExpenseOperating and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"MinorityInterestInNetIncomeLossJointVenturePartners": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacement is NoncontrollingInterestInNetIncomeLossJointVenturePartnersNonredeemable or NoncontrollingInterestInNetIncomeLossJointVenturePartnersRedeemable."
-],
-"ReinsurancePremiumsForInsuranceCompaniesByProductSegmentNetAmount": [
-"2013-01-31",
-"Element was deprecated. Possible replacement is PremiumsEarnedNet."
-],
-"AccumulatedDepreciationDepletionAndAmortizationReclassificationsOfPropertyPlantAndEquipment": [
-"2015-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is AccumulatedDepreciationDepletionAndAmortizationReclassificationsFromPropertyPlantAndEquipment1."
-],
-"SecuritizedAssetsAndAnyOtherFinancialAssetsManagedTogetherByTypeOfFinancialInstrumentAxis": [
-"2014-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is FinancialInstrumentAxis."
-],
-"FairValueAssetsMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInOtherIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueAssetsMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
-],
-"CertainLoansAcquiredInTransferAccountedForAsAvailableForSaleDebtSecuritiesAccretableYieldReclassificationsFromNonaccretableDifference": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesAccretableYieldReclassificationsFromNonaccretableDifference and members of InformationByCategoryOfDebtSecurityAxis."
-],
-"FairValueEstimateNotPracticableReasonsRetainedInterest": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"WeightedAverageRateForeignDepositRetail": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInTradingRevenue": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueLiabilitiesMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseClaimsPaid": [
-"2014-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is PaymentsForLossesAndLossAdjustmentExpense."
-],
-"OtherMaterialNoncashItems": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Possible replacement is corresponding primary line items and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
-],
-"CumulativeEffectAdjustmentApplicationOfFairValueOptionUnrealizedLossesUnrecognized": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"WeightedAverageRateForeignDepositCertificatesOfDeposit": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"EffectOfIllegalActsOnFinancialStatementsAmountMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"OtherComprehensiveIncomeLossReclassificationAdjustmentForSaleOfSecuritiesIncludedInNetIncomeNetOfTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForSaleOfSecuritiesNetOfTax."
-],
-"NotionalAmountOfForeignCurrencyDerivativePurchaseContracts": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and PositionAxis."
-],
-"TradingSecuritiesRestrictionsAdditionalInformation": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"ForeignReinsuranceTransactionsAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"DisposalGroupNotDiscontinuedOperationLossGainOnWriteDownIncomeStatementCaption": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DisposalGroupNotDiscontinuedOperationLossGainOnWriteDown and members of IncomeStatementLocationAxis."
-],
-"SubsequentEventAmountHigherRange": [
-"2013-01-31",
-"Element was deprecated because it is an invalid concept."
-],
-"LossContingencyRelatedReceivableCarryingValue": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is LossContingencyReceivable."
-],
-"NotionalAmountOfInterestRateFairValueHedgeDerivatives": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
-],
-"RegulatoryNoncurrentAssetAmortizationPeriod": [
-"2015-01-31",
-"Element was deprecated because it has a stringItemType attribute. Possible replacement is RegulatoryAssetAmortizationPeriod."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentLiabilitiesOtherLiabilities": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DerivativeInstrumentsGainLossRecognizedInIncomeNetAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"BusinessAcquisitionCostOfAcquiredEntityLiabilitiesIncurred": [
-"2013-01-31",
-"Element was deprecated because it has debit balance and instant period type attributes.  Possible replacement is BusinessCombinationConsiderationTransferredLiabilitiesIncurred."
-],
-"AccountingStandardsUpdate200914Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AccountingStandardsUpdate201008Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CashFlowHedgeLossReclassifiedToEarnings": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProfitLoss and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"PreviouslyEstimatedDevelopmentCostsIncurredDuringPeriod": [
-"2015-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is PreviouslyEstimatedDevelopmentCostsIncurred."
-],
-"LeveragedBuyoutPercentageOfPurchasePriceAllocatedToAssetsAndLiabilitiesAcquiredAtCarryoverBasis": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"BusinessAcquisitionPurchasePriceAllocationNoncurrentLiabilitiesLongTermDebt": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"GuaranteedBenefitsIncurred": [
-"2013-01-31",
-"Element was deprecated because it has a stringItemType attribute. Possible replacement is LiabilitiesForGuaranteesOnLongDurationContractsIncurredBenefits1."
-],
-"DevelopmentStageEnterpriseAdditionalInformationForStatementOfStockholdersEquityDisclosureAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"AncillaryFeeIncomeGeneratedByServicingFinancialAssetsDescriptionOfWhereReportedOnStatementOfIncome": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AncillaryFeeIncomeGeneratedByServicingFinancialAssetsAmount and members of IncomeStatementLocationAxis."
-],
-"CommonStockholdersEquity": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is StockholdersEquity."
-],
-"ImpairedAssetsToBeDisposedOfByMethodOtherThanSaleIncomeStatementClassification": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ImpairedAssetsToBeDisposedOfByMethodOtherThanSaleAmountOfImpairmentLoss and members of IncomeStatementLocationAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsMerchandise": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"WeightedAverageRateDomesticDepositRetail": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"ServicingLiabilityAtAmortizedValueIncreaseInObligation1": [
-"2015-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is ServicingLiabilityAtAmortizedCostOtherIncreaseDecreaseInObligation."
-],
-"ChangeInHistoricalClaimsRateExperienceMember": [
-"2014-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInInvestmentIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
-],
-"MaximumLengthOfTimeHedgedInForeignCurrencyCashFlowHedge": [
-"2013-01-31",
-"Element was deprecated because it is has a stringItemType attribute. Possible replacement is MaximumLengthOfTimeForeignCurrencyCashFlowHedge."
-],
-"DerivativeFairValueGrossAmountNotOffsetAgainstCollateralNet": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DerivativeFairValueOfDerivativeNet."
-],
-"MortgageLoansOnRealEstateMember": [
-"2015-01-31",
-"Element deprecated due to redundancy. Possible replacement is MortgagesMember."
-],
-"DisposalGroupAssetsOfBusinessTransferredUnderContractualArrangement": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssetsOfDisposalGroupIncludingDiscontinuedOperation and members of DisposalGroupClassificationAxis."
-],
-"GuaranteeObligationsCaptionForRecordedLiabilities": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is GuaranteeObligationsCurrentCarryingValue and members of BalanceSheetLocationAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentLiabilitiesDescription": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DirectPremiumsEarnedPropertyAndCasualty": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"OtherTaxCarryforwardExpirationDates": [
-"2013-01-31",
-"Element was deprecated because it is has a stringItemType attribute. Possible replacement is TaxCreditCarryforwardExpirationDate."
-],
-"HeldToMaturitySecuritiesRestrictionsAdditionalInformation": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"AssumedPremiumsEarnedFinancialGuaranteeInsuranceContracts": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"ServicingAssetAtAmortizedValueChangesInCarryingAmountLocationInIncomeStatementDescription": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ServicingAssetAtAmortizedValue and members of IncomeStatementLocationAxis."
-],
-"NonmonetaryNotionalAmountOfPriceRiskCashFlowHedgeDerivatives": [
-"2013-01-31",
-"Element was deprecated because the intended concept conveyed is the underlying. Possible replacements are UnderlyingDerivativeAsset, UnderlyingDerivativeLiability, UnderlyingDerivative and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis and DerivativeInstrumentRiskAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentLiabilities": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"NetAmountAtRiskByProductAndGuaranteeGuaranteeTypeAxis": [
-"2015-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are GuaranteedInsuranceContractTypeOfBenefitAxis or GuaranteedInsuranceContractTypeOfGuaranteeAxis."
-],
-"MaterialErrorInLiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseMember": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are members of ErrorCorrectionsAndPriorPeriodAdjustmentsRestatementByRestatementPeriodAndAmountAxis."
-],
-"ScheduleOfCalculationOfNumeratorAndDenominatorInEarningsPerShareTableTextBlock": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ScheduleOfEarningsPerShareBasicAndDilutedTableTextBlock."
-],
-"DerivativeAssetFairValueNet": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DerivativeFairValueOfDerivativeAssetAmountNotOffsetAgainstCollateral."
-],
-"MortgageLoansOnRealEstatePeriodicPaymentTermsBalloonPaymentAmount": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are MortgageLoansOnRealEstatePeriodicPaymentTermsBalloonPaymentToBeReceived or DebtInstrumentPeriodicPaymentTermsBalloonPaymentToBePaid."
-],
-"IncomeDepositSecuritiesForwardLookingCashFlows": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"RevenuesFromTransactionsWithOtherOperatingSegmentsOfSameEntity": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Possible replacement is Revenues and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
-],
-"AccountingStandardsUpdate200905Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CededCreditRiskOtherRisks": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"NotionalAmountOfForeignCurrencyDerivativeSaleContracts": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and PositionAxis."
-],
-"DescriptionOfEmbeddedRegulatoryAsset": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"LongDurationContractsAssumptionsByProductAndGuaranteeLapseRateLowEnd": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are LongDurationContractsAssumptionsByProductAndGuaranteeLapseRate, RangeAxis and MinimumMember."
-],
-"RealEstateWriteDownOrReserveAmount": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is SECScheduleIIIRealEstateWriteDownOrReserveAmount."
-],
-"BusinessCombinationSeparatelyRecognizedTransactionsExpensesAndLossesAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsAssetHeldForSale": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LossContingencyIncomeStatementCaption": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LossContingencyLossInPeriod and members of IncomeStatementLocationAxis."
-],
-"AssumedPremiumsWrittenOtherInsurance": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"SiteContingencyByNatureAxis": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are EnvironmentalRemediationSiteAxis or EnvironmentalRemediationContingencyAxis."
-],
-"IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingLimitedPartnershipAndGeneralPartnershipUnitBasic": [
-"2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingLimitedPartnershipAndGeneralPartnershipUnitBasic1."
-],
-"PresentValueOfFutureInsuranceProfitsAmortizationExpense": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsAmortizationExpense1."
-],
-"IncomeLossFromEquityMethodInvestmentsNetOfDistributionsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is IncomeLossFromEquityMethodInvestmentsNetOfDividendsOrDistributions."
-],
-"FinancialGuaranteeInsuranceContractsRiskManagementActivitiesMitigatingClaimLiabilitiesAccruedLiabilitiesAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"DeferredTaxLiabilityNotRecognizedAxis": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"LongLivedAssetsToBeAbandonedAssetNameDomain": [
-"2015-01-31",
-"Element deprecated due to redundancy. Possible replacement is PropertyPlantAndEquipmentTypeDomain or DisposalGroupsIncludingDiscontinuedOperationsNameDomain."
-],
-"SegmentReportingInformationAverageAssets": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Possible replacement is Assets and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
-],
-"PremiumsEarnedNetLifeAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"IncomeLossFromDiscontinuedOperationsNetOfTaxPerOutstandingGeneralPartnershipUnit": [
-"2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromDiscontinuedOperationsNetOfTaxPerOutstandingGeneralPartnershipUnit1."
-],
-"ForeignEarningsRepatriatedUnderAmericanJobsCreationActOf2004Abstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"DiscontinuedOperationIntercompanyAmountsWithDiscontinuedOperationBeforeDisposalTransactionCosts": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"PublicUtilitiesDecommissioningContributionAmounts": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"PublicUtilitiesPlantAndEquipmentDescriptionOfAcquisitionAdjustmentsAndRelatedAccumulatedDepreciation": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"CededPremiumsWrittenFinancialGuaranteeInsuranceContracts": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"OtherComprehensiveIncomeLossAmortizationPensionAndOtherPostretirementBenefitPlansNetPriorServiceCostRecognizedInNetPeriodicPensionCostNetOfTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossAmortizationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetPriorServiceCostCreditNetOfTax."
-],
-"OtherDerivativesNotDesignatedAsHedgingInstrumentsAssetsAtFairValue": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DerivativeInstrumentsNotDesignatedAsHedgingInstrumentsAssetAtFairValue."
-],
-"QuantitativeInformationAboutAssetQualityOfSecuritizedOrAssetbackedFinancingArrangementAssetsAndAnyOtherFinancialAssetsManagedTogetherTextBlock": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"BusinessCombinationProFormaInformationAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"FairValueEstimateNotPracticableReasonsAccountsPayable": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
-],
-"OtherComprehensiveIncomeAmortizationOfDefinedBenefitPlanNetPriorServiceCostRecognizedInNetPeriodicPensionCostTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossAmortizationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetPriorServiceCostCreditTax."
-],
-"SignificantAcquisitionsAndDisposalsTerms": [
-"2015-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"CapitalizedExploratoryWellCostsGreaterThanOrEqualToThreeYearsAndLessThanFourYears": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CapitalizedExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
-],
-"LongLivedAssetsToBeAbandonedLineItems": [
-"2015-01-31",
-"Element was deprecated."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseIncurredClaimsCurrentYear": [
-"2014-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is SupplementalInformationForPropertyCasualtyInsuranceUnderwritersCurrentYearClaimsAndClaimsAdjustmentExpense."
-],
-"NotionalAmountOfNonderivativeInstrumentsDesignatedAsNetInvestmentHedges": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NotionalAmountOfNonderivativeInstruments and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationOtherAssets": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"BusinessAcquisitionContingentConsiderationAtFairValueCurrent": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseReportedAndIncurredButNotReportedIBNRClaimsDisclosureAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"DescriptionOfHedgedFirmCommitmentNotQualifyingAsForeignCurrencyFairValueHedge": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"BusinessCombinationSeparatelyRecognizedTransactionsRevenuesAndGainsFinancialStatementCaption": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is BusinessCombinationSeparatelyRecognizedTransactionsRevenuesAndGainsRecognized and members of IncomeStatementLocationAxis."
-],
-"IncomeTaxExaminationLiabilityRecorded": [
-"2013-01-31",
-"Element was deprecated due to redundancy.  Possible replacement is IncomeTaxExaminationPenaltiesAndInterestAccrued."
-],
-"IncomeLossFromContinuingOperationsPerOutstandingLimitedPartnershipUnit": [
-"2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromContinuingOperationsPerOutstandingLimitedPartnershipUnitBasicNetOfTax."
-],
-"MaterialEffectOnLiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseFromChangeInAccountingPrincipleMember": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are members of AdjustmentsForChangeInAccountingPrincipleAxis."
-],
-"LeveragedBuyoutCostOfTransactionDescription": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"ProceedsFromSaleOfWaterAndWasteWaterSystems": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"EquityContributionsToFinanceLeveragedBuyout": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalRollingMaturityAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"PublicUtilitiesDisclosureOfImpactOfMergers": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"FiveYearScheduleOfMaturitiesOfParentCompanyRepaymentsOfPrincipalAfterYearFive": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalAfterYearFive."
-],
-"LongTermPurchaseCommitmentTimePeriod": [
-"2014-01-31",
-"Element was deprecated because it has a stringItemType attribute. Possible replacement is LongtermPurchaseCommitmentPeriod."
-],
-"ReinsuranceEffectOnClaimsAndBenefitsIncurredNetAmountAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"ReportingEntityMember": [
-"2014-01-31",
-"Element was deprecated because it is an invalid concept."
-],
-"TradingActivityGainsAndLossesNet": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TradingGainsLosses."
-],
-"AccountingStandardsUpdate201015Member": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LiabilitiesSubjectToCompromiseDescriptionOfEmployeeRelatedAccruals": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"StockholdersEquityNoteStockSplitConversionRatio": [
-"2013-01-31",
-"Element was deprecated because it has a decimalItemType attribute. Possible replacement is StockholdersEquityNoteStockSplitConversionRatio1."
-],
-"SellingExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is SellingExpense."
-],
-"HedgeDesignationsUsedForCreditRiskDerivatives": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationTangibleAssetsAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"FinancialGuaranteeInsuranceContractsPremiumReceivedOverContractPeriodPremiumReceivableAccretionAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"FloorBrokerageExchangeClearanceFeesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is FloorBrokerageExchangeAndClearanceFees."
-],
-"OperatingLeaseExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is LeaseAndRentalExpense."
-],
-"LeveragedBuyoutRepaymentOfExistingDebt": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"ServicingLiabilityAtAmortizedValueByTypesOfFinancialAssetsAxis": [
-"2013-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is FinancialInstrumentAxis."
-],
-"OtherNonrecurringExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OtherNonrecurringExpense."
-],
-"CurrentIncomeTaxExpenseBenefitAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"ScheduleOfInvestmentIncomeReportedAmountsByCategoryAxis": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is InvestmentTypeAxis."
-],
-"NetIncomeLossPerOutstandingLimitedPartnershipUnit": [
-"2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is NetIncomeLossPerOutstandingLimitedPartnershipUnitBasicNetOfTax."
-],
-"LongDurationContractsAssumptionsByProductAndGuaranteeGuaranteeTypeAxis": [
-"2015-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are GuaranteedInsuranceContractTypeOfBenefitAxis or GuaranteedInsuranceContractTypeOfGuaranteeAxis."
-],
-"QualitativeAndQuantitativeInformationAssetsOrLiabilitiesForTransferorsContinuingInvolvementInSecuritizationOrAssetbackedFinancingArrangementPrincipalAmountsOutstanding": [
-"2014-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is ContinuingInvolvementWithTransferredFinancialAssetsPrincipalAmountOutstanding."
-],
-"DeferredGainOnEarlyExtinguishmentOfDebtAmountMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DeferredLossOnEarlyExtinguishmentOfDebtMember."
-],
-"ScheduleOfClosedBlockSummarizedFinancialData": [
-"2013-01-31",
-"Element was deprecated."
-],
-"TaxCreditCarryforwardDeferredTaxAsset": [
-"2015-01-31",
-"Element deprecated due to redundancy. Possible replacement is DeferredTaxAssetsTaxCreditCarryforwards."
-],
-"IncomeLossFromDiscontinuedOperationsNetOfTaxPerOutstandingLimitedPartnershipUnitDiluted": [
-"2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromDiscontinuedOperationsNetOfTaxPerOutstandingLimitedPartnershipUnitDiluted1."
-],
-"ProductLiabilityAccrualPeriodExpenseCaption": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProductLiabilityAccrualPeriodExpense and members of IncomeStatementLocationAxis."
-],
-"TemporaryEquityCarryingAmountAttributableToNoncontrollingInterest": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is RedeemableNoncontrollingInterestEquityCarryingAmount."
-],
-"UnrecognizedTaxBenefitsResultingInNetOperatingLossCarryforward": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FairValueEstimateNotPracticableReasonsFederalHomeLoanBankBorrowings": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
-],
-"WeeklyReserveCalculationDescription": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifference": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferenceUndistributedEarningsOfForeignSubsidiaries, DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferenceUndistributedEarningsOfDomesticSubsidiaries, DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferenceBadDebtReserveForTaxPurposesOfQualifiedLender, and DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferencePolicyholdersSurplus."
-],
-"LeveragedBuyoutPrepaymentPenaltiesOnRetiredDebt": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"BusinessAcquisitionPurchasePriceAllocationUnfavorableContractAccrual": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"OtherNonrecurringGainMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OtherNonrecurringGain."
-],
-"RealEstateWriteDownOrReserveByPropertyAxis": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is RealEstateAndAccumulatedDepreciationDescriptionOfPropertyAxis."
-],
-"TransfersAccountedForAsSecuredBorrowingsClassificationAssets": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is TransfersAccountedForAsSecuredBorrowingsAssetsCarryingAmount and members of BalanceSheetLocationAxis."
-],
-"ScheduleOfEmployeeServiceShareBasedCompensationAllocationOfRecognizedPeriodCostsByReportLineAxis": [
-"2013-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is IncomeStatementLocationAxis."
-],
-"CertainLoansAcquiredInTransferAccountedForAsAvailableForSaleDebtSecuritiesAccretableYieldAdditions": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesAccretableYieldAdditions and members of InformationByCategoryOfDebtSecurityAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsMarketableSecurities": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"EntityWideDisclosureOnGeographicAreasLongLivedAssetsInForeignCountries": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Possible replacement is NoncurrentAssets and members of StatementGeographicalAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsWorkInProgress": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"OrderFlowFeesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OrderFlowFees."
-],
-"SegmentGeographicalGroupsOfCountriesGroupTwoMember": [
-"2013-01-31",
-"Element deprecated because it was inappropriately modeled."
-],
-"NoninterestExpenseOfferingCostMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpenseOfferingCost."
-],
-"CapitalizedExploratoryWellCostsGreaterThanOrEqualToFourYearsAndLessThanFiveYearsNumberOfProjects": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProjectsThatHaveExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationPropertyPlantAndEquipmentAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"IndicationThatEntityWasInDevelopmentStageInPriorYears": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"PercentageOfInterestBearingDomesticDepositLiabilitiesToDepositLiabilitiesDescription": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"TimeSharingTransactionsAdditionsToAllowanceForCurrentPeriodSales": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is TimeSharingTransactionsAdditionsToAllowanceForCurrentPeriodSales1."
-],
-"FairValueEstimateNotPracticableReasonsSecuritiesLoanedOrSoldUnderAgreementsToRepurchase": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
-],
-"NoninterestExpenseInvestmentAdvisoryFeesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpenseInvestmentAdvisoryFees."
-],
-"CededCreditRiskPremiumsEarned": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"FairValueDisclosureOffBalanceSheetRisksMethodology": [
-"2015-01-31",
-"Element was deprecated and replaced with a more encompassing element. Possible replacement is FairValueDisclosureOffBalanceSheetRisksDescription."
-],
-"ConcentrationOfCededCreditRisk": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ConcentrationRiskCreditRiskReinsurance."
-],
-"DeferredPolicyAcquisitionCostsTextBlock": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacement is DeferredPolicyAcquisitionCostsTextBlock1 or CapitalizationOfDeferredPolicyAcquisitionCostsPolicy."
-],
-"ResaleAgreementsInterestIncomeAmount": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"CausesOfIncreaseDecreaseInLiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAmount": [
-"2014-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is SupplementalInformationForPropertyCasualtyInsuranceUnderwritersPriorYearClaimsAndClaimsAdjustmentExpense."
-],
-"BankruptcyProceedingsEntitiesNotIncludedInBankruptcyFiling": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"GuaranteedInsuranceBenefitTypeDomain": [
-"2015-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are GuaranteedInsuranceContractTypeofBenefitDomain or GuaranteedInsuranceContractTypeOfGuaranteeDomain."
-],
-"FairValueEstimateNotPracticableReasonsInvestments": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
-],
-"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesStandardizedMeasure": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is StandardizedMeasureOfDiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReserves."
-],
-"RealEstateAccumulatedDepreciationDepreciationExpense": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is SECScheduleIIIRealEstateAccumulatedDepreciationDepreciationExpense."
-],
-"FairValueEstimateNotPracticableReasonsCashSurrenderValue": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
-],
-"FinancingReceivableModificationsSubsequentDefaultRecordedInvestment": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is FinancingReceivableModificationsSubsequentDefaultRecordedInvestment1."
-],
-"SignificantPurchaseCommitmentRemainingMinimumAmountCommitted": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is PurchaseCommitmentRemainingMinimumAmountCommitted."
-],
-"IncreaseDecreaseInIndustryFundObligation": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"ReorganizationItemsDescriptionOfRevaluationOfCustomerRelatedObligations": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"EffectsOfChangesInPrepaymentEstimateAssumptionsForCMOsAndREMICsByAffectedItemAxis": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"SaleLeasebackTransactionRelatedPartyTransaction": [
-"2013-01-31",
-"Element was deprecated due to redundancy.  Possible replacement is RelatedPartyTransactionDescriptionOfTransaction."
-],
-"ServicingLiabilityAtAmortizedValueAmortization": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance type. Possible replacement is ServicingLiabilityAtAmortizedCostAmortization."
-],
-"EffectsOfChangesInPrepaymentEstimateAssumptionsForCMOsAndREMICsTable": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"BreakpointDiscountRefund": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"InvestmentOwnedValuedByTrusteesFlag": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is InvestmentOwnedValuedByTrusteesFlag1."
-],
-"BusinessAcquisitionCostOfAcquiredEntityDescriptionOfPurchasePriceComponents": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CapitalizedExploratoryWellCostsGreaterThanOrEqualToFourYearsAndLessThanFiveYears": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CapitalizedExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
-],
-"FairValueEstimateNotPracticableReasonsEquityMethodInvestments": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseIncurredButNotReportedIBNRClaimsCommentary": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilityForClaimsAndClaimsAdjustmentExpenseMethodologiesAndAssumptions."
-],
-"MalpracticeInsuranceEntityRating": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is MalpracticeInsuranceThirdPartyCoverage and members of CreditRatingMoodysAxis, CreditRatingStandardPoorsAxis, CreditRatingFitchAxis, and CreditRatingAMBestAxis."
-],
-"AmountAvailableForDividendDistributionWithoutPriorApprovalFromRegulatoryAgency": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is StatutoryAccountingPracticesStatutoryAmountAvailableForDividendPaymentsWithoutRegulatoryApproval."
-],
-"CededCreditRiskClaimsReceivable": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"EITF083Member": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DirectPremiumsEarnedFinancialGuaranteeInsuranceContracts": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"DeferredCompensationArrangementWithIndividualMaximumContractualTerm": [
-"2014-01-31",
-"Element was deprecated because it has a stringItemType attribute. Possible replacement is DeferredCompensationArrangementWithIndividualMaximumContractualTerm1."
-],
-"ReceivablesHeldForSaleNetAmount": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are TradeAndLoansReceivablesHeldForSaleNetNotPartOfDisposalGroup or DisposalGroupIncludingDiscontinuedOperationAccountsNotesAndLoansReceivableNet."
-],
-"LifeInsuranceInForceMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are LifeInsuranceInForceGross, LifeInsuranceInForceCeded, LifeInsuranceInForceAssumed, LifeInsuranceInForceNet, or LifeInsuranceInForcePercentageAssumedToNet."
-],
-"ProvisionForLossesOnOperatingAndOrDevelopmentPropertyMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"AccrualForEnvironmentalLossContingenciesNetRollingMaturityAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"QualitativeAndQuantitativeInformationAssetsOrLiabilitiesForTransferorsContinuingInvolvementInSecuritizationOrAssetbackedFinancingArrangementSize": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"FinancialInstrumentsOwnedAndPledgedAsCollateralCaption": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is SecurityOwnedAndPledgedAsCollateralFairValue and members of BalanceSheetLocationAxis."
-],
-"InvestmentsImpairmentChargeMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ImpairmentOfInvestments."
-],
-"LongDurationContractsAssumptionsByProductAndGuaranteeLapseRateHighEnd": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are LongDurationContractsAssumptionsByProductAndGuaranteeLapseRate, RangeAxis and MaximumMember."
-],
-"CumulativeEffectAdjustmentApplicationOfFairValueOptionGrossGainsAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"ScheduleOfExpectedAmortizationExpenseTableTextBlock": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ScheduleofFiniteLivedIntangibleAssetsFutureAmortizationExpenseTableTextBlock."
-],
-"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionLapseDateNotEstimatableFlag": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionLapseDateNotEstimableFlag."
-],
-"TemporaryEquityCarryingAmountAttributableToNoncontrollingInterestAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"ExtendedProductWarrantyAccrualBalanceSheetCaption": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are ExtendedProductWarrantyAccrualCurrent, ExtendedProductWarrantyAccrualNoncurrent, and ExtendedProductWarrantyAccrual and members of BalanceSheetLocationAxis."
-],
-"ServicingAssetAtAmortizedValueOtherThanTemporaryImpairments": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is ServicingAssetAtAmortizedCostOtherThanTemporaryImpairments."
-],
-"CededCreditRiskNotConcentratedCreditRiskMember": [
-"2015-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacements are ConcentrationRiskByTypeAxis and its member ReinsurerConcentrationRiskMember and members of ConcentrationRiskByBenchmarkAxis."
-],
-"LoansHeldForSaleOther": [
-"2015-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacement is LoansReceivableHeldForSaleNetNotPartOfDisposalGroupOther."
-],
-"LiabilityForTitleClaimsAndClaimsAdjustmentExpenseIncurredButNotReportedIBNR": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseIncurredButNotReportedIBNRClaimsAmount and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"LeveragedBuyoutOptionCostChargedToExpense": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"InsuranceRatiosComment": [
-"2013-01-31",
-"Element was deprecated."
-],
-"DescriptionOfMaterialAffectsOfNoncomplianceWithCapitalRequirementsOnTrustAssets": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"FinancingReceivableRecordedInvestmentPastDueAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"NetInvestmentIncomeInsuranceEntityFixedMaturities": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NetInvestmentIncome and members of InvestmentTypeAxis."
-],
-"NotionalAmountOfInterestRateCashFlowHedgeDerivatives": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis and DerivativeInstrumentRiskAxis."
-],
-"DefinedBenefitPlanPurchasesSalesAndSettlementsAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"ScheduleOfDistributionsMadeToMemberOrLimitedPartnerTable": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacement is DistributionsMadeToLimitedLiabilityCompanyLLCMemberTable or DistributionsMadeToLimitedPartnerTable."
-],
-"FSPFAS1152AndFAS1242Member": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FinancialGuaranteeInsuranceContractsClaimLiabilitySignificantComponentsOfChangeAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"DirectPremiumsWrittenLife": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"DisposalGroupIncludingDiscontinuedOperationInventory": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DisposalGroupIncludingDiscontinuedOperationInventoryCurrent, DisposalGroupIncludingDiscontinuedOperationInventoryNoncurrent or DisposalGroupIncludingDiscontinuedOperationInventory1."
-],
-"CollaborativeArrangementsCopromotionAgreementAgreementMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is CollaborativeArrangementCopromotionMember."
-],
-"StockIssuedDuringPeriodSharesIssuedForNoncashConsideration": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CooperativeAdvertisingExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is CooperativeAdvertisingExpense."
-],
-"ContributionsFromNoncontrollingInterests": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ProceedsFromMinorityShareholders."
-],
-"CertainLoansAcquiredInTransferAccountedForAsHeldToMaturityDebtSecuritiesAccretableYieldMovementScheduleRollForward": [
-"2015-01-31",
-"Element was deprecated."
-],
-"ReorganizationItemsDescriptionOfNondebtorReorganizationItemsGainLossOnSettlementOfOtherClaimsNet": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"FloorBrokerageMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is FloorBrokerage."
-],
-"LoansHeldForSaleCommercialRealEstate": [
-"2015-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacement is LoansReceivableHeldForSaleNetNotPartOfDisposalGroupCommercialRealEstate."
-],
-"NotionalAmountOfInterestRateDerivatives": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisGainLossIncludedInTradingRevenue": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisLiabilityGainLossIncludedInEarnings and members of IncomeStatementLocationAxis."
-],
-"CededPremiumsWrittenLife": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInRollingAfterYearFive": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInRollingAfterYearFive."
-],
-"FinancingReceivableRecordedInvestment30To59DaysPastDue": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FinancingReceivableRecordedInvestmentPastDue and FinancingReceivables30To59DaysPastDueMember."
-],
-"CommunicationsAndDataProcessingMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is CommunicationsAndInformationTechnology."
-],
-"CashFlowHedgeGainReclassifiedToEarnings": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProfitLoss and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"MalpracticeInsuranceDeductible": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is MalpracticeInsuranceDeductible1."
-],
-"ScheduleOfEffectsOfChangesInPrepaymentEstimateAssumptionsForCollateralizedMortgageObligationsAndRealEstateMortgageInvestmentConduitsTextBlock": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"DiscussionOfEarningsEffectOfHybridInstrumentFairValueChanges": [
-"2015-01-31",
-"Element deprecated due to redundancy. Possible replacement is DescriptionOfHybridInstrumentsAccountedForAtFairValue."
-],
-"FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisGainLossIncludedInOtherIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisInstrumentsClassifiedInShareholdersEquityGainLossIncludedInEarnings and members of IncomeStatementLocationAxis."
-],
-"TypesOfCreditRiskDerivativesUsed": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are members of CreditDerivativesByContractTypeAxis."
-],
-"PublicUtilitiesPropertyPlantAndEquipmentEquipmentEstimatedUsefulLife": [
-"2013-01-31",
-"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentEquipmentUsefulLife."
-],
-"AccountingStandardsUpdate201017Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"PremiumsWrittenNetOtherInsurance": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PremiumsWrittenNet and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationRealEstateAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisLiabilityGainLossIncludedInOtherComprehensiveIncomeDescription": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisLiabilityGainLossIncludedInOtherComprehensiveIncome and members of OtherComprehensiveIncomeLocationAxis."
-],
-"IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingLimitedPartnershipUnitDiluted": [
-"2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingLimitedPartnershipUnitDiluted1."
-],
-"CapitalizedExploratoryWellCostsThereafter": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CapitalizedExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
-],
-"CashFlowHedgeGainLossReclassifiedToEarningsNetAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"CapitalizedExploratoryWellCostsGreaterThanOrEqualToTwoYearsAndLessThanThreeYears": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CapitalizedExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
-],
-"SignificantAcquisitionsAndDisposalsByTransactionAxis": [
-"2015-01-31",
-"Element deprecated due to redundancy. Possible replacement is PropertyPlantAndEquipmentByTypeAxis."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisGainLossIncludedInOtherIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisLiabilityGainLossIncludedInEarnings and members of IncomeStatementLocationAxis."
-],
-"DetailsOfLongLivedAssetsToBeAbandonedByAssetTextBlock": [
-"2015-01-31",
-"Element deprecated due to redundancy. Possible replacement is ScheduleOfDisposalGroupsIncludingDiscontinuedOperationsIncomeStatementBalanceSheetAndAdditionalDisclosuresTextBlock."
-],
-"IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingLimitedPartnershipUnit": [
-"2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromExtraordinaryItemsNetOfTaxPerOutstandingLimitedPartnershipUnitBasic."
-],
-"BusinessAcquisitionCostOfAcquiredEntityEquityInterestsIssuedAndIssuable": [
-"2013-01-31",
-"Element deprecated because it has a debit balance attribute and instant period type. Possible replacement is BusinessCombinationConsiderationTransferredEquityInterestsIssuedAndIssuable."
-],
-"ParticipatingSecuritiesDistributedAndUndistributedEarnings": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are ParticipatingSecuritiesDistributedAndUndistributedEarningsLossBasic or ParticipatingSecuritiesDistributedAndUndistributedEarningsLossDiluted."
-],
-"AdditionsToNoncurrentAssets": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Possible replacement is corresponding primary line items and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
-],
-"LongDurationContractsAssumptionsByProductAndGuaranteeMortalityRateHighEnd": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are LongDurationContractsAssumptionsByProductAndGuaranteeMortalityRate, RangeAxis and MaximumMember."
-],
-"ShippingHandlingAndTransportationCostsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ShippingHandlingandTransportationCosts."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseReportedAndIncurredButNotReportedIBNRClaimsCommentary": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilityForClaimsAndClaimsAdjustmentExpenseMethodologiesAndAssumptions."
-],
-"PaymentsForPurchaseOfOtherAssets": [
-"2013-01-31",
-"Element was deprecated because it was being used for either operating or investing activities. Possible replacements are PaymentsForPurchaseOfOtherAssets1, PaymentsForProceedsFromOtherInvestingActivities or PaymentsToAcquireOtherProductiveAssets."
-],
-"CumulativeEffectOfProspectiveApplicationOfNewAccountingPrinciple": [
-"2015-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is CumulativeEffectOfNewAccountingPrincipleInPeriodOfAdoption."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseReportedAndIncurredButNotReportedIBNRClaims": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilityForClaimsAndClaimsAdjustmentExpense."
-],
-"LiquidityDisclosureFutureObligationsNotExpectedToBeRepaidAmount": [
-"2015-01-31",
-"Element was deprecated due to issuance of new guidance."
-],
-"ReorganizationItemsDescriptionOfNondebtorReorganizationItemsLegalAndAdvisoryProfessionalFees": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"CashFlowHedgeGainReclassifiedToCostOfSales": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CostOfGoodsSold and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"TaxesOtherThanIncomeAndExciseTaxesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is TaxesExcludingIncomeAndExciseTaxes."
-],
-"ReorganizationItemsDescriptionOfPensionAndOtherPostretirementPlansRelatedCharges": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"LiabilityForFuturePolicyBenefitByProductSegmentDomain": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ReinsurancePremiumsForInsuranceCompaniesByProductSegmentDomain."
-],
-"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureDevelopmentCosts": [
-"2013-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesDevelopmentCosts."
-],
-"UnsolicitedTenderOfferExpensesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"CashFlowHedgeGainLossReclassifiedToEarningsNet": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProfitLoss and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"ReorganizationItemsDescriptionOfDischargeOfClaimsAndLiabilities": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"FinancialGuaranteeInsuranceContractsClaimLiabilitySignificantComponentsOfChangeTimingAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"LimitedLiabilityCompanyLLCOrLimitedPartnershipLPAssetsAndLiabilitiesPreviouslyHeldByPredecessorEntityIesToBusinessCombination": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"NetInvestmentIncomeInsuranceEntity": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is NetInvestmentIncome."
-],
-"AssetsHeldForSaleCapitalLeasedAssetsNet": [
-"2014-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacements are DisposalGroupIncludingDiscontinuedOperationCapitalLeasedAssetsCurrent, DisposalGroupIncludingDiscontinuedOperationCapitalLeasedAssetsNoncurrent or DisposalGroupIncludingDiscontinuedOperationCapitalLeasedAssets."
-],
-"DirectPremiumsWrittenPropertyAndCasualty": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"CertainLoansAcquiredInTransferAccountedForAsAvailableForSaleDebtSecuritiesAccretableYield": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesAccretableYield and members of InformationByCategoryOfDebtSecurityAxis."
-],
-"PartiesToContractualArrangementAxis": [
-"2014-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacement is LeaseArrangementTypeAxis."
-],
-"FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInTradingRevenue": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
-],
-"ReorganizationItemsDescriptionOfWriteOffOfDeferredFinancingCostsAndDebtDiscounts": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"GainLossOnDispositionOfAssetsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnDispositionOfAssets."
-],
-"BusinessCombinationContingentConsiderationArrangementsChangeInAmountOfContingentConsiderationAsset": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is BusinessCombinationContingentConsiderationArrangementsChangeInAmountOfContingentConsiderationAsset1."
-],
-"BusinessAcquisitionPurchasePriceAllocationLand": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LossOnReceivablesAxis": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"ProductRecallDomain": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"LossContingencyRelatedReceivableCarryingValueCurrent": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is LossContingencyReceivableCurrent."
-],
-"GainOnPurchaseOfBusiness": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is BusinessCombinationBargainPurchaseGainRecognizedAmount."
-],
-"DerivativeLiabilityFairValueNet1": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DerivativeFairValueOfDerivativeLiabilityAmountNotOffsetAgainstCollateral."
-],
-"ShareBasedGoodsAndNonemployeeServicesTransactionCashFlowEffects": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is IssuanceOfStockAndWarrantsForServicesOrClaims."
-],
-"LineOfCreditFacilityAmountOutstanding": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LineofCredit."
-],
-"CashFlowHedgeGainLossReclassifiedToRevenueNetAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"UnprovedOilAndGasPropertyOrMajorProjectDomain": [
-"2013-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is ProjectMember."
-],
-"SignificantChangeInUnrecognizedTaxBenefitsIsReasonablyPossibleEstimatedRangeOfChangeUpperBound": [
-"2015-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are IncreaseInUnrecognizedTaxBenefitsIsReasonablyPossible or DecreaseInUnrecognizedTaxBenefitsIsReasonablyPossible."
-],
-"PresentValueOfFutureInsuranceProfitsDecreasesAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsMaterialGainLossNotRecognizedInCurrentFiscalYear": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"ProductionAndPropertyTaxExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ProductionTaxExpense or RealEstateTaxExpense."
-],
-"CashFlowHedgeGainReclassifiedToRevenue": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is Revenues and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"PrepaidCongressionallyMandatedAssessments": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"AccumulatedDeficitDuringDevelopmentStageMember": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FairValueEstimateNotPracticableReasonsSecuritiesSoldNotYetPurchased": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
-],
-"DisposalGroupNotDiscontinuedOperationGainLossOnDisposalIncomeStatementCaption": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DisposalGroupNotDiscontinuedOperationGainLossOnDisposal and members of IncomeStatementLocationAxis."
-],
-"EntityWideRevenueMajorCustomerAmount": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Possible replacement is Revenues and members of MajorCustomersAxis."
-],
-"USGovernmentAndGovernmentAgenciesAndAuthoritiesMember": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is USTreasuryAndGovernmentMember."
-],
-"StockIssuedDuringPeriodSharesIssuedForCash": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CertainLoansAcquiredInTransferAccountedForAsHeldToMaturityDebtSecuritiesAccretableYieldAdditions": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesAccretableYieldAdditions and members of InformationByCategoryOfDebtSecurityAxis."
-],
-"OtherTaxCarryforwardValuationAllowance": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TaxCreditCarryforwardValuationAllowance."
-],
-"DepositLiabilitiesWithAbnormalTermsDescription": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"BusinessAcquisitionPurchasePriceAllocationNoncurrentAssetsDescription": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"ChangeInTaxStatusDomain": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"AllowanceForFundsUsedDuringConstructionCapitalizedInterestMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is PublicUtilitiesAllowanceForFundsUsedDuringConstructionCapitalizedInterest."
-],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsWeightedAverageGrantDateFairValuePeriodIncreaseDecrease": [
-"2013-01-31",
-"Element was deprecated due to rationalization."
-],
-"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureNetCashFlows": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesNetCashFlows."
-],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsVestedInPeriodFairValue": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardOptionsVestedInPeriodFairValue1."
-],
-"FinancialGuaranteeInsuranceContractsRiskManagementActivitiesMitigatingClaimLiabilitiesExpenseFinancialStatementCaption": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FinancialGuaranteeInsuranceContractsRiskManagementActivitiesMitigatingClaimLiabilitiesExpense and members of IncomeStatementLocationAxis."
-],
-"FairValueEstimateNotPracticableReasonsPremiumsReceivable": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
-],
-"FairValueAdjustmentsOnHedgesAndDerivativeContractsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is UnrealizedGainLossOnDerivatives."
-],
-"FairValueEstimateNotPracticableReasonsTradingLiabilities": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
-],
-"FinancialGuaranteeInsuranceContractsRiskManagementActivitiesMitigatingClaimLiabilitiesExpenseAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"DeconsolidationGainOrLossIfNotPresentedSeparatelyFinancialStatementCaption": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DeconsolidationGainOrLossAmount and members of IncomeStatementLocationAxis."
-],
-"BusinessCombinationContingentConsiderationArrangementsChangeInAmountOfContingentConsiderationLiability": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is BusinessCombinationContingentConsiderationArrangementsChangeInAmountOfContingentConsiderationLiability1."
-],
-"IncreaseDecreaseInSpotCommodities": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"MinorityInterestInNetIncomeLossOperatingPartnerships": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacement is NoncontrollingInterestInNetIncomeLossOperatingPartnershipsNonredeemable or NoncontrollingInterestInNetIncomeLossOperatingPartnershipsRedeemable."
-],
-"ExecutiveCompensationContractsMember": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"StockOptionsMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is EmployeeStockOptionMember."
-],
-"BusinessAcquisitionContingentConsiderationSharesIssuable": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DeferredTaxLiabilityNotRecognizedLineItems": [
-"2013-01-31",
-"Element was deprecated."
-],
-"PartnersCapitalAdjustedBalance": [
-"2015-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is PartnersCapitalAdjustedBalance1."
-],
-"AccountingStandardsUpdate201011Member": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LossContingencySettlementAgreementConsideration1": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is LitigationSettlementAmount."
-],
-"GainLossOnDispositionOfPropertyMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnDispositionOfAssets1."
-],
-"SFAS141RElementsIncrementalToSFAS141Abstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"FairValueAssetsMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInTradingRevenue": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueAssetsMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
-],
-"LeveragedBuyoutRedemptionOfShareBasedAwards": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"GuaranteedBenefitLiabilityGross": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilitiesForGuaranteesOnLongDurationContractsGuaranteedBenefitLiabilityGross."
-],
-"CededCreditRiskClaimsLossAdjustmentExpenseIncurred": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"LiabilitiesSubjectToCompromiseDescriptionOfOtherLiabilities": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"ScheduleOfAssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionTable": [
-"2015-01-31",
-"Element deprecated due to redundancy. Possible replacement is IncomeStatementBalanceSheetAndAdditionalDisclosuresByDisposalGroupsIncludingDiscontinuedOperationsTable."
-],
-"TradingSecuritiesCurrentAbstract": [
-"2014-01-31",
-"Element was deprecated."
 ],
 "SubsequentEventTermOfContract": [
 "2013-01-31",
 "Element deprecated because it was inappropriately modeled.  Possible replacements are LesseeLeasingArrangementsOperatingLeasesTermOfContract, LessorLeasingArrangementsOperatingLeasesTermOfContract or DerivativeTermOfContract."
 ],
-"AvailableforsaleSecuritiesContinuousUnrealizedLossPositionLessThan12MonthsAggregateLosses2": [
-"2013-01-31",
-"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is AvailableForSaleSecuritiesContinuousUnrealizedLossPositionLessThan12MonthsAggregateLosses."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseGross": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilityForClaimsAndClaimsAdjustmentExpense."
-],
-"EITF064Member": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"MinorityInterestExpenseIncomeRealEstateInvestments": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacement is NetIncomeLossFromRealEstateInvestmentPartnershipAttributableToParent."
-],
-"BusinessAcquisitionPreacquisitionContingencyDescription": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LoanPortfolioExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is LoanPortfolioExpense."
-],
-"LineItemForGainLossOnPriceRiskDerivativeInstrumentsNotDesignatedAsHedgingInstrumentsInFinancialStatements": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is GainLossOnPriceRiskDerivativeInstrumentsNotDesignatedAsHedgingInstruments and members of IncomeStatementLocationAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationIntangibleAssetsDescription": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"SecuritizedAssetsAndAnyOtherFinancialAssetsManagedTogetherAverageBalanceDuringPeriod": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LoansAndLeasesReceivableForeignDescription": [
-"2015-01-31",
-"Element was deprecated and replaced with a more encompassing element. Possible replacement is LoansAndLeasesReceivableDescription."
-],
-"AssetsHeldForSaleCurrent": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are AssetsOfDisposalGroupIncludingDiscontinuedOperationCurrent or AssetsHeldForSaleNotPartOfDisposalGroupCurrent."
-],
-"CashFlowHedgeGainLossReclassifiedToInvestmentIncomeNetAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"GainLossOnSaleOfTradeReceivablesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnSaleOfAccountsReceivable."
-],
-"CededPremiumsEarnedAccidentAndHealth": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"FAS159Member": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"PremiumsWrittenNetPropertyAndCasualty": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PremiumsWrittenNet and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"WeightedAverageRateForeignDepositSavings": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"BusinessExitCosts": [
-"2013-01-31",
-"Element was deprecated. Possible replacement is BusinessExitCosts1."
-],
-"PresentValueOfFutureInsuranceProfitsDecrease": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"DistributionMadeToMemberOrLimitedPartnerCashDistributionsPaid": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberCashDistributionsPaid or DistributionMadeToLimitedPartnerCashDistributionsPaid."
-],
-"CashFlowHedgeLossReclassifiedToInterestExpense": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is InterestExpense and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"NetAmountAtRiskByProductAndGuaranteeNetAmountAtRiskInEventOfDeath": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are NetAmountAtRiskByProductAndGuaranteeNetAmountAtRisk, GuaranteedInsuranceContractTypeOfBenefitAxis and GuaranteedMinimumDeathBenefitMember."
-],
-"ShareBasedGoodsAndNonemployeeServicesTransactionExpense": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is IssuanceOfStockAndWarrantsForServicesOrClaims."
-],
-"DiscussionOfCreditRiskDerivativeRiskManagementPolicy": [
-"2013-01-31",
-"Element was deprecated because it has a stringItemType attribute. Possible replacement is DerivativesPolicyTextBlock."
-],
-"IntermediateLifePlantsEstimatedUsefulLife": [
-"2013-01-31",
-"Element was deprecated because it is has a stringItemType attribute. Possible replacement is IntermediateLifePlantsUsefulLife."
-],
-"FactorsOtherThanDistributionPolicyAffectingDistributionPayments": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"CashFlowHedgeLossReclassifiedToRevenue": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is Revenues and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"MileageCreditPrice": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"ResearchAndDevelopmentAssetAcquiredOtherThanThroughBusinessCombinationWrittenOffIncomeStatementCaption": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ResearchAndDevelopmentAssetAcquiredOtherThanThroughBusinessCombinationWrittenOff and members of IncomeStatementLocationAxis."
-],
-"BelowMarketLeasesMember": [
-"2013-01-31",
-"Element was deprecated because it is an invalid concept. Possible replacements are elements under BelowMarketLeaseAbstract."
-],
-"BusinessCombinationConsiderationTransferredOther": [
-"2013-01-31",
-"Element was deprecated because it has debit balance and instant period type attributes.  Possible replacement is BusinessCombinationConsiderationTransferredOther1."
-],
-"GainOnPurchaseOfBusinessMember": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"StandardProductWarrantyAccrualBalanceSheetCaption": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are StandardProductWarrantyAccrualCurrent, StandardProductWarrantyAccrualNoncurrent, and StandardProductWarrantyAccrual and members of BalanceSheetLocationAxis."
-],
-"PremiumsWrittenNetAccidentAndHealthAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"LeveragedBuyoutProfessionalFeesAndOther": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"IncomeLossFromEquityRealEstatePartnershipsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is RealEstatePartnershipInvestmentSubsidiariesNetIncomeLossBeforeTax."
-],
-"ConsumerLoansAutoFinancingReceivableMember": [
-"2015-01-31",
-"Element was deprecated due to remodeling of topic area. Possible replacements are ConsumerPortfolioSegmentMember and AutomobileLoanMember."
-],
-"RetailLandSalesDepositMethodSalesContractDisclosure": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"CustomerSecuritiesForWhichEntityHasRightToSellOrRepledgeSecuritiesSoldOrRepledgedClassification": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CustomerSecuritiesForWhichEntityHasRightToSellOrRepledgeFairValueOfSecuritiesSoldOrRepledged and members of BalanceSheetLocationAxis."
-],
-"OptionIndexedToIssuersEquityRedeemableStockRedemptionRequirementsAmount": [
-"2013-01-31",
-"Element was deprecated because it has debit balance and duration period type attributes. Possible replacement is OptionIndexedToIssuersEquityRedeemableStockRedemptionRequirementsAmount1."
-],
-"DeferredTaxLiabilityNotRecognizedNameOfTemporaryDifferenceDomain": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept remodeled as primary concepts."
-],
-"DebtorInPossessionFinancingPurposeOfArrangement": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"BusinessAcquisitionCostOfAcquiredEntityPurchasePriceAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"StockIssuedDuringPeriodValueIssuedForNoncashConsiderations": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureProductionCosts1": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesProductionCosts."
-],
-"ProceedsFromSaleOfWaterAndWasteWaterSystemsAbstract": [
+"SubsidiariesAndOtherInvestmentsOfLimitedLiabilityCompanyOrLimitedPartnershipAbstract": [
 "2015-01-31",
 "Element was deprecated."
-],
-"ReinsuranceEffectOnClaimsAndBenefitsIncurredPoliciesAcquiredInPeriod": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is PolicyholderBenefitsAndClaimsIncurredGross."
-],
-"DerivativeNonmonetaryNotionalAmountPricePerBarrel": [
-"2013-01-31",
-"Element was deprecated because the intended concept conveyed is the underlying. Possible replacement is UnderlyingDerivativeVolume."
-],
-"RegulatoryNoncurrentLiabilityAmortizationPeriod": [
-"2015-01-31",
-"Element was deprecated because it has a stringItemType attribute. Possible replacement is RegulatoryLiabilityAmortizationPeriod."
 ],
 "SubsidiaryOrEquityMethodInvesteeCumulativeProceedsReceivedOnAllTransactionsDescription": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"BorrowedFunds": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DebtAndCapitalLeaseObligations."
-],
-"NetInvestmentIncomeInsuranceEntityOtherLongTermInvestments": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NetInvestmentIncome and members of InvestmentTypeAxis."
-],
-"FinanceLeasesFinancingReceivableMember": [
-"2015-01-31",
-"Element was deprecated due to remodeling of topic area. Possible replacement is FinanceLeasesPortfolioSegmentMember."
-],
-"PropertyPlantAndEquipmentNumberOfAirframesSold": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInNextRollingTwelveMonths": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInNextRollingTwelveMonths."
-],
-"CollaborativeArrangementProductMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is CollaborativeArrangementProductAgreementMember."
-],
-"AccountingStandardsUpdate201013Member": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CumulativeEffectAdjustmentApplicationOfFairValueOptionUnrealizedLossesRecognized": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"EquityForwardAgreementsMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ForwardContractsMember."
-],
-"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsAccumulatedOtherComprehensiveIncome": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"BusinessCombinationSeparatelyRecognizedTransactionsNetGainsAndLossesAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"CashFlowHedgeGainLossReclassifiedToInterestExpenseNet": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is InterestExpense and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisAssetGainLossIncludedInOtherComprehensiveIncomeDescription": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisAssetGainLossIncludedInOtherComprehensiveIncomeLoss and members of OtherComprehensiveIncomeLocationAxis."
-],
-"IncomeBeforeExtraordinaryItemsMember": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"GainLossOnSaleOfLoansReceivableMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"LongLivedAssetsHeldForSaleGainLossOnSale": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is GainLossOnSaleOfPropertyPlantEquipment."
-],
-"CommercialRealEstateConstructionFinancingReceivableMember": [
-"2015-01-31",
-"Element was deprecated due to remodeling of topic area. Possible replacements are CommercialRealEstatePortfolioSegmentMember and ConstructionLoansMember."
-],
-"SiteContingencyAccrualCaption": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AccrualForEnvironmentalLossContingencies and members of BalanceSheetLocationAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationTangibleAssets": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"BankruptcyDomain": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"EquityFinancingForLeveragedBuyout": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"MinorRestatementOfOpeningLiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseSAB108Member": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are members of ErrorCorrectionsAndPriorPeriodAdjustmentsRestatementByRestatementPeriodAndAmountAxis."
-],
-"CashFlowHedgeGainReclassifiedToInterestExpense": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is InterestExpense and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"AdministrativeFeesAmountPaid": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is PaymentForAdministrativeFees."
-],
-"FairValueEstimateNotPracticableReasonsSeniorDebtObligations": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
-],
-"RegistrationPaymentArrangementBalanceSheetCaption": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is RegistrationPaymentArrangementAccrualCarryingValue and members of BalanceSheetLocationAxis."
-],
-"HeldtomaturitySecuritiesInUnrealizedLossPositionsQualitativeDisclosureOtherThirdPartyGuaranteesDescription": [
-"2013-01-31",
-"Element was deprecated."
-],
-"OccupancyNetMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OccupancyNet."
-],
-"FinancingReceivableModificationsPostModificationRecordedInvestment1": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is FinancingReceivableModificationsPostModificationRecordedInvestment2."
-],
-"LongLivedAssetsToBeAbandonedTimingOfExpectedDisposition": [
-"2015-01-31",
-"Element deprecated due to redundancy. Possible replacement is DisposalGroupIncludingDiscontinuedOperationDescriptionAndTimingOfDisposal."
-],
-"LeveragedBuyoutTransactionDisclosureTextBlock": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"NotionalAmountOfPriceRiskDerivatives": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis."
-],
-"InvestmentsInForeignSubsidiariesAndForeignCorporateJointVenturesThatAreEssentiallyPermanentInDurationMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are UndistributedEarningsOfForeignSubsidiaries,  DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferenceUndistributedEarningsOfForeignSubsidiaries, DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxableUndistributedEarningsOfForeignSubsidiaries, DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityUndistributedEarningsOfForeignSubsidiaries, DeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticableUndistributedEarningsOfForeignSubsidiaries."
-],
-"NoninterestExpensePrintingAndFulfillmentMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpensePrintingandFulfillment."
-],
-"LongLivedAssetsHeldForSaleImpairmentCharge": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is ImpairmentOfLongLivedAssetsToBeDisposedOf."
-],
-"CashFlowHedgeLossReclassifiedToInvestmentIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is InvestmentIncomeNet and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"LongDurationContractsAssumptionsByProductAndGuaranteeMortalityRateLowEnd": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are LongDurationContractsAssumptionsByProductAndGuaranteeMortalityRate, RangeAxis and MinimumMember."
-],
-"CertainLoansAcquiredInTransferAccountedForAsHeldToMaturityDebtSecuritiesAccretableYieldPeriodIncreaseDecrease": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesAccretableYieldPeriodIncreaseDecrease and members of InformationByCategoryOfDebtSecurityAxis."
-],
-"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInRollingYearFive": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInRollingYearFive."
-],
-"TradingSecuritiesEquityCurrent": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TradingSecuritiesEquity."
-],
-"DescriptionOfHedgedFirmCommitmentNotQualifyingAsPriceRiskFairValueHedge": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"IndefiniteLivedIntangibleAssetsAcquiredDuringPeriod": [
-"2013-01-31",
-"Element was deprecated because it was incorrectly defined.  Possible replacement element is IndefiniteLivedIntangibleAssetsAcquired."
-],
-"AverageBalanceDuringPeriodOfLoansHeldInPortfolio": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"ChangeInTaxStatusAxis": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsIntangibleAsset": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"StockholdersEquityIncludingPortionAttributableToNoncontrollingInterestAdjustedBalance": [
-"2013-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is StockholdersEquityIncludingPortionAttributableToNoncontrollingInterestAdjustedBalance1."
-],
-"BusinessAcquisitionPurchasePriceAllocationNoncurrentAssets": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"BusinessAcquisitionPurchasePriceAllocationStatus": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AllowanceForLoanAndLeaseLossesRecoveriesOfBadDebts": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is AllowanceForLoanAndLeaseLossRecoveryOfBadDebts."
-],
-"BusinessAcquisitionPurchasePriceAllocationProjectedBenefitObligationAsset": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"MortgageLoansOnRealEstateRenewedAndExtendedAmount": [
-"2013-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is MortgageLoansOnRealEstateRenewedAndExtendedAmount1."
-],
-"CategoriesOfInvestmentsCostMethodInvestmentsMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is CostmethodInvestmentsMember."
-],
-"CashFlowHedgeGainLossReclassifiedToCostOfSalesNet": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CostOfGoodsSold and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"LongLivedAssetsToBeAbandonedCircumstancesLeadingToPlannedAbandonment": [
-"2015-01-31",
-"Element deprecated due to redundancy. Possible replacement is DisposalGroupIncludingDiscontinuedOperationDescriptionAndTimingOfDisposal."
-],
-"GeographicalIntersegmentEliminationsMember": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Possible replacements are members of ConsolidationItemsAxis."
-],
-"WeightedAverageRateForeignDepositChecking": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"LeveragedBuyoutContinuingOwnershipInterestByContinuingStockholders": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"VariableInterestEntityClassificationOfCarryingAmountAssetsAndLiabilitiesNet": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are VariableInterestEntityClassificationOfCarryingAmountAssets and VariableInterestEntityClassificationOfCarryingAmountLiabilities and members of BalanceSheetLocationAxis."
-],
-"ForeignReinsuranceUnderOpenYearMethodPremiumsClaimsAndExpense": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"AccountingStandardsUpdate200908Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"SignificantAcquisitionsAndDisposalsGainLossOnSaleOrDisposalNetOfTax": [
-"2015-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is DiscontinuedOperationGainLossOnDisposalOfDiscontinuedOperationNetOfTax."
-],
-"AssetsDesignatedToClosedBlockOtherClosedBlockAssets": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area. Possible replacement is AssetsDesignatedToClosedBlockOtherClosedBlockAssets1."
-],
-"OtherComprehensiveIncomeLossReclassificationAdjustmentForWritedownOfSecuritiesIncludedInNetIncomeBeforeTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForWritedownOfSecuritiesBeforeTax."
-],
-"AllowanceForLoanAndLeaseLossesProvisionForLossGross": [
-"2013-01-31",
-"Element was deprecated because it is an invalid concept. Possible replacement is ProvisionForLoanAndLeaseLosses."
-],
-"DerivativeHedgeDesignation": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
-],
-"GainsLossesOnSalesOfAssetsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnDispositionOfAssets1."
-],
-"SalesRevenueGoodsNetPercentage": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ConcentrationRiskPercentage1 and members of ConcentrationRiskByBenchmarkAxis."
-],
-"CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesOtherThanTemporaryImpairmentCharges": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesOtherthanTemporaryImpairmentChargesCreditLoss."
-],
-"StatutoryAccountingPracticesPortionOfExcessRetainedEarningsNotTaxedReason": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"GainLossOnSaleOfSubsidiarysStockMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"ProceedsFromSaleOfWasteWaterSystems": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"AccumulatedOtherComprehensiveIncomeLossBeforeTaxRollForward": [
-"2015-01-31",
-"Element was deprecated."
-],
-"SharesSubjectToMandatoryRedemptionSettlementTermsForwardPriceOrOptionStrikePrice": [
-"2014-01-31",
-"Element was deprecated because it has a perUnitItemType attribute, it represents multiple distinct concepts and the financial reporting concept can be conveyed dimensionally. Possible replacements are OptionIndexedToIssuersEquityStrikePrice1 or ForwardContractIndexedToIssuersEquityForwardRate and members of ScheduleOfSharesSubjectToMandatoryRedemptionBySettlementTermsAxis."
-],
-"FiveYearScheduleOfMaturitiesOfParentCompanyRepaymentsOfPrincipleInYearTwo": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInYearTwo."
-],
-"NotionalAmountOfOtherDerivativesNotDesignatedAsHedgingInstruments": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of HedgingDesignationAxis."
-],
-"DerivativeNonmonetaryNotionalAmountPricePerGallon": [
-"2013-01-31",
-"Element was deprecated because the intended concept conveyed is the underlying. Possible replacement is UnderlyingDerivativeVolume."
-],
-"DebtInstrumentInterestRateAtPeriodEnd": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DebtInstrumentInterestRateEffectivePercentage."
-],
-"SaleOfStockSubsidiary": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is SubsidiariesMember."
-],
-"AssetsHeldForSaleMember": [
-"2015-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacement is DisposalGroupHeldForSaleNotDiscontinuedOperationsMember."
-],
-"FairValueAssetsMeasuredOnRecurringBasisGainLossIncludedInTradingRevenue": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisAssetGainLossIncludedInEarnings1 and members of IncomeStatementLocationAxis."
-],
-"AmountAvailableForDividendDistributionWithApprovalFromRegulatoryAgencies": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is StatutoryAccountingPracticesStatutoryAmountAvailableForDividendPaymentsWithRegulatoryApproval."
-],
-"NetInvestmentIncomeInsuranceEntityShortTermInvestments": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NetInvestmentIncome and members of InvestmentTypeAxis."
-],
-"FairValueEstimateNotPracticableFinancialLiabilitiesReasonsAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"DerivativeInstrumentsGainRecognizedInIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeGainOnDerivative and members of HedgingDesignationAxis."
-],
-"ScheduleOfSignificantAcquisitionsAndDisposalsTable": [
-"2015-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are ScheduleOfBusinessAcquisitionsByAcquisitionTable or IncomeStatementBalanceSheetAndAdditionalDisclosuresByDisposalGroupsIncludingDiscontinuedOperationsTable."
-],
-"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInRollingYearTwo": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInRollingYearTwo."
-],
-"LossContingencyRelatedReceivableCarryingValueNoncurrent": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is LossContingencyReceivableNoncurrent."
-],
-"DeprecatedItems": [
-"",
-"This is a container item for US-GAAP concepts that have been deprecated."
-],
-"LiabilitiesForGuaranteesOnLongDurationContractsDesignationAsNontraditional": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"RevenueRecognitionNewAccountingPronouncementUnitOfAccounting": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LitigationSettlementGross": [
-"2013-01-31",
-"Element was deprecated. Possible replacement is LitigationSettlementAmount."
-],
-"BusinessAcquisitionPreacquisitionContingencyAmount": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DirectPremiumsWrittenOtherInsurance": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"BankruptcyClaimsDescriptionOfMaterialContractsRejected": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsReceivables": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DefinedContributionPlanMaximumAnnualContributionPerEmployeeAmount": [
-"2013-01-31",
-"Element was deprecated because it was incorrectly defined. Possible replacement is DefinedContributionPlanMaximumAnnualContributionsPerEmployeeAmount."
-],
-"HealthCareOrganizationAmountOfWriteOffsOfAllowanceForDoubtfulAccounts": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AllowanceForDoubtfulAccountsReceivableWriteOffs."
-],
-"BusinessAcquisitionCostOfAcquiredEntityPlannedRestructuringActivities": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"BusinessCombinationSeparatelyRecognizedTransactionsLiabilitiesFinancialStatementCaption": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is BusinessCombinationSeparatelyRecognizedTransactionsLiabilitiesRecognized and members of BalanceSheetLocationAxis."
-],
-"NetInvestmentIncomeInsuranceEntityInvestmentRealEstate": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NetInvestmentIncome and members of InvestmentTypeAxis."
-],
-"OtherTaxCarryforwardNameDomain": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TaxCreditCarryforwardNameDomain."
-],
-"BankruptcyProceedingsDescriptionOfOperationalImprovementPlans": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"FAS156Member": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FairValueEstimateNotPracticableFinancialAssetsReasonsAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"RecordedThirdPartyEnvironmentalRecoveriesComponents": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"ScheduleOfDistributionsMadeToMembersOrLimitedPartnersByDistributionTextBlock": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacement is  DistributionsMadeToLimitedLiabilityCompanyLlcMemberByDistributionTableTextBlock or DistributionsMadeToLimitedPartnerByDistributionTableTextBlock."
-],
-"RevolvingLoanFacilityToFinanceLeveragedBuyout": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DisposalGroupSpecialTransactionClassificationsAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"FiveYearScheduleOfMaturitiesOfParentCompanyRepaymentsOfPrincipleInYearFour": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInYearFour."
-],
-"CollaborativeArrangementProductAggregatedDisclosureMember": [
-"2013-01-31",
-"Element was deprecated because of unnecessary level of disaggregation in a parent-child relationship."
-],
-"LoansAndLeasesReceivableConsumerDescription": [
-"2015-01-31",
-"Element was deprecated and replaced with a more encompassing element. Possible replacement is LoansAndLeasesReceivableDescription."
-],
-"ExperienceRatedRefundsPayable": [
-"2013-01-31",
-"Element was deprecated due to remodeling of reinsurance topic area."
-],
-"MortgageLoansOnRealEstatePriorLiens": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is MortgageLoansOnRealEstatePriorLiens1."
-],
-"BusinessAcquisitionContingentConsiderationPotentialCashPayment": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"IncomeLossFromDiscontinuedOperationsNetOfTaxPerOutstandingLimitedPartnershipUnit": [
-"2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromDiscontinuedOperationsNetOfTaxPerOutstandingLimitedPartnershipUnitBasic."
-],
-"RestructuringAndRelatedCostCostIncurredToDate": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is RestructuringAndRelatedCostCostIncurredToDate1."
-],
-"IncreaseDecreaseInCarryingValueOfAssetsReceivedAsConsiderationInDisposalOfBusiness": [
-"2013-01-31",
-"Element was deprecated."
-],
-"HeldToMaturitySecuritiesUnrecognizedHoldingLoss": [
-"2013-01-31",
-"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is HeldToMaturitySecuritiesUnrecognizedHoldingLosses."
-],
-"OriginationAndPurchasesOfMortgageBankingAssets": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is PaymentsForOriginationAndPurchasesOfLoansHeldForSale."
-],
-"FinancingDomain": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"DisposalGroupIncludingDiscontinuedOperationIntangibleAssetsNet": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DisposalGroupIncludingDiscontinuedOperationIntangibleAssetsNoncurrent, DisposalGroupIncludingDiscontinuedOperationIntangibleAssetsCurrent or DisposalGroupIncludingDiscontinuedOperationIntangibleAssets."
-],
-"BusinessAcquisitionPurchasePriceAllocationNoncontrollingInterest": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DescriptionOfSubstantialDoubtAboutInstitutionsAbilityToContinueAsGoingConcernBankingOrSavingsInstitution": [
-"2015-01-31",
-"Element was deprecated due to issuance of new guidance."
-],
-"SiteContingencyAccrualUndiscountedAmount": [
-"2013-01-31",
-"Element was deprecated due to redundancy.  Possible replacement is AccrualForEnvironmentalLossContingenciesGross."
-],
-"ValuationAllowanceAmount": [
-"2013-01-31",
-"Element was deprecated due to redundancy.  Possible replacement is DeferredTaxAssetsValuationAllowance."
-],
-"DebtInstrumentBasisSpreadOnVariableRate": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is DebtInstrumentBasisSpreadOnVariableRate1."
-],
-"SignificantAcquisitionsAndDisposalsGainLossOnSaleOrDisposalPretax": [
-"2015-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacements are DiscontinuedOperationGainLossFromDisposalOfDiscontinuedOperationBeforeIncomeTax or DisposalGroupNotDiscontinuedOperationGainLossOnDisposal."
-],
-"OtherComprehensiveIncomeReclassificationOfDefinedBenefitPlanNetTransitionAssetObligationRecognizedInNetPeriodicBenefitCostNetOfTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetTransitionAssetObligationNetOfTax."
-],
-"DeferredPolicyAcquisitionCostsAndPresentValueOfFutureProfits": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DeferredPolicyAcquisitionCostsAndValueOfBusinessAcquired."
-],
-"CausesOfIncreaseDecreaseInLiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAxis": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilityForCatastropheClaimsByCatastrophicEventAxis."
-],
-"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsNetAmountRecognized": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FinancialGuaranteeInsuranceContractsClaimLiabilitySignificantComponentsOfChangeTimingIfNotPresentedSeparatelyFinancialStatementCaption": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FinancialGuaranteeInsuranceContractsClaimLiabilitySignificantComponentsOfChangeTiming and members of IncomeStatementLocationAxis."
-],
-"FinancingReceivableAllowanceDomain": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is FinancingReceivableRecordedInvestmentClassOfFinancingReceivableDomain."
-],
-"ReorganizationItemsDescriptionOfRetireeRelatedCharges": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"CashAndSecuritiesSegregatedUnderOtherRegulationsDescription": [
-"2015-01-31",
-"Element deprecated due to redundancy. Possible replacement is CashAndSecuritiesSegregatedUnderFederalAndOtherRegulationsDescription."
-],
-"AverageBalanceDuringPeriodOfLoansHeldInPortfolioAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"OtherAmortizationMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OtherAmortizationOfDeferredCharges."
-],
-"OtherAssetsHeldForSaleCurrent": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DisposalGroupIncludingDiscontinuedOperationOtherCurrentAssets or AssetsHeldForSaleNotPartOfDisposalGroupCurrentOther."
-],
-"ClosedBlockDividendObligation": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ClosedBlockLiabilitiesPolicyholderDividendObligation."
-],
-"LossContingencyAccrualCarryingValueProvision": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is LossContingencyAccrualProvision."
-],
-"PremiumsWrittenAssumedCededAndEarnedAndIndustryRatiosAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"PremiumsEarnedNetOtherInsuranceAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"CumulativeEffectAdjustmentApplicationOfFairValueOptionUnrealizedGainsUnrecognized": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"NotionalAmountOfForeignCurrencyFairValueHedgeDerivatives": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis and DerivativeInstrumentRiskAxis."
-],
-"PremiumIncomeSubjectToParticipationThroughReinsurancePercentage": [
-"2013-01-31",
-"Element was deprecated."
-],
-"PremiumsWrittenNetAccidentAndHealth": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PremiumsWrittenNet and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"EscrowDepositDisbursementsRelatedToPropertyAcquisition": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is EscrowDepositDisbursementsRelatedToPropertyAcquisition1."
-],
-"NoninterestExpenseTransferAgentAndCustodianFeesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpenseTransferAgentandCustodianFees."
-],
-"FairValueDisclosureOffBalanceSheetRisksSignificantAssumptions": [
-"2015-01-31",
-"Element was deprecated and replaced with a more encompassing element. Possible replacement is FairValueDisclosureOffBalanceSheetRisksDescription."
-],
-"LoansReceivableHeldForSaleNet": [
-"2015-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacement is LoansReceivableHeldForSaleNetNotPartOfDisposalGroup."
-],
-"SubsequentEventDateEvaluationEnded1": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"LiabilitiesSubjectToCompromiseDescriptionOfEnvironmentalContingencies": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAdjustmentOfOpeningBalanceAxis": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacements are AdjustmentsForChangeInAccountingPrincipleAxis and ErrorCorrectionsAndPriorPeriodAdjustmentsRestatementByRestatementPeriodAndAmountAxis."
-],
-"MinorityInterestInNetIncomeLossPreferredUnitHolders": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacement is NoncontrollingInterestInNetIncomeLossPreferredUnitHoldersRedeemable or NoncontrollingInterestInNetIncomeLossPreferredUnitHoldersNonredeemable."
-],
-"AccountingStandardsUpdate200912Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AccountingStandardsUpdate200917Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LineItemForPriceRiskFairValueHedgeDerivativeOnBalanceSheet": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are PriceRiskFairValueHedgeAssetAtFairValue, PriceRiskFairValueHedgeLiabilityAtFairValue, and PriceRiskFairValueHedgeDerivativeAtFairValueNet and members of BalanceSheetLocationAxis."
-],
-"FinancingReceivableByCreditQualityIndicatorDomain": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are CreditRatingAMBestDomain, InternalCreditAssessmentDomain, ExternalCreditRatingFitchMember, ExternalCreditRatingStandardPoorsMember, ExternalCreditRatingMoodysMember, ExternalCreditRatingByGroupingDomain."
-],
-"BankruptcyOfPartyAxis": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"SubordinatedBorrowingWithSixMonthNoticeOfIntentToWithdraw": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"MaximumFutureEarningsFromClosedBlockAssetsAndLiabilities1": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ClosedBlockAssetsAndLiabilitiesMaximumFutureEarningsToBeRecognized."
-],
-"FairValueEstimateNotPracticableReasonsFederalFundsSoldAndSecuritiesBorrowedOrPurchasedUnderAgreementsToResell": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
-],
-"AllCertainLoansAcquiredInTransferAccountedForAsHeldToMaturityDebtSecuritiesNotAccountedForUsingIncomeRecognitionModelEndOfPeriodAtCarryingValue": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AllCertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesNotAccountedForUsingIncomeRecognitionModelEndOfPeriodAtCarryingValue and members of InformationByCategoryOfDebtSecurityAxis."
-],
-"DeferredTaxLiabilityNotRecognizedTable": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"FairValueEstimateNotPracticableReasonsDeposits": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
-],
-"TradingSecuritiesFairValueDisclosure": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TradingSecurities."
-],
-"ImpairmentOfGoodwillMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GoodwillImpairmentLoss."
-],
-"ProceedsFromSaleOfOtherAssets": [
-"2013-01-31",
-"Element was deprecated because it was being used for either operating or investing activities. Possible replacements are ProceedsFromSaleOfOtherAssets1 and ProceedsFromSaleOfOtherAssetsInvestingActivities."
-],
-"CumulativeEffectAdjustmentBifurcationOfHybridsGrossGains": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"NotionalAmountOfFairValueHedgeInstruments": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
-],
-"DeferredCompensationArrangementWithIndividualRequisiteServicePeriod": [
-"2014-01-31",
-"Element was deprecated because it has a stringItemType attribute. Possible replacement is DeferredCompensationArrangementWithIndividualRequisiteServicePeriod1."
-],
-"HeldToMaturitySecuritiesContinuousUnrealizedLossPositionLessThan12MonthsAggregateLosses": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is HeldToMaturitySecuritiesContinuousUnrealizedLossPositionLessThan12MonthsAggregateLoss."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentLiabilitiesAccountsPayable": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxable": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxableUndistributedEarningsOfForeignSubsidiaries, DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxableUndistributedEarningsOfDomesticSubsidiaries, DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxableBadDebtReserveForTaxPurposesOfQualifiedLender,  and DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxablePolicyholdersSurplus."
-],
-"CapitalizedExploratoryWellCostsGreaterThanOrEqualToOneYearAndLessThanTwoYears": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CapitalizedExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
-],
-"DirectPremiumsEarnedLife": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"BankruptcyClaimsDescriptionOfClaimsUnderReviewByManagement": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"SubsequentEventDateFinancialStatementsAvailableForIssuance": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"IncomeTaxExpenseBenefitAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"LoansReceivableHeldForSaleNetBankPresentationAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"SaleLeasebackTransactionNetProceeds": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are SaleLeasebackTransactionNetProceedsInvestingActivities or SaleLeasebackTransactionNetProceedsFinancingActivities."
-],
-"GainLossOnCreditRiskHedgeIneffectiveness": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeNetHedgeIneffectivenessGainLoss and members of CreditDerivativesByContractTypeAxis."
-],
-"IncreaseDecreaseInBorrowedSecurities": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is IncreaseDecreaseInSecuritiesBorrowed."
-],
-"NotionalAmountOfCashFlowHedgeInstruments": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
-],
-"ScheduleOfLongLivedAssetsToBeAbandonedTable": [
-"2015-01-31",
-"Element deprecated due to redundancy. Possible replacement is IncomeStatementBalanceSheetAndAdditionalDisclosuresByDisposalGroupsIncludingDiscontinuedOperationsTable."
-],
-"ReorganizationItemsDescriptionOfEmployeeRelatedCharges": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"ForeignReinsuranceUnderOpenYearMethodPremiumsInUnderwritingAccount": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ForeignReinsuranceUnderOpenYearMethodPremiums."
-],
-"LiabilityForUnpaidClaimsAdjustmentExpenseByExpenseTypeTextBlock": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ScheduleOfLiabilityForUnpaidClaimsAndClaimsAdjustmentExpense."
-],
-"DefinedBenefitPlanEstimatedFutureEmployerContributionsInCurrentFiscalYear": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is DefinedBenefitPlansEstimatedFutureEmployerContributionsInCurrentFiscalYear."
-],
-"FinancialInstrumentsOwnedAndPledgedAsCollateralAssociatedLiabilitiesCaption": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is SecurityOwnedAndPledgedAsCollateralAssociatedLiabilitiesFairValue and members of BalanceSheetLocationAxis."
-],
-"CancellationOfContractDomain": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"PaymentsForRepurchaseOfCommonStockForEmployeeTaxWithholdingObligations": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is PaymentsRelatedToTaxWithholdingForShareBasedCompensation."
-],
-"SignificantAcquisitionsAndDisposalsAcquisitionCostsOrSaleProceeds": [
-"2015-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DisposalGroupIncludingDiscontinuedOperationConsideration or BusinessCombinationConsiderationTransferredIncludingEquityInterestInAcquireeHeldPriorToCombination1."
-],
-"AccountingStandardsUpdate201016Member": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"MembersOrLimitedPartnersSubsequentDistributionDate": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberDistributionDate and members of SubsequentEventTypeAxis or DistributionMadeToLimitedPartnerDistributionDate and members of SubsequentEventTypeAxis."
-],
-"UnrealizedGainLossOrWriteDownMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is MarketableSecuritiesUnrealizedGainLoss."
-],
-"OtherOperatingExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OtherCostAndExpenseOperating."
-],
-"NotionalAmountOfForeignCurrencyCashFlowHedgeDerivatives": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and DerivativeInstrumentsGainLossByHedgingRelationshipAxis."
-],
-"UnallocatedAmountToSegmentMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is MaterialReconcilingItemsMember."
-],
-"FairValueEstimateNotPracticableReasonsInvestmentInFederalHomeLoanBankStock": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
-],
-"ReorganizationItemsDescriptionOfGainLossOnRejectionOfLeasesAndOtherContractsNet": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"BusinessAcquisitionPurchasePriceAllocationProperty": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CertainLoansAcquiredInTransferAccountedForAsAvailableForSaleDebtSecuritiesAccretableYieldAccretion": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesAccretableYieldAccretion and members of InformationByCategoryOfDebtSecurityAxis."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisChangeInUnrealizedGainLossIncludedInOtherIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueLiabilitiesMeasuredOnRecurringBasisChangeInUnrealizedGainLoss and members of IncomeStatementLocationAxis."
-],
-"PrepaidReinsurancePremiumsAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"RetailLandSalesDepositMethodTermsOfSale": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"CededCreditRiskRiskClassificationDomain": [
-"2015-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacements are ConcentrationRiskBenchmarkDomain and ConcentrationRiskTypeDomain."
-],
-"CertainLoansAcquiredInTransferAccountedForAsHeldToMaturityDebtSecuritiesAccretableYieldAccretion": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesAccretableYieldAccretion and members of InformationByCategoryOfDebtSecurityAxis."
-],
-"BusinessCombinationSeparatelyRecognizedTransactionsRevenuesAndGainsAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"ReorganizationItemsDescriptionOfRevaluationOfAssetsAndLiabilitiesUponEmergenceFromBankruptcy": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"OperatingLossCarryforwardsExpirationDates": [
-"2013-01-31",
-"Element was deprecated because it has a stringItemtype attribute. Possible replacement is OperatingLossCarryforwardsExpirationDate."
-],
-"FinancingReceivableRecordedInvestment1To29DaysPastDue": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FinancingReceivableRecordedInvestmentPastDue and FinancingReceivables1To29DaysPastDueMember."
-],
-"FairValueEstimateNotPracticableReasonsCommitments": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
-],
-"EquityIssuanceDates": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"SiteContingencyAccrualDiscountRate": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AccrualForEnvironmentalLossContingenciesDiscountRate."
-],
-"NettingAndCollateralMember": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are DerivativeAssetFairValueGrossLiability, DerivativeAssetCollateralObligationToReturnCashOffset, DerivativeAssetFairValueGrossLiabilityAndObligationToReturnCashOffset, SecuritiesPurchasedUnderAgreementsToResellLiability, SecuritiesBorrowedLiability, DerivativeAssetSecuritiesPurchasedUnderAgreementsToResellSecuritiesBorrowedLiability, DerivativeLiabilityFairValueGrossAsset, DerivativeLiabilityCollateralRightToReclaimCashOffset, DerivativeLiabilityFairValueGrossAssetAndRightToReclaimCashOffset, SecuritiesSoldUnderAgreementsToRepurchaseAsset, SecuritiesLoanedAsset, or DerivativeLiabilitySecuritiesSoldUnderAgreementsToResellSecuritiesLoanedAsset."
-],
-"IncomeTaxPenaltiesAndInterestAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"ExplanationDifferencesBetweenBookAndTaxBasis": [
-"2013-01-31",
-"Element was deprecated because it is an invalid concept."
-],
-"CancellationOfContractAxis": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"AvailableForSaleSecuritiesFairValueDisclosure": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AvailableForSaleSecurities."
-],
-"SignificantAcquisitionsAndDisposalsTransactionDomain": [
-"2015-01-31",
-"Element deprecated due to redundancy. Possible replacement is PropertyPlantAndEquipmentTypeDomain."
-],
-"AccountingStandardsUpdate201024Member": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"IndicationThatFinancialStatementsAreThoseOfDevelopmentStageEnterprise": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DeferredPolicyAcquisitionCostsNet": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DeferredPolicyAcquisitionCosts."
-],
-"GovernmentInvestigationIntoIllegalOrUnethicalActivityInGovernmentContracts": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"OtherComprehensiveIncomeLossReclassificationAdjustmentForWriteDownOfSecuritiesIncludedInNetIncomeTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForWritedownOfSecuritiesTax."
-],
-"SignificantAcquisitionsAndDisposalsRestrictionOnAmountOfProceedsFromDonatedPropertyPlantAndEquipment": [
-"2015-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"FairValueEstimateNotPracticableReasonsCostMethodInvestments": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
-],
-"GoodwillImpairedIncomeStatementClassification": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is GoodwillImpairmentLoss and members of IncomeStatementLocationAxis."
-],
-"BusinessCombinationSeparatelyRecognizedTransactionsAssetsFinancialStatementCaption": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is BusinessCombinationSeparatelyRecognizedTransactionsAssetsRecognized and members of BalanceSheetLocationAxis."
-],
-"LongDurationContractsAssumptionsByProductAndGuaranteeEstimatedInvestmentYieldHighEnd": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LongDurationContractsAssumptionsByProductAndGuaranteeEstimatedAverageInvestmentYield, RangeAxis and MaximumMember."
-],
-"OtherComprehensiveIncomeLossReclassificationAdjustmentOnDerivativesIncludedInNetIncomeBeforeTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIOnDerivativesBeforeTax."
-],
-"AgingOfCapitalizedExploratoryWellCostAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"HeldToMaturitySecuritiesFairValueDisclosure": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is HeldToMaturitySecuritiesFairValue."
-],
-"MalpracticeInsuranceThirdPartyInsuranceCompany": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"HeldToMaturitySecuritiesContinuousUnrealizedLossPosition12MonthsOrLongerAggregateLosses": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is HeldToMaturitySecuritiesContinuousUnrealizedLossPosition12MonthsOrLongerAggregateLoss."
-],
-"BusinessAcquisitionPurchasePriceAllocationOtherNoncurrentAssets": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"ProductionAndDistributionCostsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ProductionAndDistributionCosts."
-],
-"InterestAndDividendIncomeMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is InvestmentIncomeInterestAndDividend."
-],
-"LimitedLiabilityCompanyOrLimitedPartnershipBusinessAndType": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"DistributionMadeToMemberOrLimitedPartnerDistributionsDeclaredPerUnit": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberDistributionsDeclaredPerUnit or DistributionMadeToLimitedPartnerDistributionsDeclaredPerUnit."
-],
-"DescriptionOfChangeInAverageTrancheLifeEstimate": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"OtherComprehensiveIncomeReclassificationOfDefinedBenefitPlansNetGainLossRecognizedInNetPeriodicBenefitCostBeforeTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetGainLossBeforeTax."
-],
-"GainLossOnInvestmentsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnInvestments."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsPrepaidExpenseAndOtherAssets": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FinancingReceivableModificationsSubsequentDefaultNumberOfContracts": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is FinancingReceivableModificationsSubsequentDefaultNumberOfContracts1."
-],
-"FiveYearScheduleOfMaturitiesOfParentCompanyRepaymentsOfPrincipleInYearFive": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInYearFive."
-],
-"NotionalAmountOfCreditRiskDerivatives": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of CreditDerivativesByContractTypeAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationNetTangibleAssets": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LiabilitiesForGuaranteesOnLongDurationContractsGuaranteedBenefitType": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are the children of LiabilitiesForGuaranteesOnLongDurationContractsLineItems and members of GuaranteedInsuranceContractTypeOfBenefitAxis."
-],
-"DescriptionOfCreditRiskDerivativeActivities": [
-"2013-01-31",
-"Element was deprecated because it has a stringItemType attribute. Possible replacement is DisclosureOfCreditDerivativesTextBlock."
-],
-"NetAmountAtRiskByProductAndGuaranteeSeparateAccountValueAtAnnuitization": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are NetAmountAtRiskByProductAndGuaranteeSeparateAccountValue, GuaranteedInsuranceContractTypeOfBenefitAxis and AnnuitizationBenefitMember."
-],
-"SignificantMattersUnresolvedSinceBankruptcyEmergenceDescriptionOfMatters": [
-"2015-01-31",
-"Element was deprecated and replaced with a more encompassing element. Possible replacement is SignificantMattersUnresolvedSinceBankruptcyEmergence."
-],
-"GainLossOnSaleOfLeasedAssetsNetOperatingLeasesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"EnvironmentalCostsOfPropertyForSaleDisposalOrAbandonmentAnticipatedExitCosts": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is EnvironmentalExitCostsAnticipatedCost."
-],
-"EnvironmentalCostsOfPropertyForSaleDisposalOrAbandonmentDisclosures": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is EnvironmentalExitCostsNatureOfCosts."
-],
-"CashForLeveragedBuyoutBySourceAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"OtherExpenseOfInsuranceEntities": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is OtherExpenses."
-],
-"SettlementOfDebtMember": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"AssetsHeldForSaleAtCarryingValue": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are AssetsOfDisposalGroupIncludingDiscontinuedOperation or AssetsHeldForSaleNotPartOfDisposalGroup."
-],
-"LeveragedBuyoutOwnershipInterestOfNewInvestors": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"OtherComprehensiveIncomeLossReclassificationPensionAndOtherPostretirementBenefitPlansNetGainLossRecognizedInNetPeriodicBenefitCostTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetGainLossTax."
-],
-"CashFlowHedgeGainLossReclassifiedToOtherIncomeNetAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"CumulativeEffectAdjustmentApplicationOfFairValueOptionUnrealizedGainsRecognized": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CumulativeEffectAdjustmentApplicationOfFairValueOptionGrossLossesAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"SubsidiaryOrEquityMethodInvesteeReasonForOmittingDeferredIncomeTaxProvisionOnCumulativeGainLossRecognized": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"FiveYearScheduleOfMaturitiesOfParentCompanyRepaymentsOfPrincipleWithinOneYear": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInNextTwelveMonths."
-],
-"LossContingencyRangeOfPossibleLoss": [
-"2015-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are LossContingencyRangeOfPossibleLossMinimum and LossContingencyRangeOfPossibleLossMaximum."
-],
-"EntityWideDisclosureOnGeographicAreasLongLivedAssetsInEntitysCountryOfDomicile": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Possible replacement is NoncurrentAssets and members of StatementGeographicalAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationIntangibleAssetsOtherThanGoodwill": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAdjustmentOfOpeningBalanceTypeDomain": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacements are ChangeInAccountingPrincipleMember and AdjustmentsForErrorCorrectionDomain."
-],
-"ReorganizationItemsDescriptionOfDebtorInPossessionFacilityFinancingCosts": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"AcquiredIndefiniteLivedIntangibleAssetAmount": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is IndefinitelivedIntangibleAssetsAcquired."
-],
-"CertainLoansAcquiredInTransferAccountedForAsHeldToMaturityDebtSecuritiesAccretableYieldReclassificationsToNonaccretableDifference": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesAccretableYieldReclassificationsToNonaccretableDifference and members of InformationByCategoryOfDebtSecurityAxis."
-],
-"DevelopmentStageEnterprisesAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"GainLossOnCreditRiskDerivativesNet": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeGainLossOnDerivativeNet and members of CreditDerivativesByContractTypeAxis."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseIncurredClaimsPriorYears": [
-"2014-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is SupplementalInformationForPropertyCasualtyInsuranceUnderwritersPriorYearClaimsAndClaimsAdjustmentExpense."
-],
-"BusinessCombinationStepAcquisitionEquityInterestInAcquireeFairValue": [
-"2013-01-31",
-"Element was deprecated because it has debit balance and instant period type attributes. Possible replacement is BusinessCombinationStepAcquisitionEquityInterestInAcquireeFairValue1."
-],
-"RefundsReceivedRelatedToRevenueFromDifferentYearMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"EquitySecuritiesOtherMember": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"RealEstateInsuranceMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is RealEstateInsurance."
-],
-"AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionSegmentClassification": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionGainLossOnDisposition1 and members of StatementBusinessSegmentsAxis."
-],
-"GainLossOnSettlementOfDerivativeInstrumentMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnSaleOfDerivatives."
-],
-"ProjectsWithExploratoryWellCostsCapitalizedForMoreThanOneYearByProjectAxis": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is CapitalizedCostsOfUnprovedPropertiesExcludedFromAmortizationByPropertyOrProjectAxis."
-],
-"BusinessAcquisitionContingentConsiderationAtFairValue": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AssetsHeldForSaleAtCarryingValueAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"NetInvestmentIncomeInsuranceEntityEquitySecurities": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NetInvestmentIncome and members of InvestmentTypeAxis."
-],
-"RealEstateAndAccumulatedDepreciationAccumulatedDepreciation": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is RealEstateAccumulatedDepreciation."
-],
-"DebtInstrumentConvertibleInterestExpense": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is InterestExpenseDebt and members of LongtermDebtTypeAxis or ShortTermDebtTypeAxis."
-],
-"OperatingLeaseExpenseOtherExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is LeaseAndRentalExpense."
-],
-"DirectPremiumsEarnedOtherInsurance": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"CashForLeveragedBuyout": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"BusinessAcquisitionPurchasePriceAllocationWarrantyLiability": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FairValueInstrumentsClassifiedInShareholdersEquityMeasuredOnRecurringBasisGainLossIncludedInTradingRevenue": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisInstrumentsClassifiedInShareholdersEquityGainLossIncludedInEarnings and members of IncomeStatementLocationAxis."
-],
-"ComponentOfOtherOperatingCostAndExpenseNameDomain": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"AvailableForSaleSecuritiesGrossUnrealizedLosses1": [
-"2013-01-31",
-"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is AvailableForSaleSecuritiesGrossUnrealizedLoss."
-],
-"RecordedUnconditionalPurchaseObligationDescription": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"CededCreditRiskAmount": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ReinsuranceRecoverables with CededCreditRiskConcentratedCreditRiskMember."
-],
-"ExplanationOfNecessaryInformationNotAvailableAndDevelopmentCostExcessive": [
 "2015-01-31",
 "Element was deprecated because of low usage."
 ],
@@ -4551,1748 +6071,228 @@
 "2013-01-31",
 "Element was deprecated due to redundancy. Possible replacement is SaleOfStockPricePerShare."
 ],
-"DisposalGroupIncludingDiscontinuedOperationLiabilitiesOfDisposalGroup": [
-"2015-01-31",
-"Element was deprecated because it has a stringItemType attribute. Possible replacement is LiabilitiesOfDisposalGroupIncludingDiscontinuedOperation."
-],
-"CumulativeEffectAdjustmentGrossLosses": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"BankruptcyClaimsDateByWhichContractsMustBeRejectedByDebtors": [
+"SubsidiaryOrEquityMethodInvesteeReasonForOmittingDeferredIncomeTaxProvisionOnCumulativeGainLossRecognized": [
 "2015-01-31",
 "Element was deprecated because of low usage."
-],
-"SegmentReportingInformationInvestments": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Possible replacement is corresponding primary line items and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
-],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsPeriodIncreaseDecreaseIntrinsicValue": [
-"2013-01-31",
-"Element was deprecated due to rationalization."
-],
-"ReorganizationItemsDescriptionOfInterestIncomeOnAccumulatedCash": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionAssetNameDomain": [
-"2015-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are PropertyPlantAndEquipmentTypeDomain and DisposalGroupClassificationDomain."
-],
-"OutstandingStockAwardsMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is StockCompensationPlanMember."
-],
-"CompensatingBalancesCashAndCashEquivalentsMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is RestrictedCashAndCashEquivalentsCashAndCashEquivalentsMember."
-],
-"AccrualForEnvironmentalLossContingenciesCaption": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AccrualForEnvironmentalLossContingencies and members of BalanceSheetLocationAxis."
-],
-"PublicUtilitiesRateOfReturnsBelowRateCase": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"ChangeInUnrealizedGainLossOnFairValueHedgingInstruments": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is ChangeInUnrealizedGainLossOnFairValueHedgingInstruments1."
-],
-"BusinessAcquisitionCostOfAcquiredEntityOtherNoncashConsideration": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"OtherThanTemporaryImpairmentLossesInvestmentsHeldtomaturitySecuritiesPortionRecognizedInEarningsNetQualitativeDisclosuresThirdPartyGuaranteesDescription": [
-"2013-01-31",
-"Element was deprecated."
-],
-"FairValueEstimateNotPracticableReasonsCashAndCashEquivalents": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
-],
-"SourcesAndUsesOfCashForLeveragedBuyoutAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureIncomeTaxExpense1": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesIncomeTaxExpense."
-],
-"InternalCreditRatingMember": [
-"2013-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is InternalCreditAssessmentDomain."
-],
-"CapitalizedExploratoryWellCostsGreaterThanOrEqualToThreeYearsAndLessThanFourYearsNumberOfProjects": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProjectsThatHaveExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
-],
-"FinancingReceivableTroubledDebtRestructuringDomain": [
-"2015-01-31",
-"Element was deprecated due to remodeling of the topic area. Possible replacements are FinancingReceivablePortfolioSegmentDomain, FinancingReceivableRecordedInvestmentClassOfFinancingReceivableDomain, ClassOfFinancingReceivableTypeOfBorrowerDomain, EquitySecuritiesIndustryMember, CollateralDomain, GeographicDistributionDomain."
-],
-"ParticipatingMortgageLoansResultsOfOperations": [
-"2015-01-31",
-"Element deprecated due to redundancy. Possible replacement is ParticipatingMortgageLoanDescription."
-],
-"PresentValueOfFutureInsuranceProfitsImpairmentWriteDown": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsImpairmentWriteDown1."
-],
-"NewContractDomain": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInRemainderOfFiscalYear": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalRemainderOfFiscalYear."
-],
-"BusinessCombinationSeparatelyRecognizedTransactionsNetGainsAndLossesFinancialStatementCaption": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is BusinessCombinationSeparatelyRecognizedTransactionsNetGainsAndLosses and members of IncomeStatementLocationAxis."
-],
-"PremiumIncomeSubjectToParticipationThroughReinsuranceValue": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AssumedPremiumsEarned."
-],
-"CededPremiumsEarnedFinancialGuaranteeInsuranceContracts": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"FinancialGuaranteeInsuranceContractsPremiumsReceivableNewBusinessWritten": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is FinancialGuaranteeInsuranceContractsPremiumReceivableNewBusinessWritten."
-],
-"SalesOfEquityToFinanceLeveragedBuyout": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CostMethodInvestmentsAggregateCarryingAmount": [
-"2013-01-31",
-"Element deprecated due to redundancy. Possible replacement is CostMethodInvestments."
-],
-"WeightedAverageRateForeignDepositMoneyMarketDemandAccount": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"LeveragedBuyoutConsiderationPaidForOutstandingShares": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"EntityWideDisclosureOnGeographicAreasRevenueFromExternalCustomersAttributedToForeignCountries": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Possible replacement is Revenues and members of StatementGeographicalAxis."
-],
-"OtherExpenseCapitalizationToDeferredAcquisitionCostDAC": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is DeferredPolicyAcquisitionCostsAdditions."
-],
-"EarningsPerShareBasicMember": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"DisposalGroupIncludingDiscontinuedOperationGoodwill": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DisposalGroupIncludingDiscontinuedOperationGoodwillNoncurrent, DisposalGroupIncludingDiscontinuedOperationGoodwillCurrent or DisposalGroupIncludingDiscontinuedOperationGoodwill1."
-],
-"PensionCostMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is PensionCostsMember."
-],
-"MalpracticeLossContingencyAccrualAdjustment": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AmortizationOfAcquiredIntangibleAssets": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AmortizationOfIntangibleAssets."
-],
-"AvailableForSaleSecuritiesInUnrealizedLossPositionsQualitativeDisclosureNumberOfPositions": [
-"2013-01-31",
-"Element was deprecated because it was a decimalItemType attribute. Possible replacement is AvailableForSaleSecuritiesInUnrealizedLossPositionsQualitativeDisclosureNumberOfPositions1."
-],
-"ScheduleofLevelThreeDefinedBenefitPlanAssetsRollForwardTableTextBlock": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ScheduleOfEffectOfSignificantUnobservableInputsChangesInPlanAssetsTableTextBlock."
-],
-"DistributionMadeToMemberOrLimitedPartnerDeclarationDate1": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberDeclarationDate or DistributionMadeToLimitedPartnerDeclarationDate."
-],
-"CallOptionsWrittenMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CallOptionMember with ShortMember."
-],
-"SiteContingencyAccrualPresentValue": [
-"2013-01-31",
-"Element was deprecated due to redundancy.  Possible replacement is AccrualForEnvironmentalLossContingencies."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseReportedAndIncurredButNotReportedIBNRClaimsAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentLiabilitiesLongTermDebt": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DiscussionOfMethodOfMeasuringFairValueOfCreditRiskDerivatives": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are members of ValuationTechniqueAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationPropertyPlantAndEquipment": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"IncomeLossFromContinuingOperationsPerOutstandingGeneralPartnershipUnit": [
-"2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromContinuingOperationsPerOutstandingGeneralPartnershipUnitNetOfTax."
-],
-"QualitativeAndQuantitativeInformationAssetOrLiabilityTransferorsContinuingInvolvementSecuritizationOrAssetbackedFinancingPrincipalAmountOutstandingDerecognizedAmount": [
-"2014-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is DerecognizedAssetsSecuritizedOrAssetbackedFinancingArrangementAssetsAndAnyOtherFinancialAssetsManagedTogetherPrincipalAmountOutstanding."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsCashAndCashEquivalents": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LiabilitiesOfAssetsHeldForSale": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilitiesOfDisposalGroupIncludingDiscontinuedOperation."
-],
-"NetAmountAtRiskByProductAndGuaranteeSeparateAccountValueInEventOfDeath": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are NetAmountAtRiskByProductAndGuaranteeSeparateAccountValue, GuaranteedInsuranceContractTypeOfBenefitAxis and GuaranteedMinimumDeathBenefitMember."
-],
-"ForeignCurrencyDerivativesAtFairValueNet": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeFairValueOfDerivativeNet and ForeignExchangeContractMember."
-],
-"FairValueEstimateNotPracticableReasonsMandatorilyRedeemablePreferredStock": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
-],
-"RestructuringReserveSettledWithCash": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is PaymentsForRestructuring."
-],
-"DirectPremiumsLifeInsuranceInForce": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is LifeInsuranceInForceGross."
-],
-"OtherComprehensiveIncomeReclassificationOfDefinedBenefitPlanNetTransitionAssetObligationRecognizedInNetPeriodicBenefitCostBeforeTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetTransitionAssetObligationBeforeTax."
-],
-"PartiesToContractualArrangementMember": [
-"2014-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacement is LeaseArrangementTypeDomain."
-],
-"AssumedPremiumsWrittenAccidentAndHealth": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"BankruptcyProceedingsEntitiesIncludedInBankruptcyFiling": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"LineItemForCreditRiskDerivativesOnBalanceSheet": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are members of BalanceSheetLocationAxis."
-],
-"InvestmentsInAndAdvancesToAffiliatesBalanceContracts": [
-"2013-01-31",
-"Element was deprecated because it has a decimalItemType attribute. Possible replacement is InvestmentsInAndAdvancesToAffiliatesBalanceContracts1."
-],
-"BusinessAcquisitionCostOfAcquiredEntityAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"LiabilitiesSubjectToCompromiseDescriptionOfPensionAndOtherPostretirementObligations": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"BusinessAcquisitionPurchasePriceAllocationGoodwillAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"LimitedLiabilityCompanyOrLimitedPartnershipManagingMemberOrGeneralPartnerAdministrator": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"DirectPremiumsEarnedAccidentAndHealth": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"AllowanceForDoubtfulAccountsReceivableChargeOffs": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is AllowanceForDoubtfulAccountsReceivableWriteOffs."
-],
-"OtherComprehensiveIncomeLossReclassificationPensionAndOtherPostretirementBenefitPlansNetTransitionAssetObligationRecognizedInNetPeriodicBenefitCostTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetTransitionAssetObligationTax."
-],
-"CustomerSecuritiesForWhichEntityHasRightToSellOrRepledgeDescription": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"SecuritiesOwnedAndSoldNotYetPurchasedAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"BusinessAcquisitionContingentConsiderationAccountingTreatment": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"IntercompanyForeignCurrencyBalanceForeignCurrency": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"TransitionToCompetitionLiabilityNoncurrent": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"HeldtomaturitySecuritiesRestrictedDisclosureAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"RealEstateAndAccumulatedDepreciationCarryingAmountOfLandAndBuildingsAndImprovements": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is RealEstateGrossAtCarryingValue."
-],
-"AccountingStandardsUpdate200913Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FiniteLivedComputerSoftwareGross": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is CapitalizedComputerSoftwareGross."
-],
-"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureCashInflows": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesCashInflows."
-],
-"ContingentlyIssuableSharesMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is StockCompensationPlanMember."
-],
-"RealEstateOwnedValuationAllowanceProvision": [
-"2014-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is RealEstateOwnedValuationAllowanceProvision1."
-],
-"MarketingAndAdvertisingExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is MarketingAndAdvertisingExpense."
-],
-"OptionIndexedToIssuersEquityStrikePrice": [
-"2014-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is OptionIndexedToIssuersEquityStrikePrice1."
-],
-"DescriptionAndEffectsOfChangesInPrepaymentEstimateAssumptionsForCMOsAndREMICsLineItems": [
-"2013-01-31",
-"Element was deprecated."
-],
-"RealEstateOwnedAmountOfLossAtAcquisition": [
-"2013-01-31",
-"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is RealEstateOwnedAmountOfLossAtAcquisition1."
-],
-"ReportableSegmentsMember": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Create member element to identify specific segment."
-],
-"NetIncomeMember": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"NetInvestmentIncomeInsuranceEntityPolicyLoans": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is NetInvestmentIncome and members of InvestmentTypeAxis."
-],
-"ReorganizationItemsDescriptionOfLegalAndAdvisoryProfessionalFees": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"OtherThanTemporaryImpairmentLossesInvestmentsAvailableforsaleSecuritiesPortionRecognizedInEarningsNetQualitativeDisclosuresThirdPartyGuaranteesDescription": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AvailableforsaleSecuritiesInUnrealizedLossPositionsQualitativeDisclosureOtherThirdPartyGuaranteesDescription."
-],
-"AssetsHeldForSaleOtherNoncurrent": [
-"2014-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacement is DisposalGroupIncludingDiscontinuedOperationOtherNoncurrentAssets."
-],
-"SwaptionsMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is SwaptionMember."
-],
-"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesEntitysShareOfEquityMethodInvesteesStandardizedDiscountedFutureNetCashFlows": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is StandardizedMeasureOfDiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReserves and EquityMethodInvesteeMember."
-],
-"RevenueRecognitionNewAccountingPronouncementRevenueRecognizedUnderPriorGuidance": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LongLivedAssetsHeldForSaleProceedsFromSale": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is ProceedsFromSaleOfPropertyPlantAndEquipment."
-],
-"InvestmentOwnedOtherThanSecuritiesLoanedForShortSalesAtFairValue": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"NotionalAmountOfPriceRiskDerivativeInstrumentsNotDesignatedAsHedgingInstruments": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeAssetNotionalAmount, DerivativeLiabilityNotionalAmount or DerivativeNotionalAmount and members of DerivativeInstrumentRiskAxis and HedgingDesignationAxis."
-],
-"DistributionMadeToMemberOrLimitedPartnerDistributionsPaidPerUnit": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberDistributionsPaidPerUnit or DistributionMadeToLimitedPartnerDistributionsPaidPerUnit."
-],
-"MultiemployerPlansCollectiveBargainingArrangementDescription": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is MultiemployerPlansCollectiveBargainingArrangementExpirationDateDescription."
-],
-"SubsequentEventRevisedFinancialStatementsDateEvaluatedDescription": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"DebtInstrumentDecreaseRepayments": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replace is RepaymentsOfDebt."
-],
-"AccountingStandardsUpdate201018Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"PresentValueOfFutureInsuranceProfitsUnrealizedInvestmentLosses": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsUnrealizedInvestmentLosses1."
-],
-"PurchasedPutOptionMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PutOptionMember with LongMember."
-],
-"StockIssuedDuringPeriodValueIssuedForCash": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"BusinessCombinationBargainPurchaseGainRecognizedAmountFinancialStatementCaption": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is BusinessCombinationBargainPurchaseGainRecognizedAmount and members of IncomeStatementLocationAxis."
-],
-"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionFlag": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareRedemptionRestrictionFlag1."
-],
-"CallOptionsPurchasedMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CallOptionMember with LongMember."
-],
-"MinorityInterestInNetIncomeLossLimitedPartnerships": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacement is NoncontrollingInterestInNetIncomeLossLimitedPartnershipsNonredeemable or NoncontrollingInterestInNetIncomeLossLimitedPartnershipsRedeemable."
-],
-"LongDurationContractsAssumptionsByProductAndGuaranteeVolatilityRateLowEnd": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are LongDurationContractsAssumptionsByProductAndGuaranteeVolatilityRate, RangeAxis and MinimumMember."
-],
-"NonmonetaryNotionalAmountOfPriceRiskFairValueHedgeDerivatives": [
-"2013-01-31",
-"Element was deprecated because the intended concept conveyed is the underlying. Possible replacements are UnderlyingDerivativeAsset, UnderlyingDerivativeLiability, UnderlyingDerivative and members of DerivativeInstrumentsGainLossByHedgingRelationshipAxis and DerivativeInstrumentRiskAxis."
-],
-"OtherSellingAndMarketingExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OtherSellingAndMarketingExpense."
-],
-"CompensatedAbsencesAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"IssuanceOfEquityMember": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"IncreaseDecreaseInLossAndLossAdjustmentExpenseReserve": [
-"2015-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is IncreaseDecreaseInLiabilityForClaimsAndClaimsAdjustmentExpenseReserve."
-],
-"OtherComprehensiveIncomeLossReclassificationAdjustmentForSaleOfSecuritiesIncludedInNetIncomeTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIForSaleOfSecuritiesTax."
-],
-"BusinessAcquisitionPurchasePriceAllocationMineralRights": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DepositAssetsOrLiabilitiesEffectOfChangeInPresentValueAssumptionsResultingInAdditionsToExpectedRecoveries": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DepositAssetsEffectOfChangeInPresentValueAssumptionsResultingInAdditionsToExpectedRecoveries and DepositLiabilitiesEffectOfChangeInPresentValueAssumptionsResultingInAdditionsToExpectedRecoveries."
-],
-"RevenueRecognitionNewAccountingPronouncementAllocation": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"ScheduleOfEarningsPerShareReconciliationTableTextBlock": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ScheduleOfEarningsPerShareBasicAndDilutedTableTextBlock."
-],
-"OtherDeferredCostsDisclosures": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"IncomeDepositSecuritiesDividendPolicy": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"ForeignEarningsRepatriatedUnderAmericanJobsCreationActOf2004Description": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"NoninterestExpenseDirectorsFeesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpenseDirectorsFees."
-],
-"BusinessAcquisitionPurchasePriceAllocationUnmarketableSecurities": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FinancingReceivableAllowanceForCreditLossesAcquiredWithDeterioratedCreditQuality": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FinancingReceivableAllowanceForCreditLosses and ReceivablesAcquiredWithDeterioratedCreditQualityMember."
-],
-"FiniteLivedIntangibleAssetsRemainingAmortizationPeriod": [
-"2013-01-31",
-"Element was deprecated because it is has a stringItemType attribute. Possible replacement is FiniteLivedIntangibleAssetsRemainingAmortizationPeriod1."
-],
-"PublicUtilitiesPropertyPlantAndEquipmentTransmissionAndDistributionEstimatedUsefulLife": [
-"2013-01-31",
-"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentTransmissionAndDistributionUsefulLife."
-],
-"FairValueLiabilitiesMeasuredOnRecurringBasisGainLossIncludedInInvestmentIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisLiabilityGainLossIncludedInEarnings and members of IncomeStatementLocationAxis."
-],
-"FDICPremiumExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is FederalDepositInsuranceCorporationPremiumExpense."
-],
-"IndefiniteLivedIntangibleAssetsImpairmentLosses": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is ImpairmentOfIntangibleAssetsIndefinitelivedExcludingGoodwill."
-],
-"NotionalAmountOfNetInvestmentHedgingInstrumentsTotalAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"TimeSharingTransactionsAdditionsToAllowanceForCurrentPeriodSalesOnReceivablesSoldWithRecourse": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is TimeSharingTransactionsAdditionsToAllowanceForCurrentPeriodSalesOnReceivablesSoldWithRecourse1."
-],
-"FairValueEstimateNotPracticableReasonsDebtInstrument": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
-],
-"LiabilityForFuturePolicyBenefitsLiabilitiesAssumed": [
-"2013-01-31",
-"Element was deprecated because it has credit balance attribute. Possible replacement is LiabilityForFuturePolicyBenefitsPeriodExpense."
-],
-"DistributionMadeToMemberOrLimitedPartnerDistributionDate1": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberDistributionDate or DistributionMadeToLimitedPartnerDistributionDate."
-],
-"DistributionMadeToMemberOrLimitedPartnerShareDistributionDilutionPerShare": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberUnitDistributionDilutionPerUnit or DistributionMadeToLimitedPartnerUnitDistributionDilutionPerUnit."
-],
-"PolicyholdersSurplusOfLifeInsuranceEntityMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are PolicyHoldersSurplus, DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferencePolicyHoldersSurplus, DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxablePolicyHoldersSurplus, DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityPolicyHoldersSurplus, and DeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticablePolicyHoldersSurplus."
-],
-"OtherPremiumRevenueNet": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is PremiumsEarnedNetOtherInsurance."
-],
-"DividendPaymentRestrictionsScheduleAmountsPaid": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is PaymentsOfDividends."
-],
-"BusinessAcquisitionPurchasePriceAllocationGoodwillExpectedTaxDeductibleAmountDescription": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsInventory": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DescriptionOfLocationOfHybridInstrumentsOnBalanceSheet": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is HybridInstrumentsAtFairValueNet and members of BalanceSheetLocationAxis."
-],
-"OtherComprehensiveIncomeLossAmortizationPensionAndOtherPostretirementBenefitPlansNetPriorServiceCostRecognizedInNetPeriodicBenefitCostBeforeTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossAmortizationAdjustmentFromAOCIPensionAndOtherPostretirementBenefitPlansForNetPriorServiceCostCreditBeforeTax."
-],
-"LeveragedBuyoutPredecessorBasisAdjustment": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CertainLoansAcquiredInTransferAccountedForAsHeldToMaturityDebtSecuritiesAccretableYieldReclassificationsFromNonaccretableDifference": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesAccretableYieldReclassificationsFromNonaccretableDifference and members of InformationByCategoryOfDebtSecurityAxis."
-],
-"DevelopmentStageEnterpriseNatureOfActivities": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsAssetToBeDisposedOf": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"BusinessAcquisitionPurchasePriceAllocationNoncurrentLiabilitiesDescription": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"EffectOfChangeInAverageTrancheLifeEstimate": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"CreditDerivativeCurrentFairValue": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is CreditRiskDerivativeLiabilitiesAtFairValue."
-],
-"AllowanceForLoanAndLeaseLossesProvisionForLossNetAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"PresentValueOfFutureInsuranceProfits": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ValueOfBusinessAcquiredVOBA."
-],
-"TradingSecuritiesRestrictedCurrent": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TradingSecuritiesRestricted."
-],
-"ExpropriationOfAssetsAxis": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"DisposalGroupLiabilitiesOfBusinessTransferredUnderContractualArrangement": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LiabilitiesOfDisposalGroupIncludingDiscontinuedOperation and members of DisposalGroupClassificationAxis."
-],
-"FinancingAxis": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"CertainLoansAcquiredInTransferAccountedForAsHeldToMaturityDebtSecuritiesAccretableYieldDisposalsOfLoans": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesAccretableYieldDisposalsOfLoans and members of InformationByCategoryOfDebtSecurityAxis."
-],
-"CashFlowHedgeGainLossReclassifiedToInterestExpenseNetAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"FairValueEstimateNotPracticableReasonsTradingAccountAssets": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
-],
-"ChangesInFranchises": [
-"2015-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are SignificantChangesFranchisesSold, SignificantChangesFranchisesPurchasedDuringPeriod, SignificantChangesFrachisedOutletsInOperation, or SignificantChangesFrachisorOutletsInOperation."
-],
-"DeferredIncomeTaxExpenseBenefitAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"MalpracticeLossContingencySettlementOfClaims": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is MalpracticeLossContingencyPeriodCost."
-],
-"DerivativeFairValueGrossAmountNotOffsetAgainstCollateralNetAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAdjustmentOfOpeningBalanceTable": [
-"2014-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"SignificantChangeInUnrecognizedTaxBenefitsIsReasonablyPossibleEstimatedRangeOfChangeLowerBound": [
-"2015-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are IncreaseInUnrecognizedTaxBenefitsIsReasonablyPossible or DecreaseInUnrecognizedTaxBenefitsIsReasonablyPossible."
-],
-"DeferredTaxLiabilityNotRecognizedCumulativeAmountOfTemporaryDifference": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are\nUndistributedEarningsOfForeignSubsidiaries, UndistributedEarningsOfDomesticSubsidiaries, BadDebtReserveForTaxPurposesOfQualifiedLender, and PolicyholdersSurplus."
-],
-"CashFlowHedgeLossReclassifiedToCostOfSales": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CostOfGoodsSold and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"FairValueAssetsAndLiabilitiesMeasuredOnRecurringBasisGainLossIncludedInEarningsDescription": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisAssetGainLossIncludedInEarnings1, FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisLiabilityGainLossIncludedInEarnings, and FairValueAssetsAndLiabilitiesMeasuredOnRecurringBasisGainLossIncludedInEarnings and members of IncomeStatementLocationAxis."
-],
-"LoansReceivableWithVariableRatesOfInterest": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is LoansReceivableWithVariableRatesOfInterest1."
-],
-"DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipmentNet": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipmentNoncurrent, DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipmentCurrent or DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipment."
-],
-"BusinessAcquisitionPurchasePriceAllocationAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"RevenueFromAdministrativeServices": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AdministrativeServicesRevenue and members of LegalEntityAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationDeferredTaxLiabilitiesNoncurrent": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"PublicUtilitiesPropertyPlantAndEquipmentFuelEstimatedUsefulLife": [
-"2013-01-31",
-"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentFuelUsefulLife."
-],
-"TimeDepositsWeightedAverageInterestRateDescription": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"ComponentOfOtherExpenseNonoperatingTable": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"CommunicationsDataProcessingAndOccupancyMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is CommunicationsInformationTechnologyAndOccupancy."
-],
-"BusinessCombinationContingentConsiderationArrangementsAndIndemnificationAssetsAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"CashFlowHedgeGainReclassifiedToOtherIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is OtherIncome and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"BoardMemberCompensationContractsMember": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"DiscontinuedOperationTaxEffectOfOtherIncomeLossFromDispositionOfDiscontinuedOperation": [
-"2015-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"FinancialGuaranteeInsuranceContractsClaimLiabilitySignificantComponentsOfChangeLikelihoodOfDefaultIfNotPresentedSeparatelyFinancialStatementCaption": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FinancialGuaranteeInsuranceContractsClaimLiabilitySignificantComponentsOfChangeLikelihoodOfDefault and members of IncomeStatementLocationAxis."
-],
-"PresentValueOfFutureInsuranceProfitsIncreases": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"RestructuringAndRelatedCostExpectedCost": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is RestructuringAndRelatedCostExpectedCost1."
-],
-"PremiumsReceivableAllowanceForDoubtfulAccountsProvisionChargedToExpense": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is PremiumsReceivableAllowanceForDoubtfulAccountsProvisionChargedToExpense1."
-],
-"FairValueEstimateNotPracticableReasonsNotesReceivable": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
-],
-"DerecognizedAssetsSecuritizedOrAssetbackedFinancingArrangementAssetsAndAnyOtherFinancialAssetsManagedTogetherAverageBalanceDuringPeriod": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DisposalGroupIncludingDiscontinuedOperationCashFlowsOfDisposalGroup": [
-"2015-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"DepositAssetsOrLiabilitiesPresentValueOfExpectedRecoveries": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacement is DepositAssetsPresentValueOfExpectedRecoveries."
-],
-"BankruptcyProceedingsDescriptionOfNonUSEntities": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"CashAndSecuritiesSegregatedUnderSecuritiesExchangeCommissionRegulationDescription": [
-"2015-01-31",
-"Element deprecated due to redundancy. Possible replacement is CashAndSecuritiesSegregatedUnderFederalAndOtherRegulationsDescription."
-],
-"PremiumsNetLifeInsuranceInForceAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"RealEstateAndAccumulatedDepreciationDescriptionOfProperty": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are corresponding primary line items and members of StatementGeographicalAxis and MortgageLoansOnRealEstateDescriptionTypeOfPropertyAxis."
-],
-"ForeignCurrencyDerivativeAssetsAtFairValue": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeFairValueOfDerivativeAsset and ForeignExchangeContractMember."
-],
-"CreditDerivativeTerm": [
-"2013-01-31",
-"Element was deprecated because it is has a stringItemType attribute. Possible replacement is CreditDerivativeTerm1."
-],
-"OtherComprehensiveIncomeLossReclassificationAdjustmentOnDerivativesIncludedInNetIncomeNetOfTax": [
-"2013-01-31",
-"Element was deprecated due to remodeling of other comprehensive income area. Possible replacement is OtherComprehensiveIncomeLossReclassificationAdjustmentFromAOCIOnDerivativesNetOfTax."
-],
-"ReclassificationFromAccumulatedOtherComprehensiveIncomeCurrentPeriodBeforeTaxAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareInvestmentRedemptionNoticePeriod": [
-"2014-01-31",
-"Element was deprecated because it has a stringItemType attribute. Possible replacement is FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareInvestmentRedemptionNoticePeriod1."
-],
-"FairValueEstimateNotPracticableReasonsLiabilitiesRelatedToInvestmentContracts": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
-],
-"DepositAssetsOrLiabilitiesEffectOfChangeInInterestAccrualAssumptionOnExpectedRecoveryAmounts": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DepositAssetsEffectOfIncreaseDecreaseInInterestAccrualAssumptionOnExpectedRecoveryAmounts and DepositLiabilitiesEffectOfIncreaseDecreaseInInterestAccrualAssumptionOnExpectedRecoveryAmounts."
-],
-"CompensatedAbsencesLiabilityVacationAndHoliday": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AccruedVacationCurrentAndNoncurrent."
-],
-"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsAmountsRecognizedInBalanceSheet": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LoansAndLeasesReceivableCommercialDescription": [
-"2015-01-31",
-"Element was deprecated and replaced with a more encompassing element. Possible replacement is LoansAndLeasesReceivableDescription."
-],
-"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsAccruedBenefitLiability": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DisposalGroupIncludingDiscontinuedOperationLongLivedAssets": [
-"2015-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"IncreaseDecreaseInPrepaidGasDelivery": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"DescriptionOfDerivativeInstrumentsByRiskExposure": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DerivativeUnderlyingRisk."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentLiabilitiesAccruedLiabilities": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DiscontinuedOperationNatureOfActivitiesHavingContinuingCashFlowsAfterDisposal": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"WeightedAverageRateForeignDepositOtherTimeDeposit": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"CausesOfIncreaseDecreaseInLiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseCauseDomain": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is CatastrophicEventDomain."
-],
-"FairValueAssetsMeasuredOnRecurringBasisGainLossIncludedInOtherIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisAssetGainLossIncludedInEarnings1 and members of IncomeStatementLocationAxis."
-],
-"DisposalGroupIncludingDiscontinuedOperationLongLivedAssetsCurrent": [
-"2015-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"ReinsurerOtherAssetsAndLiabilitiesAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"DescriptionOfMaterialAffectsOfNoncomplianceOfBranchesOfForeignFinancialInstitutions": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"LiabilityForFuturePolicyBenefitByProductSegmentAxis": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"BusinessAcquisitionContingentConsiderationSharesIssuableDescription": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LimitedLiabilityCompanyOrLimitedPartnershipManagingMemberOrGeneralPartnerRole": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"ProductionBarrelsOfOilEquivalents": [
-"2013-01-31",
-"Element was deprecated because it has a boeItemType attribute. Possible replacement is ProductionBarrelsOfOilEquivalents1."
-],
-"DirectPremiumsWrittenFinancialGuaranteeInsuranceContracts": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAdjustmentOfOpeningBalanceAmount": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseOpeningBalanceAdjustments."
-],
-"AssumedPremiumsWrittenLife": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"FederalHomeLoanBankAdvancesMaturitiesSummary": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AdvancesFromFederalHomeLoanBanks."
-],
-"DefinedBenefitPlanAmortizationOfNetPriorServiceCostCredit": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is DefinedBenefitPlanFutureAmortizationOfPriorServiceCostCredit."
-],
-"AvailableforsaleSecuritiesGrossUnrealizedGain": [
-"2013-01-31",
-"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is AvailableForSaleSecuritiesGrossUnrealizedGains."
-],
-"OtherDeferredCostAmortizationExpense": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is OtherAmortizationOfDeferredCharges."
-],
-"PreOpeningCostsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is PreOpeningCosts."
-],
-"LiquidityDisclosureTextBlock": [
-"2015-01-31",
-"Element was deprecated due to issuance of new guidance."
-],
-"EquityIssuancePerShareAmount": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CapitalizedExploratoryWellCostsGreaterThanOrEqualToOneYearAndLessThanTwoYearsNumberOfProjects": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ProjectsThatHaveExploratoryWellCostsThatHaveBeenCapitalizedForPeriodGreaterThanOneYear and members of AgingOfCapitalizedExploratoryWellCostsAxis."
-],
-"RegulatoryCapitalDisclosuresForBusinessCombinations": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"OtherAssetsHeldForSale": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DisposalGroupIncludingDiscontinuedOperationOtherAsset or AssetsHeldForSaleNotPartOfDisposalGroupOther."
-],
-"FinancingReceivableInformationByCreditQualityIndicatorAxis": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are CreditRatingAMBestAxis, CreditRatingMoodysAxis, CreditRatingStandardPoorsAxis, CreditRatingFitchAxis, ExternalCreditRatingByGroupingAxis, InternalCreditAssessmentAxis."
-],
-"AvailableForSaleSecuritiesGrossUnrealizedGainLoss": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is AvailableForSaleSecuritiesGrossUnrealizedGainLoss1."
-],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsTotalShareBasedLiabilitiesPaid": [
-"2014-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsShareBasedLiabilitiesPaid."
-],
-"MinorityInterestInNetIncomeLossOtherMinorityInterests": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacement is NoncontrollingInterestInNetIncomeLossOtherNoncontrollingInterestsNonredeemable or NoncontrollingInterestInNetIncomeLossOtherNoncontrollingInterestsRedeemable."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsAssetNotToBeUsed": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DisposalGroupIncludingDiscontinuedOperationLongLivedAssetsCurrentAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsPrepaidBenefitCost": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CededPremiumsWrittenPropertyAndCasualty": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsWritten and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"GainLossOnOilAndGasHedgingActivityMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"ProvedDevelopedReservesBOE": [
-"2013-01-31",
-"Element was deprecated because it has a boeItemType attribute. Possible replacement is ProvedDevelopedReservesBOE1."
-],
-"HedgingStrategyByGuaranteeType": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LongDurationContractsHedgingStrategies and members of GuaranteedInsuranceContractTypeOfGuaranteeAxis."
-],
-"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureIncomeTaxExpense": [
-"2013-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesIncomeTaxExpense."
-],
-"TemporaryEquityRedemptionValue": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TemporaryEquityCarryingAmountIncludingPortionAttributableToNoncontrollingInterests."
-],
-"CreditRatingDomain": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are CreditRatingAMBestDomain, InternalCreditAssessmentDomain, ExternalCreditRatingFitchMember, ExternalCreditRatingStandardPoorsMember, ExternalCreditRatingMoodysMember, ExternalCreditRatingByGroupingDomain."
-],
-"LossContingencyRelatedReceivableCaption": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are LossContingencyReceivableCurrent, LossContingencyReceivableNoncurrent, and LossContingencyReceivable and members of BalanceSheetLocationAxis."
-],
-"OtherNoninterestExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is OtherNoninterestExpense."
-],
-"ExpenseRelatedToDistributionOrServicingAndUnderwritingFeesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ExpenseRelatedtoDistributionorServicingandUnderwritingFees."
-],
-"PaymentsToDevelopLiquefiedNaturalGasSites": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"PresentValueOfFutureInsuranceProfitsInterestAccrued": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsInterestAccrued1."
-],
-"OtherTaxCarryforwardDataByItemAxis": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TaxCreditCarryforwardAxis."
-],
-"CashFlowHedgeGainReclassifiedToInvestmentIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is InvestmentIncomeNet and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationMethodology": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"EffectsOfReinsuranceAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"SegmentReportingInformationNetAssets": [
-"2013-01-31",
-"Element was deprecated due to remodeling of Segment area. Possible replacement is corresponding primary line items and members of StatementBusinessSegmentsAxis or SubsegmentsAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationNoncurrentAssetsAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"FairValueOptionEventsTriggeringElectionEffectOnEarnings": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"LiabilitiesSubjectToCompromiseDescriptionOfInterestOnPrepetitionLiabilities": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"AccrualForEnvironmentalLossContingenciesNetAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"BorrowingsToFinanceLeveragedBuyout": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AssumedPremiumsLifeInsuranceInForce": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is LifeInsuranceInForceAssumed."
-],
-"GainLossOnSaleOfOilAndGasPropertiesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossOnSaleOfProperty."
-],
-"MembersOrLimitedPartnersSubsequentDistributionAmount": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DistributionMadeToLimitedLiabilityCompanyLLCMemberCashDistributionsPaid and members of SubsequentEventTypeAxis or DistributionMadeToLimitedPartnerCashDistributionsPaid and members of SubsequentEventTypeAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationGoodwillAmount": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"ImpairmentInValueOfAssetDomain": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"LossOnReceivablesDomain": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"ForeignReinsuranceUnderOpenYearMethodAdditions": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"BusinessAcquisitionPurchasePriceAllocationNaturalResources": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FinancialGuaranteeInsuranceContractsPremiumReceivedOverContractPeriodUnearnedPremiumRevenueAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"BusinessAcquisitionPurchasePriceAllocationCapitalLeaseObligationAccrual": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CommercialRealEstateOtherReceivableMember": [
-"2015-01-31",
-"Element was deprecated due to remodeling of topic area. Possible replacements are CommercialPortfolioSegmentMember and RealEstateLoanMember."
-],
-"OtherTaxCarryforwardDescription": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TaxCreditCarryforwardDescription."
-],
-"AccrualForEnvironmentalLossContingenciesNet": [
-"2013-01-31",
-"Element was deprecated due to redundancy.  Possible replacement is AccrualForEnvironmentalLossContingencies."
-],
-"RoyaltyPaymentsExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is RoyaltyExpense."
-],
-"FederalHomeLoanBankAdvancesShortTerm": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is FederalHomeLoanBankAdvancesMaturitiesSummaryDueWithinOneYearOfBalanceSheetDate."
-],
-"QualitativeAndQuantitativeInformationAssetOrLiabilityTransferorsContinuingInvolvementSecuritizationOrAssetbackedFinancingPrincipalAmountOutstandingContinuedRecognitionAmount": [
-"2014-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is SecuritizedAssetsAndAnyOtherFinancialAssetsManagedTogetherPrincipalAmountOutstanding."
-],
-"ProjectWithExploratoryWellCostsCapitalizedForMoreThanOneYearNameDomain": [
-"2013-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is ProjectMember."
-],
-"CertainLoansAcquiredInTransferAccountedForAsAvailableForSaleDebtSecuritiesAccretableYieldDisposalsOfLoans": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CertainLoansAcquiredInTransferAccountedForAsDebtSecuritiesAccretableYieldDisposalsOfLoans and members of InformationByCategoryOfDebtSecurityAxis."
-],
-"AdvertisingExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is AdvertisingExpense."
-],
-"CashFlowHedgeLossReclassifiedToOtherExpense": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is OtherCostAndExpenseOperating and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
-],
-"InvestmentIncomeCategoriesDomain": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is InvestmentTypeCategorizationMember."
-],
-"DefinedBenefitPlanAmountsThatWillBeAmortizedFromAccumulatedOtherComprehensiveIncomeLossInNextFiscalYear": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is DefinedBenefitPlanAmountToBeAmortizedFromAccumulatedOtherComprehensiveIncomeLossNextFiscalYear."
-],
-"ComponentOfOtherIncomeNonoperatingNameDomain": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
-],
-"AssetsHeldForSaleCurrentAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"EarningsPerShareDilutedMember": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionByAssetAxis": [
-"2015-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are PropertyPlantAndEquipmentByTypeAxis and DisposalGroupClassificationAxis."
-],
-"FiniteLivedIntangibleAssetsAcquired": [
-"2013-01-31",
-"Element was deprecated because it was incorrectly defined.  Possible replacement element is FiniteLivedIntangibleAssetsAcquired1."
-],
-"DisposalGroupIncludingDiscontinuedOperationLongLivedAssetsNoncurrentAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"DefinedContributionPlanMaximumAnnualContributionPerEmployeePercent": [
-"2013-01-31",
-"Element was deprecated because it was incorrectly defined. Possible replacement is DefinedContributionPlanMaximumAnnualContributionsPerEmployeePercent."
 ],
 "SummaryOfOtherTaxCarryforwardsTextBlock": [
 "2013-01-31",
 "Element was deprecated due to redundancy. Possible replacement is SummaryOfTaxCreditCarryforwardsTextBlock."
 ],
-"EmployeeServiceShareBasedCompensationPolicyForIssuingSharesUponExercise": [
+"SuppliesAndPostageExpenseMember": [
 "2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardPolicyForIssuingSharesUponExercise."
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is SuppliesAndPostageExpense."
 ],
-"BusinessAcquisitionPreexistingRelationshipAbstract": [
+"SuppliesExpenseMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is SuppliesExpense."
+],
+"SwaptionsMember": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is SwaptionMember."
+],
+"TaxBenefitFromStockOptionsExercised1": [
+"2013-01-31",
+"Element was deprecated because it was incorrectly defined. Possible replacement is DeferredTaxExpenseFromStockOptionsExercised."
+],
+"TaxCreditCarryforwardDeferredTaxAsset": [
+"2015-01-31",
+"Element deprecated due to redundancy. Possible replacement is DeferredTaxAssetsTaxCreditCarryforwards."
+],
+"TaxesAndLicensesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is TaxesAndLicenses."
+],
+"TaxesOtherThanIncomeAndExciseTaxesMember": [
+"2013-01-31",
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is TaxesExcludingIncomeAndExciseTaxes."
+],
+"TemporaryEquityCarryingAmountAttributableToNoncontrollingInterest": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is RedeemableNoncontrollingInterestEquityCarryingAmount."
+],
+"TemporaryEquityCarryingAmountAttributableToNoncontrollingInterestAbstract": [
 "2014-01-31",
 "Element was deprecated."
 ],
-"TradingSecuritiesRestrictedAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"ExperienceRatedRefundsReceivable": [
-"2013-01-31",
-"Element was deprecated due to remodeling of reinsurance topic area."
-],
-"DisposalGroupIncludingDiscontinuedOperationLongLivedAssetsNoncurrent": [
-"2015-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"GainLossFromPriceRiskManagementActivityMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is GainLossFromPriceRiskManagementActivity."
-],
-"SubordinatedNotesToFinanceLeveragedBuyout": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LineOfCreditFacilityDecreaseForgiveness": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is LineOfCreditFacilityDecreaseForgiveness1."
-],
-"DepositAssetsOrLiabilitiesAmortizationExpenseFromExpirations": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacement is DepositAssetsAmortizatonExpenseFromExpirations."
-],
-"ScheduleOfPurchasePriceAllocationTableTextBlock": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"RestructuringAndRelatedCostExpectedCostRemaining": [
+"TemporaryEquityRedemptionValue": [
 "2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is RestructuringAndRelatedCostExpectedCostRemaining1."
+"Element was deprecated due to redundancy. Possible replacement is TemporaryEquityCarryingAmountIncludingPortionAttributableToNoncontrollingInterests."
 ],
-"LoansHeldForSaleConsumerHomeEquity": [
-"2015-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacement is LoansReceivableHeldForSaleNetNotPartOfDisposalGroupConsumerHomeEquity."
-],
-"ReorganizationItemsDescriptionOfGainLossOnSettlementOfOtherClaimsNet": [
+"TimeDepositsWeightedAverageInterestRateDescription": [
 "2015-01-31",
 "Element was deprecated because of low usage."
 ],
-"GoodwillAllocationAdjustment": [
+"TimeSharingTransactionsAdditionsToAllowanceForCurrentPeriodSales": [
 "2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is GoodwillPurchaseAccountingAdjustments."
+"Element was deprecated because it has a credit balance attribute. Possible replacement is TimeSharingTransactionsAdditionsToAllowanceForCurrentPeriodSales1."
 ],
-"ReinsuranceEffectOnOperations": [
+"TimeSharingTransactionsAdditionsToAllowanceForCurrentPeriodSalesOnReceivablesSoldWithRecourse": [
 "2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is NaturePurposeAndEffectOfReinsuranceTransactions."
+"Element was deprecated because it has a credit balance attribute. Possible replacement is TimeSharingTransactionsAdditionsToAllowanceForCurrentPeriodSalesOnReceivablesSoldWithRecourse1."
 ],
-"RegistrationPaymentArrangementGainsAndLossesClassification": [
+"TradeReceivablesHeldForSaleNet": [
 "2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is RegistrationPaymentArrangementGainsAndLosses and members of IncomeStatementLocationAxis."
-],
-"LineOfCreditFacilityIncreaseAdditionalBorrowings": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is ProceedsFromLinesOfCredit."
-],
-"SignificantAcquisitionsAndDisposalsDescription": [
-"2015-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacement is DisposalGroupIncludingDiscontinuedOperationDescriptionAndTimingOfDisposal."
-],
-"FAS163Member": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FinancialGuaranteeInsuranceContractsClaimLiabilitySignificantComponentsOfChangeEffectOfChangeInDiscountRateIfNotPresentedSeparatelyFinancialStatementCaption": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FinancialGuaranteeInsuranceContractsClaimLiabilitySignificantComponentsOfChangeEffectOfChangeInDiscountRate and members of IncomeStatementLocationAxis."
-],
-"DirectPremiumsWrittenAccidentAndHealth": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DirectPremiumsWritten and members ofReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"OtherTaxCarryforwardLineItems": [
-"2013-01-31",
-"Element was deprecated."
-],
-"MalpracticeInsuranceTailCoverage": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"BusinessAcquisitionPurchasePriceAllocationOtherNoncurrentLiabilities": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FAS158Member": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DescriptionOfChangeInCashFlowProjectionsEstimate": [
-"2013-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"AllowanceForLoanAndLeaseLossesAdjustmentsNetAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"MergerAndAcquisitionCosts": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"IncomeTaxExpenseBenefitContinuingOperations": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is IncomeTaxExpenseBenefit."
-],
-"NetIncreaseDecreaseInAdvancePaymentsByBorrowersForTaxesAndInsurance": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is IncreaseDecreaseInAdvancePaymentsByBorrowersForTaxesAndInsurance."
-],
-"PostageExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is PostageExpense."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"BusinessAcquisitionPurchasePriceAllocationAssetsAcquiredLiabilitiesAssumedNet": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"PremiumsEarnedNetPropertyAndCasualtyAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"AccountingStandardsUpdate201002Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"PremiumsWrittenNetPropertyAndCasualtyAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"SaleOfStockReasonForOmittingDeferredIncomeTaxProvisionOnGainLossRecognized": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"LineOfCreditFacilityDecreaseRepayments": [
-"2013-01-31",
-"Element was deprecated due to redundancy.  Possible replacement is RepaymentsOfLinesOfCredit."
-],
-"MortgageLoansOnRealEstateWriteDownOrReserveAmount": [
-"2013-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is MortgageLoansOnRealEstateWriteDownOrReserveAmount1."
-],
-"CommercialLinesMember": [
-"2013-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is PropertyAndCasualtyCommercialInsuranceProductLineMember."
-],
-"PreferredStockSubjectToMandatoryRedemptionMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is MandatorilyRedeemablePreferredStockMember."
-],
-"DescriptionOfChangeInMeasurementDateSFAS158": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"LongLivedAssetsToBeAbandonedByAssetAxis": [
-"2015-01-31",
-"Element deprecated due to redundancy. Possible replacement is PropertyPlantAndEquipmentByTypeAxis and IncomeStatementBalanceSheetAndAdditionalDisclosuresByDisposalGroupsIncludingDiscontinuedOperationsAxis."
-],
-"LoansReceivableWithFixedRatesOfInterest": [
-"2013-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is LoansReceivableWithFixedRatesOfInterest1."
-],
-"CreditRiskDerivativesAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"DerivativeDescriptionOfVariableRateBasis": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeVariableInterestRate and members of VariableRateAxis."
+"Element was deprecated because it was inappropriately modeled. Possible replacement is TradeReceivablesHeldForSaleNetNotPartOfDisposalGroup."
 ],
 "TradingAccountAssetsFairValueDisclosure": [
 "2013-01-31",
 "Element was deprecated due to redundancy. Possible replacement is TradingSecurities."
 ],
-"NoninterestExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is NoninterestExpense."
+"TradingActivityGainsAndLossesNet": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TradingGainsLosses."
 ],
-"LiabilitiesSubjectToCompromiseDescriptionOfCashDisbursementsAndReclassificationsUnderBankruptcyCourtOrders": [
+"TradingSecuritiesCurrent": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TradingSecurities."
+],
+"TradingSecuritiesCurrentAbstract": [
+"2014-01-31",
+"Element was deprecated."
+],
+"TradingSecuritiesDebtCurrent": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TradingSecuritiesDebt."
+],
+"TradingSecuritiesEquityCurrent": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TradingSecuritiesEquity."
+],
+"TradingSecuritiesFairValueDisclosure": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TradingSecurities."
+],
+"TradingSecuritiesRestrictedAbstract": [
+"2015-01-31",
+"Element was deprecated."
+],
+"TradingSecuritiesRestrictedCurrent": [
+"2013-01-31",
+"Element was deprecated due to redundancy. Possible replacement is TradingSecuritiesRestricted."
+],
+"TradingSecuritiesRestrictionsAdditionalInformation": [
 "2015-01-31",
 "Element was deprecated because of low usage."
 ],
-"LongLivedAssetsToBeAbandonedCarryingValueOfAsset": [
-"2015-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"CollaborativeArrangementsAndNoncollaborativeArrangementTransactionsMember": [
+"TransfersAccountedForAsSecuredBorrowingsClassificationAssets": [
 "2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ArrangementsAndNonarrangementTransactionsMember."
-],
-"InventoriesPropertyHeldForSaleCurrent": [
-"2015-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacements are DisposalGroupIncludingDiscontinuedOperationInventoryCurrent, DisposalGroupIncludingDiscontinuedOperationInventoryNoncurrent or DisposalGroupIncludingDiscontinuedOperationInventory1."
-],
-"DescriptionOfChangeInAccountingPrincipleSFAS158": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"NetIncomeLossPerOutstandingLimitedPartnershipUnitDiluted": [
-"2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is NetIncomeLossNetOfTaxPerOutstandingLimitedPartnershipUnitDiluted."
-],
-"CededCreditRiskConcentratedCreditRiskMember": [
-"2015-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacements are ConcentrationRiskByTypeAxis and its member ReinsurerConcentrationRiskMember and members of ConcentrationRiskByBenchmarkAxis."
-],
-"BusinessAcquisitionPurchasePriceAllocationAssetsAcquiredLiabilitiesAssumedNetAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"PresentValueOfFutureInsuranceProfitsIncreasesAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"FuelTransportationMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is FuelMember."
-],
-"NetAmountAtRiskByProductAndGuaranteeRangeOfGuaranteedMinimumReturnRates": [
-"2015-01-31",
-"Element was deprecated because it has a stringItemType attribute and the financial reporting concept can be conveyed dimensionally. Possible replacement is NetAmountAtRiskByProductAndGuaranteeGuaranteedMinimumReturnRate and members of RangeAxis."
-],
-"GuaranteedBenefitsPaid": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilitiesForGuaranteesOnLongDurationContractsBenefitsPaid."
-],
-"DefinedBenefitPlanEstimatedFutureEmployerContributionsInNextFiscalYear": [
-"2013-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is DefinedBenefitPlansEstimatedFutureEmployerContributionsInNextFiscalYear."
-],
-"LongDurationContractsHedgingStrategyAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"LoansToFinanceLeveragedBuyout": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"UndistributedEarningsAllocatedToParticipatingSecurities": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are UndistributedEarningsLossAllocatedToParticipatingSecuritiesBasic or UndistributedEarningsLossAllocatedToParticipatingSecuritiesDiluted."
-],
-"LeveragedBuyoutMethodologyAndAssumptions": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FairValueAssetsMeasuredOnRecurringBasisGainLossIncludedInInvestmentIncome": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FairValueMeasurementWithUnobservableInputsReconciliationRecurringBasisAssetGainLossIncludedInEarnings1 and members of IncomeStatementLocationAxis."
-],
-"ExplanationOfChangeInCumulativeTranslationAdjustment": [
-"2015-01-31",
-"Element deprecated due to redundancy. Possible replacement is ForeignCurrencyTranslationAdjustmentDescription."
-],
-"FinancialGuaranteeInsuranceContractsClaimLiabilitySignificantComponentsOfChangeAccretionOfDiscountAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"ManagementsAssertionOfAdequacyOfInsuranceReserves": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAmountAssumedFromOtherCompanies": [
-"2013-01-31",
-"Element was deprecated. Possible replacement is AssumedPremiumsEarned."
-],
-"CustomerSecuritiesForWhichEntityHasRightToSellOrRepledgeClassification": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CustomerSecuritiesForWhichEntityHasRightToSellOrRepledgeFairValue and members of BalanceSheetLocationAxis."
-],
-"WeightedAverageRateForeignDepositLiabilitiesDescription": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"PremiumsWrittenNetLife": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is PremiumsWrittenNet and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"EntityWideRevenueMajorCustomerPercentage": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ConcentrationRiskPercentage1 and members of ConcentrationRiskByBenchmarkAxis."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseIncurredClaims": [
-"2014-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseIncurredClaims1."
-],
-"ImpairmentOfIntangibleAssetsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ImpairmentOfIntangibleAssetsExcludingGoodwill."
-],
-"BusinessAcquisitionPurchasePriceAllocationUnclassifiedAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"EnvironmentalCostsOfPropertyForSaleDisposalOrAbandonmentAccruedExitCosts": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is EnvironmentalExitCostsCostsAccruedToDate."
-],
-"BusinessAcquisitionPurchasePriceAllocationDeferredIncomeTaxesAssetLiabilityNet": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AssumedPremiumsEarnedLife": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssumedPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
-],
-"DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiability": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are\nDeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityUndistributedEarningsOfForeignSubsidiaries, DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityUndistributedEarningsOfDomesticSubsidiaries, DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityBadDebtReserveForTaxPurposesOfQualifiedLender, and DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityPolicyholdersSurplus."
-],
-"AccretionExpenseMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is AccretionExpenseIncludingAssetRetirementObligations."
-],
-"NetInterestIncomeLossAfterProvisionForLoanLosses": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is InterestIncomeExpenseAfterProvisionForLoanLoss."
-],
-"DescriptionOfHedgedFirmCommitmentNotQualifyingAsInterestRateFairValueHedge": [
-"2015-01-31",
-"Element was deprecated because of low usage."
-],
-"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInRollingYearFour": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInRollingYearFour."
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is TransfersAccountedForAsSecuredBorrowingsAssetsCarryingAmount and members of BalanceSheetLocationAxis."
 ],
 "TransfersAccountedForAsSecuredBorrowingsClassificationAssociatedLiabilities": [
 "2013-01-31",
 "Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is TransfersAccountedForAsSecuredBorrowingsAssociatedLiabilitiesCarryingAmount and members of BalanceSheetLocationAxis."
 ],
-"SoftwareMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ComputerSoftwareIntangibleAssetMember."
-],
-"ReserveForLossesAndLossAdjustmentExpenses": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilityForClaimsAndClaimsAdjustmentExpense."
-],
-"SignificantAcquisitionsAndDisposalsDateOfTransactionForAcquisitionsOrDisposals": [
-"2015-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are BusinessAcquisitionDateOfAcquisitionAgreement1, BusinessAcquisitionEffectiveDateOfAcquisition1 or DisposalDate1."
-],
-"AccountingStandardsUpdate200910Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"DescriptionOfLocationOfGainLossOnPriceRiskDerivativeOnIncomeStatement": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is GainLossOnPriceRiskDerivativesNet and members of IncomeStatementLocationAxis."
-],
-"LiabilityForTitleClaimsAndClaimsAdjustmentExpenseAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"ImpairedLongLivedAssetsHeldAndUsedSegmentClassification": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ImpairmentOfLongLivedAssetsHeldForUse and members of StatementBusinessSegmentsAxis and SubsegmentsAxis."
-],
-"LiquidityDisclosureFutureObligationsNotExpectedToBeRepaidParentCompanyInformation": [
-"2015-01-31",
-"Element was deprecated due to issuance of new guidance."
-],
-"IneffectivenessOnCreditRiskHedgesIsImmaterial": [
-"2013-01-31",
-"Element was deprecated because it is an invalid concept."
-],
-"SubsidiariesAndOtherInvestmentsOfLimitedLiabilityCompanyOrLimitedPartnershipAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"MinorityInterestAndEarningsLossesEquityInvestmentsMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is IncomeLossFromEquityMethodInvestments."
-],
-"ConsumerOtherFinancingReceivableMember": [
-"2015-01-31",
-"Element was deprecated due to remodeling of topic area. Possible replacement is ConsumerPortfolioSegmentMember."
-],
-"FinancialGuaranteeInsuranceContractsPremiumReceivedOverContractPeriodPremiumReceivableIfNotPresentedSeparatelyFinancialStatementCaption": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FinancialGuaranteeInsuranceContractsPremiumReceivedOverContractPeriodPremiumReceivable and members of BalanceSheetLocationAxis."
-],
-"ReinsuranceLossOnUncollectibleAccountsInPeriodDescription": [
-"2013-01-31",
-"Element was deprecated due to remodeling of reinsurance topic area."
-],
-"BusinessCombinationSeparatelyRecognizedTransactionsLiabilitiesAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"DevelopmentStageEnterprises": [
-"2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AverageBalanceDuringPeriodOfLoansManagedAndSecuritized": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"FinancialGuaranteeInsuranceContractsClaimLiabilitySignificantComponentsOfChangeEffectOfChangeInDiscountRateAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"IncomeTaxExaminationInterestFromExamination": [
-"2013-01-31",
-"Element was deprecated because of redundancy.  Possible replacement is IncomeTaxExaminationInterestExpense."
-],
-"CededCreditRiskRiskClassificationAxis": [
-"2015-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacements are ConcentrationRiskByBenchmarkAxis and ConcentrationRiskByTypeAxis."
-],
-"ManagementFeeAmountPaid": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is PaymentForManagementFee."
-],
-"ReorganizationItemsDescriptionOfImpairmentLoss": [
+"TransitionToCompetitionLiabilityNoncurrent": [
 "2015-01-31",
 "Element was deprecated because of low usage."
 ],
-"ForwardContractIndexedToIssuersEquityRedeemableStockRedemptionRequirementsAmount": [
+"TravelAndEntertainmentExpenseMember": [
 "2013-01-31",
-"Element was deprecated because it has debit balance and duration period type attributes. Possible replacement is OptionIndexedToIssuersEquityRedeemableStockRedemptionRequirementsAmount1."
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is TravelAndEntertainmentExpense."
 ],
-"IncomeTaxExaminationRangeOfPossibleLosses": [
+"TypeOfDeferredCompensationDomain": [
+"2014-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacements are DeferredBonusAndProfitSharingArrangementIndividualContractTypeOfDeferredCompensationDomain, OtherPostretirementBenefitsIndividualContractsTypeOfDeferredCompensationDomain, or EquityBasedArrangementsIndividualContractsTypeOfDeferredCompensationDomain."
+],
+"TypesOfCreditRiskDerivativesUsed": [
 "2013-01-31",
-"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is IncomeTaxExaminationEstimateOfPossibleLoss and members of RangeAxis."
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are members of CreditDerivativesByContractTypeAxis."
 ],
-"CededPremiumsEarnedPropertyAndCasualty": [
+"TypesOfItemsHedgedByCreditRiskDerivatives": [
 "2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CededPremiumsEarned and members of ReinsurancePremiumsForInsuranceCompaniesByProductSegmentAxis."
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are members of UnderlyingAssetClassAxis."
 ],
-"DebtInstrumentConvertibleEffectiveInterestRate": [
+"USGovernmentAndGovernmentAgenciesAndAuthoritiesMember": [
+"2014-01-31",
+"Element was deprecated due to redundancy. Possible replacement is USTreasuryAndGovernmentMember."
+],
+"UnallocatedAmountToSegmentMember": [
 "2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DebtInstrumentInterestRateEffectivePercentage, DebtInstrumentInterestRateEffectivePercentageRateRangeMinimum, DebtInstrumentInterestRateEffectivePercentageRateRangeMaximum and members of LongtermDebtTypeAxis or ShortTermDebtTypeAxis."
+"Element was deprecated due to redundancy. Possible replacement is MaterialReconcilingItemsMember."
 ],
-"DescriptionOfAccountingMethodUsedForCreditRiskDerivatives": [
+"UndistributedDomesticEarningsMember": [
 "2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are members of ValuationTechniqueAxis."
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are UndistributedEarningsOfDomesticSubsidiaries, DeferredTaxLiabilityNotRecognizedDescriptionOfTemporaryDifferenceUndistributedEarningsOfDomesticSubsidiaries, DeferredTaxLiabilityNotRecognizedEventsThatWouldCauseTemporaryDifferenceToBeTaxableUndistributedEarningsOfDomesticSubsidiaries, DeferredTaxLiabilityNotRecognizedAmountOfUnrecognizedDeferredTaxLiabilityUndistributedEarningsOfDomesticSubsidiaries, or DeferredTaxLiabilityNotRecognizedDeterminationOfDeferredTaxLiabilityIsNotPracticableUndistributedEarningsOfDomesticSubsidiaries."
 ],
-"DerivativeInstrumentsGainLossRecognizedInIncomeNet": [
+"UndistributedEarningsAllocatedToParticipatingSecurities": [
+"2014-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacements are UndistributedEarningsLossAllocatedToParticipatingSecuritiesBasic or UndistributedEarningsLossAllocatedToParticipatingSecuritiesDiluted."
+],
+"UnprovedOilAndGasPropertyOrMajorProjectDomain": [
 "2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeGainLossOnDerivativeNet and members of HedgingDesignationAxis."
+"Element was deprecated due to rationalization of dimensions. Possible replacement is ProjectMember."
 ],
-"IncomeLossBeforeExtraordinaryItemsAndCumulativeEffectOfChangeInAccountingPrinciplePerOutstandingLimitedPartnershipUnit": [
+"UnrealizedGainLossOrWriteDownMember": [
 "2013-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is IncomeLossFromOperationsBeforeExtraordinaryItemsPerOutstandingLimitedPartnershipUnitBasicNetOfTax."
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is MarketableSecuritiesUnrealizedGainLoss."
 ],
-"ReinsurancePremiumsForInsuranceCompaniesByProductSegmentGrossAmount": [
-"2013-01-31",
-"Element was deprecated. Possible replacement is DirectPremiumsEarned."
-],
-"IncentiveFeeAmountPaid": [
-"2013-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is PaymentForIncentiveFee."
-],
-"ProfessionalFeesMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is ProfessionalFees."
-],
-"BusinessAcquisitionPurchasePriceAllocationCurrentAssetsAssetNotToBeUsedAbstract": [
-"2013-01-31",
-"Element was deprecated."
-],
-"DiscontinuedOperationPeriodOfContinuingCashFlowsAfterDisposal": [
-"2015-01-31",
+"UnrecognizedTaxBenefitsResultingInNetOperatingLossCarryforward": [
+"2014-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"PublicUtilitiesPropertyPlantAndEquipmentVehiclesEstimatedUsefulLife": [
-"2013-01-31",
-"Element was deprecated because it is has a stringItemType attribute. Possible replacement is PublicUtilitiesPropertyPlantAndEquipmentVehiclesUsefulLife."
-],
-"SiteContingencyNatureOfContingencyDomain": [
-"2013-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are EnvironmentalRemediationSiteDomain or EnvironmentalRemediationContingencyDomain."
-],
-"EmbeddedDerivativeDescriptionOfLocationOfGainLossInFinancialStatements": [
-"2015-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are EmbeddedDerivativeGainOnEmbeddedDerivative, EmbeddedDerivativeLossOnEmbeddedDerivative, and EmbeddedDerivativeGainLossOnEmbeddedDerivativeNet and members of IncomeStatementLocationAxis."
-],
-"FairValueEstimateNotPracticableReasonsAbstract": [
-"2015-01-31",
-"Element was deprecated."
-],
-"RealEstateWriteDownOrReservePropertyDomain": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is RealEstateAndAccumulatedDepreciationNameOfPropertyDomain."
-],
-"AllowanceForCostOfEquityFundsUsedDuringConstructionMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is PublicUtilitiesAllowanceForFundsUsedDuringConstructionCapitalizedInterest."
-],
-"OtherInsuranceIndustryDisclosures": [
+"UnrecordedUnconditionalPurchaseObligationContractQuantityReceived": [
 "2015-01-31",
 "Element was deprecated because of low usage."
 ],
-"SubsequentEventAmountLowerRange": [
+"UnsolicitedTenderOfferExpensesMember": [
 "2013-01-31",
-"Element was deprecated because it is an invalid concept."
+"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally."
 ],
-"ChangeInMeasurementDateSFAS158Abstract": [
+"UnusualOrInfrequentItemGross1": [
 "2013-01-31",
-"Element was deprecated."
+"Element was deprecated because it represents multiple distinct concepts. Possible replacement for a gain is UnusualOrInfrequentItemGainGross, or UnusualOrInfrequentItemLossGross to represent a loss."
 ],
-"PremiumsWrittenNetOtherInsuranceAbstract": [
+"ValuationAllowanceAmount": [
 "2013-01-31",
-"Element was deprecated."
+"Element was deprecated due to redundancy.  Possible replacement is DeferredTaxAssetsValuationAllowance."
 ],
-"CashFlowHedgeGainLossReclassifiedToOtherIncomeNet": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is OtherIncome and members of StatementEquityComponentsAxis and ReclassificationOutOfAccumulatedOtherComprehensiveIncomeAxis."
+"VariableInterestEntityClassificationOfCarryingAmountAssetsAndLiabilitiesNet": [
+"2015-01-31",
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are VariableInterestEntityClassificationOfCarryingAmountAssets and VariableInterestEntityClassificationOfCarryingAmountLiabilities and members of BalanceSheetLocationAxis."
 ],
-"InstrumentTypeMember": [
-"2013-01-31",
-"Element was deprecated because it was incorrectly defined. Possible replacement is EnergyDomain."
-],
-"BusinessAcquisitionPurchasePriceAllocationBuildings": [
-"2013-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"ListedOptionsMember": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ExchangeTradedOptionsMember."
-],
-"LiabilitiesSubjectToCompromiseBalanceAtBankruptcyEffectiveDate": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilitiesSubjectToCompromise."
-],
-"DeferredCompensationArrangementWithIndividualPostretirementBenefitsByTitleOfIndividualAxis": [
-"2013-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is TitleofIndividualAxis."
-],
-"PrepaidReinsurancePremiumsMethodologyAndAssumptions": [
-"2013-01-31",
-"Element was deprecated due to redundancy. Possible replacement is NaturePurposeAndEffectOfReinsuranceTransactions."
-],
-"RegulatoryNoncurrentLiabilityEndDateForRecovery": [
+"WeeklyReserveCalculationDescription": [
 "2015-01-31",
 "Element was deprecated because of low usage."
 ],
-"AssetsHeldForSaleLongLivedAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"LoansHeldForSaleConsumerCreditCard": [
+"WeightedAverageRateDomesticDepositLiabilitiesDescription": [
 "2015-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacement is LoansReceivableHeldForSaleNetNotPartOfDisposalGroupConsumerCreditCard."
+"Element was deprecated because of low usage."
 ],
-"AmortizationOfIntangiblesNonproductionMember": [
-"2013-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacement is AmortizationOfIntangibleAssets."
+"WeightedAverageRateDomesticDepositRetail": [
+"2015-01-31",
+"Element was deprecated because of low usage."
 ],
-"AssetManagementFees": [
-"2013-01-31",
-"Element was deprecated due to remodeling of topic area. Possible replacement is AssetManagementFees1 or InvestmentAdvisoryManagementAndAdministrativeFees."
+"WeightedAverageRateForeignDepositCertificatesOfDeposit": [
+"2015-01-31",
+"Element was deprecated because of low usage."
 ],
-"AccountingStandardsUpdate201003Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+"WeightedAverageRateForeignDepositChecking": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"WeightedAverageRateForeignDepositLiabilitiesDescription": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"WeightedAverageRateForeignDepositMoneyMarketDemandAccount": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"WeightedAverageRateForeignDepositNoticeOfWithdrawal": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"WeightedAverageRateForeignDepositOtherTimeDeposit": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"WeightedAverageRateForeignDepositRetail": [
+"2015-01-31",
+"Element was deprecated because of low usage."
+],
+"WeightedAverageRateForeignDepositSavings": [
+"2015-01-31",
+"Element was deprecated because of low usage."
 ]
 }

--- a/dqc_us_rules/resources/DQC_US_0018/2017_deprecated-concepts.json
+++ b/dqc_us_rules/resources/DQC_US_0018/2017_deprecated-concepts.json
@@ -3,56 +3,8 @@
 "2016-01-31",
 "Element was deprecated because of low usage."
 ],
-"AccountingStandardsUpdate200905Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AccountingStandardsUpdate200908Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AccountingStandardsUpdate200910Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AccountingStandardsUpdate200912Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AccountingStandardsUpdate200913Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AccountingStandardsUpdate200914Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AccountingStandardsUpdate200915Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
 "AccountingStandardsUpdate200916Member": [
 "2015-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AccountingStandardsUpdate200917Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AccountingStandardsUpdate201001Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AccountingStandardsUpdate201002Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AccountingStandardsUpdate201003Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AccountingStandardsUpdate201008Member": [
-"2014-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
 "AccountingStandardsUpdate201011Member": [
@@ -71,20 +23,32 @@
 "2015-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"AccountingStandardsUpdate201017Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AccountingStandardsUpdate201018Member": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
 "AccountingStandardsUpdate201024Member": [
 "2015-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
 "AccountingStandardsUpdate201028Member": [
 "2015-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"AccountingStandardsUpdate201201Member": [
+"2017-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"AccountingStandardsUpdate201204Member": [
+"2017-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"AccountingStandardsUpdate201205Member": [
+"2017-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"AccountingStandardsUpdate201207Member": [
+"2017-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"AccountingStandardsUpdate201304Member": [
+"2017-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
 "AccretionOfDiscount": [
@@ -183,6 +147,10 @@
 "2016-01-31",
 "Element was deprecated because of low usage."
 ],
+"AdoptionOfSFAS158EmployersAccountingForDefinedBenefitPensionAndOtherPostretirementPlansAbstract": [
+"2017-01-31",
+"Element was deprecated."
+],
 "AdvancePaymentsByBorrowersForTaxesAndInsuranceSummary": [
 "2016-01-31",
 "Element was deprecated because of low usage."
@@ -202,6 +170,10 @@
 "AncillaryFeeIncomeGeneratedByServicingFinancialAssetsDescriptionOfWhereReportedOnStatementOfIncome": [
 "2015-01-31",
 "Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AncillaryFeeIncomeGeneratedByServicingFinancialAssetsAmount and members of IncomeStatementLocationAxis."
+],
+"ApplicationOfRecognitionProvisionsOfSFAS158IncrementalEffectsOnBalanceSheetAbstract": [
+"2017-01-31",
+"Element was deprecated."
 ],
 "AssetRecoveryDamagedPropertyCostsCurrent": [
 "2016-01-31",
@@ -235,53 +207,9 @@
 "2015-01-31",
 "Element deprecated due to redundancy. Possible replacement is ScheduleOfDisposalGroupsIncludingDiscontinuedOperationsIncomeStatementBalanceSheetAndAdditionalDisclosuresTextBlock."
 ],
-"AssetsHeldForSaleAtCarryingValue": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are AssetsOfDisposalGroupIncludingDiscontinuedOperation or AssetsHeldForSaleNotPartOfDisposalGroup."
-],
-"AssetsHeldForSaleAtCarryingValueAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"AssetsHeldForSaleCapitalLeasedAssetsNet": [
-"2014-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacements are DisposalGroupIncludingDiscontinuedOperationCapitalLeasedAssetsCurrent, DisposalGroupIncludingDiscontinuedOperationCapitalLeasedAssetsNoncurrent or DisposalGroupIncludingDiscontinuedOperationCapitalLeasedAssets."
-],
-"AssetsHeldForSaleCurrent": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are AssetsOfDisposalGroupIncludingDiscontinuedOperationCurrent or AssetsHeldForSaleNotPartOfDisposalGroupCurrent."
-],
-"AssetsHeldForSaleCurrentAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"AssetsHeldForSaleLongLived": [
-"2014-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
-"AssetsHeldForSaleLongLivedAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
 "AssetsHeldForSaleMember": [
 "2015-01-31",
 "Element was deprecated because it was inappropriately modeled. Possible replacement is DisposalGroupHeldForSaleNotDiscontinuedOperationsMember."
-],
-"AssetsHeldForSaleOtherNoncurrent": [
-"2014-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacement is DisposalGroupIncludingDiscontinuedOperationOtherNoncurrentAssets."
-],
-"AssetsHeldForSalePropertyPlantAndEquipment": [
-"2014-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacements are DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipmentNoncurrent, DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipmentCurrent or DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipment."
-],
-"AssetsOfDisposalGroupIncludingDiscontinuedOperationNoncurrent": [
-"2014-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacement is DisposalGroupIncludingDiscontinuedOperationAssetsNoncurrent."
-],
-"AssumedPremiumsLifeInsuranceInForce": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is LifeInsuranceInForceAssumed."
 ],
 "AuctionMarketPreferredSecurities": [
 "2016-01-31",
@@ -343,10 +271,6 @@
 "2016-01-31",
 "Element was deprecated and replaced with a more encompassing element. Possible replacement is MarketableSecuritiesAvailableForSaleSecuritiesPolicy."
 ],
-"AvailableForSaleSecuritiesDebtMaturitiesAmortizedCost": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AvailableForSaleDebtSecuritiesAmortizedCostBasis."
-],
 "AvailableForSaleSecuritiesGrossRealizedGainsLossesCostBasisMethodologyOfSecuritiesSold": [
 "2016-01-31",
 "Element was deprecated because of low usage."
@@ -358,26 +282,6 @@
 "AvailableForSaleSecuritiesTransfersToTradingGainsLossesBasisMethodologyOfAmountReclassified": [
 "2016-01-31",
 "Element was deprecated and replaced with a more encompassing element. Possible replacement is MarketableSecuritiesAvailableForSaleSecuritiesPolicy."
-],
-"AverageBalanceDuringPeriodOfLoansHeldForSaleOrSecuritization": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AverageBalanceDuringPeriodOfLoansHeldInPortfolio": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AverageBalanceDuringPeriodOfLoansHeldInPortfolioAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"AverageBalanceDuringPeriodOfLoansManagedAndSecuritized": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"AverageBalanceDuringPeriodOfLoansSecuritized": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
 "AverageProductionCostInformation": [
 "2016-01-31",
@@ -443,10 +347,6 @@
 "2016-01-31",
 "Element was deprecated because of low usage."
 ],
-"BorrowedFunds": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DebtAndCapitalLeaseObligations."
-],
 "BreakpointDiscountRefund": [
 "2015-01-31",
 "Element was deprecated because of low usage."
@@ -454,22 +354,6 @@
 "BrokerDealerSecuritiesOwnedNotReadilyMarketableAtEstimatedFairValue": [
 "2016-01-31",
 "Element was deprecated because of low usage."
-],
-"BusinessAcquisitionPreacquisitionContingencyDescriptionOfSettlement": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"BusinessAcquisitionPreexistingRelationshipAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"BusinessAcquisitionPreexistingRelationshipDescription": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is BusinessCombinationSeparatelyRecognizedTransactionsDescription and members of BusinessCombinationSeparatelyRecognizedTransactionsAxis."
-],
-"BusinessAcquisitionPreexistingRelationshipGainLossRecognized": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is BusinessCombinationSeparatelyRecognizedTransactionsNetGainsAndLosses and members of BusinessCombinationSeparatelyRecognizedTransactionsAxis."
 ],
 "BusinessAcquisitionStandardIndustrialClassificationSICCodeForAcquiredEntity": [
 "2016-01-31",
@@ -567,18 +451,6 @@
 "2016-01-31",
 "Element was deprecated because of low usage."
 ],
-"CausesOfIncreaseDecreaseInLiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAmount": [
-"2014-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is SupplementalInformationForPropertyCasualtyInsuranceUnderwritersPriorYearClaimsAndClaimsAdjustmentExpense."
-],
-"CausesOfIncreaseDecreaseInLiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAxis": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilityForCatastropheClaimsByCatastrophicEventAxis."
-],
-"CausesOfIncreaseDecreaseInLiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseCauseDomain": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is CatastrophicEventDomain."
-],
 "CededCreditRiskConcentratedCreditRiskMember": [
 "2015-01-31",
 "Element was deprecated because it was inappropriately modeled. Possible replacements are ConcentrationRiskByTypeAxis and its member ReinsurerConcentrationRiskMember and members of ConcentrationRiskByBenchmarkAxis."
@@ -594,10 +466,6 @@
 "CededCreditRiskRiskClassificationDomain": [
 "2015-01-31",
 "Element was deprecated because it was inappropriately modeled. Possible replacements are ConcentrationRiskBenchmarkDomain and ConcentrationRiskTypeDomain."
-],
-"CededPremiumsLifeInsuranceInForce": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is LifeInsuranceInForceCeded."
 ],
 "CertainLoansAcquiredInTransferAccountedForAsAvailableForSaleDebtSecuritiesAccretableYield": [
 "2015-01-31",
@@ -667,10 +535,6 @@
 "2016-01-31",
 "Element was deprecated because it was inappropriately modeled. Possible replacement is financial statement line item elements and members of ChangeInAccountingEstimateByTypeAxis and StatementScenarioAxis."
 ],
-"ChangeInHistoricalClaimsRateExperienceMember": [
-"2014-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
 "ChangesInFranchises": [
 "2015-01-31",
 "Element was deprecated because it represents multiple distinct concepts. Possible replacements are SignificantChangesFranchisesSold, SignificantChangesFranchisesPurchasedDuringPeriod, SignificantChangesFrachisedOutletsInOperation, or SignificantChangesFrachisorOutletsInOperation."
@@ -678,10 +542,6 @@
 "ChemicalsRevenue": [
 "2016-01-31",
 "Element was deprecated because of low usage. Possible replacements are RevenueMineralSales or OtherAlternativeEnergySalesRevenue."
-],
-"ClassOfWarrantOrRightExercisePriceOfWarrantsOrRights": [
-"2014-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is ClassOfWarrantOrRightExercisePriceOfWarrantsOrRights1."
 ],
 "ClosedBlockDividendObligationEffectOfOperatingResults": [
 "2016-01-31",
@@ -767,58 +627,6 @@
 "2016-01-31",
 "Element was deprecated and replaced with a more encompassing element. Possible replacement is CostOfTransmission."
 ],
-"CumulativeEffectAdjustmentAbstract": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CumulativeEffectAdjustmentApplicationOfFairValueOptionGrossGains": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CumulativeEffectAdjustmentApplicationOfFairValueOptionGrossGainsAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"CumulativeEffectAdjustmentApplicationOfFairValueOptionGrossLosses": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CumulativeEffectAdjustmentApplicationOfFairValueOptionGrossLossesAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"CumulativeEffectAdjustmentApplicationOfFairValueOptionUnrealizedGainsRecognized": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CumulativeEffectAdjustmentApplicationOfFairValueOptionUnrealizedGainsUnrecognized": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CumulativeEffectAdjustmentApplicationOfFairValueOptionUnrealizedLossesRecognized": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CumulativeEffectAdjustmentApplicationOfFairValueOptionUnrealizedLossesUnrecognized": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CumulativeEffectAdjustmentBifurcationOfHybridsGrossGains": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CumulativeEffectAdjustmentBifurcationOfHybridsGrossLosses": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CumulativeEffectAdjustmentGrossGains": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"CumulativeEffectAdjustmentGrossLosses": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
 "CumulativeEffectOfProspectiveApplicationOfNewAccountingPrinciple": [
 "2015-01-31",
 "Element was deprecated because it has a duration period type attribute. Possible replacement is CumulativeEffectOfNewAccountingPrincipleInPeriodOfAdoption."
@@ -847,9 +655,9 @@
 "2015-01-31",
 "Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is CustomerSecuritiesForWhichEntityHasRightToSellOrRepledgeFairValueOfSecuritiesSoldOrRepledged and members of BalanceSheetLocationAxis."
 ],
-"DebtInstrumentInterestRateAtPeriodEnd": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DebtInstrumentInterestRateEffectivePercentage."
+"DebtInstrumentConvertibleThresholdConsecutiveTradingDays": [
+"2017-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is DebtInstrumentConvertibleThresholdConsecutiveTradingDays1."
 ],
 "DebtInstrumentInterestRateEffectivePercentageRateRangeMaximum": [
 "2016-01-31",
@@ -899,13 +707,13 @@
 "2015-01-31",
 "Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DeconsolidationGainOrLossAmount and members of IncomeStatementLocationAxis."
 ],
-"DeferredCompensationArrangementWithIndividualMaximumContractualTerm": [
-"2014-01-31",
-"Element was deprecated because it has a stringItemType attribute. Possible replacement is DeferredCompensationArrangementWithIndividualMaximumContractualTerm1."
+"DeferredCompensationArrangementWithIndividualDistributionsPaid": [
+"2017-01-31",
+"Element was deprecated because it has debit balance and instant period type attributes. Possible replacement is DeferredCompensationArrangementWithIndividualDistributionPaid."
 ],
-"DeferredCompensationArrangementWithIndividualRequisiteServicePeriod": [
-"2014-01-31",
-"Element was deprecated because it has a stringItemType attribute. Possible replacement is DeferredCompensationArrangementWithIndividualRequisiteServicePeriod1."
+"DeferredCompensationArrangementWithIndividualEmployerContribution": [
+"2017-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is DeferredCompensationArrangementWithIndividualContributionsByEmployer."
 ],
 "DeferredElectricCost": [
 "2016-01-31",
@@ -951,14 +759,6 @@
 "2016-01-31",
 "Element was deprecated because it has a debit balance attribute. Possible replacement is DeferredPolicyAcquisitionCostForeignCurrencyTranslationGainLoss."
 ],
-"DeferredPolicyAcquisitionCostsAndPresentValueOfFutureProfits": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DeferredPolicyAcquisitionCostsAndValueOfBusinessAcquired."
-],
-"DeferredPolicyAcquisitionCostsNet": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is DeferredPolicyAcquisitionCosts."
-],
 "DeferredRevenueRefundPayments": [
 "2016-01-31",
 "Element was deprecated because it has a debit balance attribute. Possible replacement is DeferredRevenueRefundPayments1."
@@ -975,21 +775,229 @@
 "2016-01-31",
 "Element was deprecated because of low usage."
 ],
-"DefinedBenefitPlanAccumulatedOtherComprehensiveIncomeLossAfterTax": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AccumulatedOtherComprehensiveIncomeLossDefinedBenefitPensionAndOtherPostretirementPlansNetOfTax."
+"DefinedBenefitPlanAccumulatedOtherComprehensiveIncomeMinimumPensionLiabilityAfterTax": [
+"2017-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DefinedBenefitPlanAccumulatedOtherComprehensiveIncomeMinimumPensionLiabilityBeforeTax": [
+"2017-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DefinedBenefitPlanAmortizationOfNetTransitionAssetObligation": [
+"2017-01-31",
+"Element was deprecated because it has debit balance and duration period type attributes. Possible replacement is DefinedBenefitPlanExpectedAmortizationOfTransitionAssetObligationNextFiscalYear."
+],
+"DefinedBenefitPlanAmortizationOfTransitionObligationsAssets": [
+"2017-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is DefinedBenefitPlanAmortizationOfTransitionAssetObligation."
+],
+"DefinedBenefitPlanAmountToBeAmortizedFromAccumulatedOtherComprehensiveIncomeLossNextFiscalYear": [
+"2017-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is DefinedBenefitPlanExpectedAmortizationNextFiscalYear."
+],
+"DefinedBenefitPlanAssetsForPlanBenefitsAbstract": [
+"2017-01-31",
+"Element was deprecated."
+],
+"DefinedBenefitPlanAssetsForPlanBenefitsCurrentAndNoncurrent": [
+"2017-01-31",
+"Element deprecated due to redundancy. Possible replacement is DefinedBenefitPlanAssetsForPlanBenefitsNoncurrent."
+],
+"DefinedBenefitPlanAssumptionsUsedCalculatingBenefitObligationDiscountRateSupportBondIndices": [
+"2017-01-31",
+"Element was deprecated and replaced with a more encompassing element. Possible replacement is DefinedBenefitPlanAssumptionsUsedInCalculationsNarrativeDescription."
+],
+"DefinedBenefitPlanAssumptionsUsedCalculatingBenefitObligationDiscountRateSupportMethodologyAndSourceData": [
+"2017-01-31",
+"Element was deprecated and replaced with a more encompassing element. Possible replacement is DefinedBenefitPlanAssumptionsUsedInCalculationsNarrativeDescription."
+],
+"DefinedBenefitPlanAssumptionsUsedCalculatingNetPeriodicBenefitCostChangeDueToSubsequentInterimMeasurement": [
+"2017-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"DefinedBenefitPlanAssumptionsUsedCalculatingNetPeriodicBenefitCostDiscountRateSupportBondIndices": [
+"2017-01-31",
+"Element was deprecated and replaced with a more encompassing element. Possible replacement is DefinedBenefitPlanAssumptionsUsedInCalculationsNarrativeDescription."
+],
+"DefinedBenefitPlanAssumptionsUsedCalculatingNetPeriodicBenefitCostDiscountRateSupportMethodologyAndSourceData": [
+"2017-01-31",
+"Element was deprecated and replaced with a more encompassing element. Possible replacement is DefinedBenefitPlanAssumptionsUsedInCalculationsNarrativeDescription."
+],
+"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsDisclosuresAbstract": [
+"2017-01-31",
+"Element was deprecated."
+],
+"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsNetAmountRecognizedAbstract": [
+"2017-01-31",
+"Element was deprecated."
+],
+"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsNetGainsLossesNotYetRecognized": [
+"2017-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsNetPriorServiceCostsCreditsNotYetRecognized": [
+"2017-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DefinedBenefitPlanBeforeAdoptionOfSFAS158RecognitionProvisionsNetTransitionObligationsAssetsNotYetRecognized": [
+"2017-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"DefinedBenefitPlanBenefitsPaid": [
+"2017-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacements are DefinedBenefitPlanBenefitObligationBenefitsPaid and DefinedBenefitPlanPlanAssetsBenefitsPaid."
+],
+"DefinedBenefitPlanContributionsByPlanParticipants": [
+"2017-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacements are DefinedBenefitPlanBenefitObligationContributionsByPlanParticipant and DefinedBenefitPlanPlanAssetsContributionsByPlanParticipant."
+],
+"DefinedBenefitPlanCurrentAssets": [
+"2017-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
+"DefinedBenefitPlanDescriptionOfPlanAmendment": [
+"2017-01-31",
+"Element was deprecated and replaced with a more encompassing element. Possible replacement is DefinedBenefitPlanExplanationOfSignificantChangeInBenefitObligationOrPlanAssetsNotApparentFromOtherRequiredDisclosures."
+],
+"DefinedBenefitPlanDescriptionOfSettlementsAndCurtailments": [
+"2017-01-31",
+"Element was deprecated and replaced with a more encompassing element. Possible replacement is DefinedBenefitPlanExplanationOfSignificantChangeInBenefitObligationOrPlanAssetsNotApparentFromOtherRequiredDisclosures."
+],
+"DefinedBenefitPlanEffectOfPlanAmendmentOnAccumulatedBenefitObligation": [
+"2017-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is DefinedBenefitPlanAccumulatedBenefitObligationIncreaseDecreaseForPlanAmendment."
+],
+"DefinedBenefitPlanEffectOfPlanAmendmentOnNetPeriodicBenefitCost": [
+"2017-01-31",
+"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is DefinedBenefitPlanNetPeriodicBenefitCostCreditIncreaseDecreaseForPlanAmendment."
+],
+"DefinedBenefitPlanEffectOfSettlementsAndCurtailmentsOnAccumulatedBenefitObligation": [
+"2017-01-31",
+"Element was deprecated because it has credit balance and instant period type attributes. Possible replacement is DefinedBenefitPlanAccumulatedBenefitObligationIncreaseDecreaseForSettlementAndCurtailment."
+],
+"DefinedBenefitPlanExpectedContributionsInCurrentFiscalYear": [
+"2017-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is DefinedBenefitPlanExpectedFutureEmployerContributionsCurrentFiscalYear."
+],
+"DefinedBenefitPlanExpectedContributionsInCurrentFiscalYearAbstract": [
+"2017-01-31",
+"Element was deprecated."
+],
+"DefinedBenefitPlanExpectedFutureBenefitPaymentsFiveRollingYearsThereafter": [
+"2017-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacement is DefinedBenefitPlanExpectedFutureBenefitPaymentsFiveFiscalYearsThereafter."
+],
+"DefinedBenefitPlanExpectedFutureBenefitPaymentsNextRollingTwelveMonths": [
+"2017-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacement is DefinedBenefitPlanExpectedFutureBenefitPaymentsNextTwelveMonths."
+],
+"DefinedBenefitPlanExpectedFutureBenefitPaymentsRollingMaturityAbstract": [
+"2017-01-31",
+"Element was deprecated."
+],
+"DefinedBenefitPlanExpectedFutureBenefitPaymentsRollingYearFive": [
+"2017-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacement is DefinedBenefitPlanExpectedFutureBenefitPaymentsYearFive."
+],
+"DefinedBenefitPlanExpectedFutureBenefitPaymentsRollingYearFour": [
+"2017-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacement is DefinedBenefitPlanExpectedFutureBenefitPaymentsYearFour."
+],
+"DefinedBenefitPlanExpectedFutureBenefitPaymentsRollingYearThree": [
+"2017-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacement is DefinedBenefitPlanExpectedFutureBenefitPaymentsYearThree."
+],
+"DefinedBenefitPlanExpectedFutureBenefitPaymentsRollingYearTwo": [
+"2017-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacement is DefinedBenefitPlanExpectedFutureBenefitPaymentsYearTwo."
+],
+"DefinedBenefitPlanForeignCurrencyExchangeRateChangesPlanAssets": [
+"2017-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is DefinedBenefitPlanPlanAssetsForeignCurrencyTranslationGainLoss."
+],
+"DefinedBenefitPlanFutureAmortizationOfGainLoss": [
+"2017-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is DefinedBenefitPlanExpectedAmortizationOfGainLossNextFiscalYear."
+],
+"DefinedBenefitPlanFutureAmortizationOfPriorServiceCostCredit": [
+"2017-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is DefinedBenefitPlanExpectedAmortizationOfPriorServiceCostCreditNextFiscalYear."
+],
+"DefinedBenefitPlanGrossPrescriptionDrugSubsidyReceiptsReceived": [
+"2017-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacements are DefinedBenefitPlanBenefitObligationPrescriptionDrugSubsidyReceipt and DefinedBenefitPlanPlanAssetsPrescriptionDrugSubsidyReceipt."
+],
+"DefinedBenefitPlanHealthCareCostTrendRateAssumedForNextFiscalYear": [
+"2017-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is DefinedBenefitPlanHealthCareCostTrendRateAssumedNextFiscalYear."
 ],
 "DefinedBenefitPlanMeasurementDate": [
 "2016-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
+"DefinedBenefitPlanOtherInformation": [
+"2017-01-31",
+"Element was deprecated and replaced with a more encompassing element. Possible replacement is DefinedBenefitPlansGeneralInformation."
+],
 "DefinedBenefitPlanPurchasesSalesAndSettlementsAbstract": [
 "2015-01-31",
 "Element was deprecated."
 ],
-"DefinedContributionPensionMember": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is PensionPlansDefinedBenefitMember."
+"DefinedBenefitPlanTargetPlanAssetAllocations": [
+"2017-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is DefinedBenefitPlanPlanAssetsTargetAllocationPercentage."
+],
+"DefinedBenefitPlanTargetPlanAssetAllocationsRangeMaximum": [
+"2017-01-31",
+"Element was deprecated because it has a duration period type attribute and because the financial reporting concept can be conveyed dimensionally. Possible replacement is DefinedBenefitPlanPlanAssetsTargetAllocationPercentage, RangeAxis and MaximumMember."
+],
+"DefinedBenefitPlanTargetPlanAssetAllocationsRangeMinimum": [
+"2017-01-31",
+"Element was deprecated because it has a duration period type attribute and because the financial reporting concept can be conveyed dimensionally. Possible replacement is DefinedBenefitPlanPlanAssetsTargetAllocationPercentage, RangeAxis and MinimumMember."
+],
+"DefinedBenefitPlanUltimateHealthCareCostTrendRate": [
+"2017-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is DefinedBenefitPlanUltimateHealthCareCostTrendRate1."
+],
+"DefinedBenefitPlanYearThatRateReachesUltimateTrendRate": [
+"2017-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is DefinedBenefitPlanYearHealthCareCostTrendRateReachesUltimateTrendRate."
+],
+"DefinedBenefitPlansDisclosuresDefinedBenefitPlansAxis": [
+"2017-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacement is RetirementPlanTypeAxis, RetirementPlanSponsorLocationAxis, RetirementPlanTaxStatusAxis, RetirementPlanFundingStatusAxis or RetirementPlanNameAxis."
+],
+"DefinedBenefitPlansDomain": [
+"2017-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacement is RetirementPlanTypeDomain, RetirementPlanSponsorLocationDomain, RetirementPlanTaxStatusDomain, RetirementPlanFundingStatusDomain or RetirementPlanNameDomain."
+],
+"DefinedBenefitPlansEstimatedFutureEmployerContributionsInCurrentFiscalYear": [
+"2017-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is DefinedBenefitPlanExpectedFutureEmployerContributionsRemainderOfFiscalYear."
+],
+"DefinedBenefitPlansEstimatedFutureEmployerContributionsInNextFiscalYear": [
+"2017-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is DefinedBenefitPlanExpectedFutureEmployerContributionsNextFiscalYear."
+],
+"DefinedContributionPlanNameAxis": [
+"2017-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacement is RetirementPlanNameAxis."
+],
+"DefinedContributionPlanNameDomain": [
+"2017-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacement is RetirementPlanNameDomain."
+],
+"DefinedContributionPlanNumberOfEmployeesCovered": [
+"2017-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is DefinedContributionPlanNumberOfEmployees."
+],
+"DefinedContributionPlanTypeAxis": [
+"2017-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacement is RetirementPlanTypeAxis, RetirementPlanSponsorLocationAxis, RetirementPlanTaxStatusAxis or RetirementPlanNameAxis."
+],
+"DefinedContributionPlanTypeDomain": [
+"2017-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacement is RetirementPlanTypeDomain, RetirementPlanSponsorLocationDomain, RetirementPlanTaxStatusDomain or RetirementPlanNameDomain."
 ],
 "DemutualizationByInsuranceEntityDescriptionOfSecuritiesIssued": [
 "2016-01-31",
@@ -1007,21 +1015,9 @@
 "2015-01-31",
 "Element was deprecated because of low usage."
 ],
-"DeprecatedItems": [
-"",
-"This is a container item for US-GAAP concepts that have been deprecated."
-],
-"DepreciableAssetsMember": [
-"2014-01-31",
-"Element was deprecated because it was inappropriately modeled."
-],
 "DerecognizedAssetsInformationAboutAssetQualityOfSecuritizedOrAssetbackedFinancingArrangementAssetsAndAnyOtherFinancialAssetsManagedTogetherTextBlock": [
 "2016-01-31",
-"Element deprecated due to redundancy. Possible replacement is ScheduleOfQuantitativeInformationAboutDerecognizedSecuritizedOrAssetbackedFinancingArrangementAssetsAndAnyOtherFinancialAssetsManagedTogetherTextBlock."
-],
-"DerecognizedAssetsSecuritizedOrAssetbackedFinancingArrangementAssetsAndAnyOtherFinancialAssetsManagedTogetherAverageBalanceDuringPeriod": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+"Element deprecated because it was inappropriately modeled. Possible replacements are ScheduleOfQuantitativeInformationAboutDerecognizedSecuritizedOrAssetbackedFinancingArrangementAssetsAndAnyOtherFinancialAssetsManagedTogetherTextBlock and TransfersAndServicingOfFinancialAssetsTextBlock."
 ],
 "DerivativeByNatureAxis": [
 "2016-01-31",
@@ -1030,10 +1026,6 @@
 "DerivativeCreditRisk": [
 "2016-01-31",
 "Element was deprecated because of low usage."
-],
-"DerivativeDescriptionOfVariableRateBasis": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are DerivativeVariableInterestRate and members of VariableRateAxis."
 ],
 "DerivativeHigherFixedInterestRateRange": [
 "2016-01-31",
@@ -1203,6 +1195,10 @@
 "2015-01-31",
 "Element was deprecated because of low usage."
 ],
+"DescriptionOfRelatedPartyLeasingArrangements": [
+"2017-01-31",
+"Element was deprecated and replaced with a more encompassing element. Possible replacement is RelatedPartyTransactionDescriptionOfTransaction."
+],
 "DescriptionOfSubstantialDoubtAboutInstitutionsAbilityToContinueAsGoingConcernBankingOrSavingsInstitution": [
 "2015-01-31",
 "Element was deprecated due to issuance of new guidance."
@@ -1251,10 +1247,6 @@
 "2016-01-31",
 "Element was deprecated because of low usage."
 ],
-"DirectPremiumsLifeInsuranceInForce": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is LifeInsuranceInForceGross."
-],
 "DisallowedCostsForRecentlyCompletedPlantPolicy": [
 "2016-01-31",
 "Element was deprecated and replaced with a more encompassing element. Possible replacement is PublicUtilitiesPolicyTextBlock."
@@ -1295,37 +1287,9 @@
 "2015-01-31",
 "Element was deprecated because it was inappropriately modeled."
 ],
-"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReserves10PercentAnnualDiscountForEstimatedTimingOfCashFlows": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesTenPercentAnnualDiscountForEstimatedTimingOfCashFlows."
-],
 "DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesEntitysShareOfEquityMethodInvesteesStandardizedDiscountedFutureNetCashFlows": [
 "2015-01-31",
 "Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is StandardizedMeasureOfDiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReserves and EquityMethodInvesteeMember."
-],
-"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureCashInflows": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesCashInflows."
-],
-"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureDevelopmentCosts1": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesDevelopmentCosts."
-],
-"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureIncomeTaxExpense1": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesIncomeTaxExpense."
-],
-"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureNetCashFlows": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesNetCashFlows."
-],
-"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesFutureProductionCosts1": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is FutureNetCashFlowsRelatingToProvedOilAndGasReservesProductionCosts."
-],
-"DiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReservesStandardizedMeasure": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is StandardizedMeasureOfDiscountedFutureNetCashFlowsRelatingToProvedOilAndGasReserves."
 ],
 "DiscussionOfEarningsEffectOfHybridInstrumentFairValueChanges": [
 "2015-01-31",
@@ -1350,18 +1314,6 @@
 "DisposalGroupIncludingDiscontinuedOperationCashFlowsOfDisposalGroup": [
 "2015-01-31",
 "Element was deprecated because it was inappropriately modeled."
-],
-"DisposalGroupIncludingDiscontinuedOperationGoodwill": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DisposalGroupIncludingDiscontinuedOperationGoodwillNoncurrent, DisposalGroupIncludingDiscontinuedOperationGoodwillCurrent or DisposalGroupIncludingDiscontinuedOperationGoodwill1."
-],
-"DisposalGroupIncludingDiscontinuedOperationIntangibleAssetsNet": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DisposalGroupIncludingDiscontinuedOperationIntangibleAssetsNoncurrent, DisposalGroupIncludingDiscontinuedOperationIntangibleAssetsCurrent or DisposalGroupIncludingDiscontinuedOperationIntangibleAssets."
-],
-"DisposalGroupIncludingDiscontinuedOperationInventory": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DisposalGroupIncludingDiscontinuedOperationInventoryCurrent, DisposalGroupIncludingDiscontinuedOperationInventoryNoncurrent or DisposalGroupIncludingDiscontinuedOperationInventory1."
 ],
 "DisposalGroupIncludingDiscontinuedOperationLiabilitiesOfDisposalGroup": [
 "2015-01-31",
@@ -1391,10 +1343,6 @@
 "2015-01-31",
 "Element was deprecated."
 ],
-"DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipmentNet": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipmentNoncurrent, DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipmentCurrent or DisposalGroupIncludingDiscontinuedOperationPropertyPlantAndEquipment."
-],
 "DisposalGroupIncludingDiscontinuedOperationStatusOfDisposalGroupAtLatestBalanceSheetDate": [
 "2015-01-31",
 "Element was deprecated because it was inappropriately modeled. Possible replacement is DisposalGroupIncludingDiscontinuedOperationDescriptionAndTimingOfDisposal."
@@ -1414,6 +1362,14 @@
 "DisposalGroupSpecialTransactionClassificationsAbstract": [
 "2015-01-31",
 "Element was deprecated."
+],
+"DomesticPensionPlansOfForeignEntityDefinedBenefitMember": [
+"2017-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacement is RetirementPlanSponsorLocationAxis and DomesticPlanMember and members of AllCountriesDomain."
+],
+"DomesticPostretirementBenefitPlansOfForeignEntityDefinedBenefitMember": [
+"2017-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacement is RetirementPlanSponsorLocationAxis and DomesticPlanMember and members of AllCountriesDomain."
 ],
 "EITF064Member": [
 "2015-01-31",
@@ -1483,21 +1439,13 @@
 "2016-01-31",
 "Element was deprecated because of low usage."
 ],
-"EnvironmentalCostsOfPropertyForSaleDisposalOrAbandonmentAccruedExitCosts": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is EnvironmentalExitCostsCostsAccruedToDate."
+"EmployeeServiceShareBasedCompensationCashReceivedFromExerciseOfStockOptions": [
+"2017-01-31",
+"Element deprecated due to redundancy. Possible replacement is ProceedsFromStockOptionsExercised."
 ],
-"EnvironmentalCostsOfPropertyForSaleDisposalOrAbandonmentAnticipatedExitCosts": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is EnvironmentalExitCostsAnticipatedCost."
-],
-"EnvironmentalCostsOfPropertyForSaleDisposalOrAbandonmentBalanceSheetCaption": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is EnvironmentalExitCostsCostsAccruedToDate and members of BalanceSheetLocationAxis."
-],
-"EnvironmentalCostsOfPropertyForSaleDisposalOrAbandonmentDisclosures": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is EnvironmentalExitCostsNatureOfCosts."
+"EmployeeServiceShareBasedCompensationTaxBenefitRealizedFromExerciseOfStockOptions": [
+"2017-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
 "EnvironmentalExitCostsReasonablyPossibleAdditionalLossesHighEstimate": [
 "2016-01-31",
@@ -1542,6 +1490,26 @@
 "ExchangeMembershipWithRightsOfOwnershipAndToConductBusinessPolicy": [
 "2016-01-31",
 "Element was deprecated and replaced with a more encompassing element. Possible replacement is ExchangeMembershipsPolicy."
+],
+"ExpectedAmortizationExpenseOfEndingPresentValueOfFutureInsuranceProfitsYearFive": [
+"2017-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsAmortizationExpenseYearFive."
+],
+"ExpectedAmortizationExpenseOfEndingPresentValueOfFutureInsuranceProfitsYearFour": [
+"2017-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsAmortizationExpenseYearFour."
+],
+"ExpectedAmortizationExpenseOfEndingPresentValueOfFutureInsuranceProfitsYearOne": [
+"2017-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsAmortizationExpenseYearOne."
+],
+"ExpectedAmortizationExpenseOfEndingPresentValueOfFutureInsuranceProfitsYearThree": [
+"2017-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsAmortizationExpenseYearThree."
+],
+"ExpectedAmortizationExpenseOfEndingPresentValueOfFutureInsuranceProfitsYearTwo": [
+"2017-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsAmortizationExpenseYearTwo."
 ],
 "ExplanationOfChangeInCumulativeTranslationAdjustment": [
 "2015-01-31",
@@ -1750,10 +1718,6 @@
 "FairValueEstimateNotPracticableReasonsTradingLiabilities": [
 "2015-01-31",
 "Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FairValueNotPracticableReasons and members of FinancialInstrumentAxis."
-],
-"FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareInvestmentRedemptionNoticePeriod": [
-"2014-01-31",
-"Element was deprecated because it has a stringItemType attribute. Possible replacement is FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareInvestmentRedemptionNoticePeriod1."
 ],
 "FairValueInvestmentsEntitiesThatCalculateNetAssetValuePerShareReasonsForMeasurements": [
 "2016-01-31",
@@ -1994,10 +1958,6 @@
 "FederalHomeLoanBankAdvancesMaturitiesSummaryByInterestRateTypeUnderOneYearInterestRateRange": [
 "2016-01-31",
 "Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FederalHomeLoanBankAdvancesMaturitiesSummaryByInterestRateTypeFixedRateUnderOneYear or FederalHomeLoanBankAdvancesMaturitiesSummaryByInterestRateTypeFloatingRateUnderOneYear and members of RangeAxis."
-],
-"FederalHomeLoanBankAdvancesShortTerm": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is FederalHomeLoanBankAdvancesMaturitiesSummaryDueWithinOneYearOfBalanceSheetDate."
 ],
 "FederalHomeLoanBankLeverageRatioActual": [
 "2016-01-31",
@@ -2259,6 +2219,14 @@
 "2015-01-31",
 "Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FinancingReceivableAllowanceForCreditLosses and ReceivablesAcquiredWithDeterioratedCreditQualityMember."
 ],
+"FinancingReceivableNonaccrualPercentPastDue": [
+"2017-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is FinancingReceivableNonaccrualPercentPastDue1."
+],
+"FinancingReceivablePercentPastDue": [
+"2017-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is FinancingReceivablePercentPastDue1."
+],
 "FinancingReceivableRecordedInvestment1To29DaysPastDue": [
 "2015-01-31",
 "Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are FinancingReceivableRecordedInvestmentPastDue and FinancingReceivables1To29DaysPastDueMember."
@@ -2291,34 +2259,6 @@
 "2016-01-31",
 "Element was deprecated because it has a debit balance attribute. Possible replacement is FiniteLivedIntangibleAssetsForeignCurrencyTranslationGainLoss."
 ],
-"FiveYearScheduleOfMaturitiesOfDebtOfParentCompanyAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"FiveYearScheduleOfMaturitiesOfParentCompanyRepaymentOfPrincipleInYearThree": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInYearThree."
-],
-"FiveYearScheduleOfMaturitiesOfParentCompanyRepaymentsOfPrincipalAfterYearFive": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalAfterYearFive."
-],
-"FiveYearScheduleOfMaturitiesOfParentCompanyRepaymentsOfPrincipleInYearFive": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInYearFive."
-],
-"FiveYearScheduleOfMaturitiesOfParentCompanyRepaymentsOfPrincipleInYearFour": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInYearFour."
-],
-"FiveYearScheduleOfMaturitiesOfParentCompanyRepaymentsOfPrincipleInYearTwo": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInYearTwo."
-],
-"FiveYearScheduleOfMaturitiesOfParentCompanyRepaymentsOfPrincipleWithinOneYear": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInNextTwelveMonths."
-],
 "FlightEquipmentOwnedAccumulatedDepreciation": [
 "2016-01-31",
 "Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AccumulatedDepreciationDepletionAndAmortizationPropertyPlantAndEquipment and members of PropertyPlantAndEquipmentByTypeAxis."
@@ -2335,21 +2275,13 @@
 "2016-01-31",
 "Element was deprecated."
 ],
-"ForeignCurrencyDerivativeAssetsAtFairValue": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeFairValueOfDerivativeAsset and ForeignExchangeContractMember."
+"ForeignPensionPlansDefinedBenefitMember": [
+"2017-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacement is RetirementPlanSponsorLocationAxis and ForeignPlanMember and members of AllCountriesDomain."
 ],
-"ForeignCurrencyDerivativeLiabilitiesAtFairValue": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeFairValueOfDerivativeLiability and ForeignExchangeContractMember."
-],
-"ForeignCurrencyDerivativesAtFairValueNet": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is DerivativeFairValueOfDerivativeNet and ForeignExchangeContractMember."
-],
-"ForeignCurrencyDerivativesAtFairValueNetAbstract": [
-"2014-01-31",
-"Element was deprecated."
+"ForeignPostretirementBenefitPlansDefinedBenefitMember": [
+"2017-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacement is RetirementPlanSponsorLocationAxis and ForeignPlanMember and members of AllCountriesDomain."
 ],
 "FractionationRevenue": [
 "2016-01-31",
@@ -2362,10 +2294,6 @@
 "GainContingencyIncomeStatementCaption": [
 "2016-01-31",
 "Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is FormerGainContingencyRecognizedInCurrentPeriod and members of IncomeStatementLocationAxis."
-],
-"GainLossFromSaleOfFinancialAssetsInSecuritizationsOrAssetBackedFinancingArrangement": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is SecuritizationFinancialAssetForWhichTransferIsAccountedAsSaleGainLossOnSale."
 ],
 "GasPurchaseContractNet": [
 "2016-01-31",
@@ -2430,14 +2358,6 @@
 "GuaranteedInvestmentContractInterestRateAssumptionsLowEnd": [
 "2016-01-31",
 "Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LiabilityForPolicyholderContractDepositsInterestRate and members of ProductOrServiceAxis and RangeAxis with MinimumMember."
-],
-"HealthCareOrganizationAmountOfWriteOffsOfAllowanceForDoubtfulAccounts": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is AllowanceForDoubtfulAccountsReceivableWriteOffs."
-],
-"HealthCareOrganizationChangeInWriteOffs": [
-"2014-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacement is AllowanceForDoubtfulAccountsReceivableWriteOffs."
 ],
 "HealthCareOrganizationLossContractsExpense": [
 "2016-01-31",
@@ -2527,6 +2447,10 @@
 "2015-01-31",
 "Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is ImpairmentOfLongLivedAssetsHeldForUse and members of StatementBusinessSegmentsAxis and SubsegmentsAxis."
 ],
+"InclusionOfInvestmentIncomeInAssessmentOfPremiumDeficiencyOnShortDurationContracts": [
+"2017-01-31",
+"Element was deprecated because of low usage. Possible replacement is AnticipatedInvestmentIncomeAsComponentOfPremiumDeficiencyOnShortDurationContractsPolicy."
+],
 "IncomeDepositSecuritiesAbstract": [
 "2015-01-31",
 "Element was deprecated."
@@ -2591,9 +2515,9 @@
 "2016-01-31",
 "Element was deprecated because of low usage."
 ],
-"IncreaseDecreaseInBorrowedSecurities": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is IncreaseDecreaseInSecuritiesBorrowed."
+"IncreaseDecreaseInDeferredPensionCosts": [
+"2017-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
 "IncreaseDecreaseInFinancialGuaranteeInsuranceContractLiabilities": [
 "2016-01-31",
@@ -2611,9 +2535,21 @@
 "2015-01-31",
 "Element was deprecated because of low usage."
 ],
+"IncreaseDecreaseInPrepaidPensionCosts": [
+"2017-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
 "IncreaseDecreaseInPrincipalPaymentsOnContractReceivables": [
 "2016-01-31",
 "Element was deprecated because of low usage."
+],
+"IncreaseDecreaseInRestrictedCashAbstract": [
+"2017-01-31",
+"Element was deprecated."
+],
+"IncreaseDecreaseInRestrictedCashAndInvestmentsAbstract": [
+"2017-01-31",
+"Element was deprecated."
 ],
 "IncreaseDecreaseInRetainedInterestInSecuritizedReceivables": [
 "2015-01-31",
@@ -2626,6 +2562,66 @@
 "IncreaseDecreaseInTimeDepositsForeign": [
 "2015-01-31",
 "Element was deprecated because of low usage."
+],
+"IncrementalEffectOnBalanceSheetApplicationOfSFAS158RecognitionProvisionsLineItems": [
+"2017-01-31",
+"Element was deprecated."
+],
+"IncrementalEffectOnBalanceSheetAssetLineItemBalanceApplicationOfSFAS158RecognitionProvisions": [
+"2017-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"IncrementalEffectOnBalanceSheetAssetLineItemBalanceBeforeAdditionalMinimumPensionLiabilityAMLAdjustmentAndApplicationOfSFAS158RecognitionProvisions": [
+"2017-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"IncrementalEffectOnBalanceSheetAssetLineItemChangeDueToAdditionalMinimumPensionLiabilityAMLAdjustmentPeriodIncreaseDecrease": [
+"2017-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"IncrementalEffectOnBalanceSheetAssetLineItemChangeDueToApplicationOfSFAS158RecognitionProvisionsPeriodIncreaseDecrease": [
+"2017-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"IncrementalEffectOnBalanceSheetChangeDueToApplicationOfSFAS158RecognitionProvisionsAbstract": [
+"2017-01-31",
+"Element was deprecated."
+],
+"IncrementalEffectOnBalanceSheetChangeInAssetLineItemDueToApplicationOfSFAS158RecognitionProvisionsRollForward": [
+"2017-01-31",
+"Element was deprecated."
+],
+"IncrementalEffectOnBalanceSheetChangeInLiabilityOrEquityLineItemDueToApplicationOfSFAS158RecognitionProvisionsRollForward": [
+"2017-01-31",
+"Element was deprecated."
+],
+"IncrementalEffectOnBalanceSheetChangesDueToAdditionalMinimumPensionLiabilityAMLAdjustmentAndApplicationOfSFAS158RecognitionProvisionsAlternativePresentationAbstract": [
+"2017-01-31",
+"Element was deprecated."
+],
+"IncrementalEffectOnBalanceSheetChangesInAssetLineItemDueToAdditionalMinimumPensionLiabilityAMLAdjustmentAndApplicationOfSFAS158RecognitionProvisionsRollForward": [
+"2017-01-31",
+"Element was deprecated."
+],
+"IncrementalEffectOnBalanceSheetChangesInLiabilityOrEquityLineItemDueToAMLAdjustmentAndApplicationOfSFAS158RecognitionProvisionsRollForward": [
+"2017-01-31",
+"Element was deprecated."
+],
+"IncrementalEffectOnBalanceSheetLiabilityOrEquityLineItemBalanceApplicationOfSFAS158RecognitionProvisions": [
+"2017-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"IncrementalEffectOnBalanceSheetLiabilityOrEquityLineItemBalanceBeforeAMLAdjustmentAndApplicationOfSFAS158RecognitionProvisions": [
+"2017-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"IncrementalEffectOnBalanceSheetLiabilityOrEquityLineItemChangeDueToAdditionalMinimumPensionLiabilityAMLAdjustmentPeriodIncreaseDecrease": [
+"2017-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"IncrementalEffectOnBalanceSheetLiabilityOrEquityLineItemChangeDueToApplicationOfSFAS158RecognitionProvisionsPeriodIncreaseDecrease": [
+"2017-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
 "IndefiniteLivedIntangibleAssetsTranslationAdjustments": [
 "2016-01-31",
@@ -2643,37 +2639,169 @@
 "2016-01-31",
 "Element was deprecated because it represents multiple distinct concepts. Possible replacements are BalanceSheetLocationAxis, IncomeStatementLocationAxis or OtherComprehensiveIncomeLocationAxis."
 ],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombination": [
+"2017-01-31",
+"Element deprecated due to redundancy. Possible replacement is ValueOfBusinessAcquiredVOBA."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationAbstract": [
+"2017-01-31",
+"Element was deprecated."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationAdditions": [
+"2017-01-31",
+"Element deprecated due to redundancy. Possible replacement is PresentValueOfFutureInsuranceProfitsAdditionsFromAcquisitions."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationAmortizationExpenseNextRollingTwelveMonths": [
+"2017-01-31",
+"Element was deprecated because of low usage."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationAmortizationExpenseNextTwelveMonths": [
+"2017-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is PresentValueOfFutureInsuranceProfitsAmortizationExpenseYearOne."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationAmortizationExpenseRemainderOfFiscalYear": [
+"2017-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is PresentValueOfFutureInsuranceProfitsAmortizationExpenseRemainderOfFiscalYear."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationAmortizationExpenseRollingMaturityAbstract": [
+"2017-01-31",
+"Element was deprecated."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationAmortizationExpenseRollingYearFive": [
+"2017-01-31",
+"Element was deprecated because of low usage."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationAmortizationExpenseRollingYearFour": [
+"2017-01-31",
+"Element was deprecated because of low usage."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationAmortizationExpenseRollingYearThree": [
+"2017-01-31",
+"Element was deprecated because of low usage."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationAmortizationExpenseRollingYearTwo": [
+"2017-01-31",
+"Element was deprecated because of low usage."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationAmortizationExpenseYearFive": [
+"2017-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is PresentValueOfFutureInsuranceProfitsAmortizationExpenseYearFive."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationAmortizationExpenseYearFour": [
+"2017-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is PresentValueOfFutureInsuranceProfitsAmortizationExpenseYearFour."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationAmortizationExpenseYearThree": [
+"2017-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is PresentValueOfFutureInsuranceProfitsAmortizationExpenseYearThree."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationAmortizationExpenseYearTwo": [
+"2017-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is PresentValueOfFutureInsuranceProfitsAmortizationExpenseYearTwo."
+],
 "IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationDecreases": [
 "2016-01-31",
 "Element was deprecated because of low usage."
 ],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationDecreasesAbstract": [
+"2017-01-31",
+"Element was deprecated."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationDisclosuresTextBlock": [
+"2017-01-31",
+"Element deprecated due to redundancy. Possible replacement is PresentValueOfFutureInsuranceProfitsTextBlock."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationDispositions": [
+"2017-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is PresentValueOfFutureInsuranceProfitsDisposition."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationEstimatedAmountAmortizedDuringNextFiveYearsAbstract": [
+"2017-01-31",
+"Element was deprecated."
+],
 "IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationImpairmentWritedown": [
 "2016-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationImpairmentWritedown1."
+"Element was deprecated because it has a credit balance attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsImpairmentWritedown1."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationImpairmentWritedown1": [
+"2017-01-31",
+"Element deprecated due to redundancy. Possible replacement is PresentValueOfFutureInsuranceProfitsImpairmentWritedown1."
 ],
 "IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationIncreases": [
 "2016-01-31",
 "Element was deprecated because of low usage."
 ],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationIncreasesAbstract": [
+"2017-01-31",
+"Element was deprecated."
+],
 "IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationInterestAccrued": [
 "2016-01-31",
 "Element was deprecated because of low usage."
 ],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationPercentageOfAmountAmortizedDuringNextFiveYearsAbstract": [
+"2017-01-31",
+"Element was deprecated."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationPercentageOfAmountAmortizedYearFive": [
+"2017-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is PresentValueOfFutureInsuranceProfitsPercentageOfAmortizationExpenseYearFive."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationPercentageOfAmountAmortizedYearFour": [
+"2017-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is PresentValueOfFutureInsuranceProfitsPercentageOfAmortizationExpenseYearFour."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationPercentageOfAmountAmortizedYearOne": [
+"2017-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is PresentValueOfFutureInsuranceProfitsPercentageOfAmortizationExpenseYearOne."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationPercentageOfAmountAmortizedYearThree": [
+"2017-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is PresentValueOfFutureInsuranceProfitsPercentageOfAmortizationExpenseYearThree."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationPercentageOfAmountAmortizedYearTwo": [
+"2017-01-31",
+"Element was deprecated because it was inappropriately modeled. Possible replacement is PresentValueOfFutureInsuranceProfitsPercentageOfAmortizationExpenseYearTwo."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationPeriodIncreaseDecrease": [
+"2017-01-31",
+"Element deprecated due to redundancy. Possible replacement is PresentValueOfFutureInsuranceProfitsPeriodIncreaseDecrease."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationTableTextBlock": [
+"2017-01-31",
+"Element deprecated due to redundancy. Possible replacement is PresentValueOfFutureInsuranceProfitsTableTextBlock."
+],
 "IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationUnrealizedInvestmentGains": [
 "2016-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationUnrealizedInvestmentGains1."
+"Element was deprecated because it has a debit balance attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsUnrealizedInvestmentGains1."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationUnrealizedInvestmentGains1": [
+"2017-01-31",
+"Element deprecated due to redundancy. Possible replacement is PresentValueOfFutureInsuranceProfitsUnrealizedInvestmentGains1."
 ],
 "IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationUnrealizedInvestmentLosses": [
 "2016-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationUnrealizedInvestmentLosses1."
+"Element was deprecated because it has a credit balance attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsUnrealizedInvestmentLosses1."
+],
+"IntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationUnrealizedInvestmentLosses1": [
+"2017-01-31",
+"Element deprecated due to redundancy. Possible replacement is PresentValueOfFutureInsuranceProfitsUnrealizedInvestmentLosses1."
 ],
 "IntangiblesAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationAmortizationExpense": [
 "2016-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is IntangiblesAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationAmortizationExpense1."
+"Element was deprecated because it has a credit balance attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsAmortizationExpense1."
+],
+"IntangiblesAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationAmortizationExpense1": [
+"2017-01-31",
+"Element deprecated due to redundancy. Possible replacement is PresentValueOfFutureInsuranceProfitsAmortizationExpense1."
 ],
 "IntercompanyForeignCurrencyBalanceForeignCurrency": [
 "2015-01-31",
 "Element was deprecated because of low usage."
+],
+"InterestCreditedToPolicyOwnerAccounts": [
+"2017-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is InterestCreditedToPolicyOwnerAccount."
 ],
 "InterestExpenseForeignDepositLiabilities": [
 "2016-01-31",
@@ -2787,9 +2915,17 @@
 "2015-01-31",
 "Element was deprecated because of low usage."
 ],
+"JapaneseWelfarePensionInsuranceLawGeneralDescription": [
+"2017-01-31",
+"Element was deprecated because of low usage."
+],
 "LateFeeIncomeGeneratedByServicingFinancialAssetsDescriptionOfWhereReportedOnStatementOfIncome": [
 "2015-01-31",
 "Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LateFeeIncomeGeneratedByServicingFinancialAssetsAmount and members of IncomeStatementLocationAxis."
+],
+"LeasePolicyTextBlock": [
+"2017-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacement is LessorLeasesPolicyTextBlock or LesseeLeasesPolicyTextBlock."
 ],
 "LiabilitiesForGuaranteesOnLongDurationContractsBenefitsPaid": [
 "2016-01-31",
@@ -2806,10 +2942,6 @@
 "LiabilitiesForGuaranteesOnLongDurationContractsGuaranteedBenefitType": [
 "2015-01-31",
 "Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are the children of LiabilitiesForGuaranteesOnLongDurationContractsLineItems and members of GuaranteedInsuranceContractTypeOfBenefitAxis."
-],
-"LiabilitiesOfAssetsHeldForSale": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilitiesOfDisposalGroupIncludingDiscontinuedOperation."
 ],
 "LiabilitiesSubjectToCompromiseAircraftObligationsAndDeferredGains": [
 "2016-01-31",
@@ -2971,101 +3103,9 @@
 "2016-01-31",
 "Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LiabilityForPolicyholderContractDepositsInterestRate and members of ProductOrServiceAxis and RangeAxis with MinimumMember."
 ],
-"LiabilityForTitleClaimsAndClaimsAdjustmentExpenseAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"LiabilityForTitleClaimsAndClaimsAdjustmentExpenseIncurredButNotReportedIBNR": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseIncurredButNotReportedIBNRClaimsAmount and members of ProductOrServiceAxis."
-],
-"LiabilityForTitleClaimsAndClaimsAdjustmentExpenseKnownClaims": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseReportedClaimsAmount and members of ProductOrServiceAxis."
-],
-"LiabilityForUnpaidClaimsAdjustmentExpenseByExpenseTypeTextBlock": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ScheduleOfLiabilityForUnpaidClaimsAndClaimsAdjustmentExpense."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAdjustmentOfOpeningBalanceAmount": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseOpeningBalanceAdjustments."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAdjustmentOfOpeningBalanceAxis": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacements are AdjustmentsForChangeInAccountingPrincipleAxis and ErrorCorrectionsAndPriorPeriodAdjustmentsRestatementByRestatementPeriodAndAmountAxis."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAdjustmentOfOpeningBalanceLineItems": [
-"2014-01-31",
-"Element was deprecated."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAdjustmentOfOpeningBalanceTable": [
-"2014-01-31",
-"Element was deprecated due to remodeling of topic area."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseAdjustmentOfOpeningBalanceTypeDomain": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacements are ChangeInAccountingPrincipleMember and AdjustmentsForErrorCorrectionDomain."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseClaimsPaid": [
-"2014-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is PaymentsForLossesAndLossAdjustmentExpense."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseClaimsPaidCurrentYear": [
-"2014-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseClaimsPaidCurrentYear1."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseClaimsPaidPriorYears": [
-"2014-01-31",
-"Element was deprecated because it has a debit balance attribute. Possible replacement is LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseClaimsPaidPriorYears1."
-],
 "LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseForeignExchange": [
 "2016-01-31",
 "Element was deprecated because it was inappropriately modeled. Possible replacement is LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseForeignCurrencyTranslationGainLoss."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseGross": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilityForClaimsAndClaimsAdjustmentExpense."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseIncurredButNotReportedIBNRClaimsCommentary": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilityForClaimsAndClaimsAdjustmentExpenseMethodologiesAndAssumptions."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseIncurredClaims": [
-"2014-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseIncurredClaims1."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseIncurredClaimsCurrentYear": [
-"2014-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is SupplementalInformationForPropertyCasualtyInsuranceUnderwritersCurrentYearClaimsAndClaimsAdjustmentExpense."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseIncurredClaimsPriorYears": [
-"2014-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is SupplementalInformationForPropertyCasualtyInsuranceUnderwritersPriorYearClaimsAndClaimsAdjustmentExpense."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseReportedAndIncurredButNotReportedIBNRClaims": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilityForClaimsAndClaimsAdjustmentExpense."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseReportedAndIncurredButNotReportedIBNRClaimsAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseReportedAndIncurredButNotReportedIBNRClaimsCommentary": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilityForClaimsAndClaimsAdjustmentExpenseMethodologiesAndAssumptions."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseReportedAndIncurredButNotReportedIBNRClaimsDisclosureAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"LiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseReportedClaimsCommentary": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LiabilityForClaimsAndClaimsAdjustmentExpenseMethodologiesAndAssumptions."
-],
-"LifeInsuranceInForcePremiumsPercentageAssumedToNet": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is LifeInsuranceInForcePercentageAssumedToNet."
 ],
 "LimitedLiabilityCompanyLLCOrLimitedPartnershipLPAssetsAndLiabilitiesPreviouslyHeldByPredecessorEntityIesToBusinessCombination": [
 "2015-01-31",
@@ -3099,10 +3139,6 @@
 "2015-01-31",
 "Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is UnrealizedGainLossOnHybridInstrumentNet and members of IncomeStatementLocationAxis."
 ],
-"LineOfCreditFacilityAmountOutstanding": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LineofCredit."
-],
 "LineOfCreditFacilityRevolvingCreditConversionToTermLoanStatus": [
 "2016-01-31",
 "Element was deprecated because of low usage."
@@ -3127,13 +3163,17 @@
 "2015-01-31",
 "Element was deprecated due to issuance of new guidance."
 ],
+"LitigationSettlementAmount": [
+"2017-01-31",
+"Element was deprecated because it represents multiple distinct concepts. Possible replacement is LitigationSettlementAmountAwardedFromOtherParty or LitigationSettlementAmountAwardedToOtherParty."
+],
 "LoansAndLeasesReceivableAllowanceAbstract": [
 "2016-01-31",
 "Element was deprecated."
 ],
 "LoansAndLeasesReceivableCommercial": [
 "2016-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LoansAndLeasesReceivableBeforeFeesGross and CommercialPortfolioSegmentMember."
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LoansAndLeasesReceivableGrossCarryingAmount and CommercialPortfolioSegmentMember."
 ],
 "LoansAndLeasesReceivableCommercialAbstract": [
 "2016-01-31",
@@ -3161,7 +3201,7 @@
 ],
 "LoansAndLeasesReceivableConsumer": [
 "2016-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LoansAndLeasesReceivableBeforeFeesGross and ConsumerPortfolioSegmentMember."
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LoansAndLeasesReceivableGrossCarryingAmount and ConsumerPortfolioSegmentMember."
 ],
 "LoansAndLeasesReceivableConsumerAbstract": [
 "2016-01-31",
@@ -3209,7 +3249,7 @@
 ],
 "LoansAndLeasesReceivableForeign": [
 "2016-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LoansAndLeasesReceivableBeforeFeesGross and GeographicDistributionForeignMember."
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LoansAndLeasesReceivableGrossCarryingAmount and GeographicDistributionForeignMember."
 ],
 "LoansAndLeasesReceivableForeignAbstract": [
 "2016-01-31",
@@ -3221,19 +3261,19 @@
 ],
 "LoansAndLeasesReceivableForeignCommercial": [
 "2016-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LoansAndLeasesReceivableBeforeFeesGross, GeographicDistributionForeignMember and CommercialPortfolioSegmentMember."
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LoansAndLeasesReceivableGrossCarryingAmount, GeographicDistributionForeignMember and CommercialPortfolioSegmentMember."
 ],
 "LoansAndLeasesReceivableForeignCommercialAndConsumerOther": [
 "2016-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LoansAndLeasesReceivableBeforeFeesGross, GeographicDistributionForeignMember, and members of FinancingReceivablePortfolioSegmentAxis, FinancingReceivableRecordedInvestmentByClassOfFinancingReceivableAxis, CollateralAxis, ClassOfFinancingReceivableTypeOfBorrowerAxis, and EquitySecuritiesByIndustryAxis."
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LoansAndLeasesReceivableGrossCarryingAmount, GeographicDistributionForeignMember, and members of FinancingReceivablePortfolioSegmentAxis, FinancingReceivableRecordedInvestmentByClassOfFinancingReceivableAxis, CollateralAxis, ClassOfFinancingReceivableTypeOfBorrowerAxis, and EquitySecuritiesByIndustryAxis."
 ],
 "LoansAndLeasesReceivableForeignCommercialAndConsumerRealEstate": [
 "2016-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LoansAndLeasesReceivableBeforeFeesGross, GeographicDistributionForeignMember, and members of FinancingReceivablePortfolioSegmentAxis and FinancingReceivableRecordedInvestmentByClassOfFinancingReceivableAxis."
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LoansAndLeasesReceivableGrossCarryingAmount, GeographicDistributionForeignMember, and members of FinancingReceivablePortfolioSegmentAxis and FinancingReceivableRecordedInvestmentByClassOfFinancingReceivableAxis."
 ],
 "LoansAndLeasesReceivableForeignConsumerInstallmentAndRevolving": [
 "2016-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LoansAndLeasesReceivableBeforeFeesGross, GeographicDistributionForeignMember, and members of FinancingReceivablePortfolioSegmentAxis and FinancingReceivableRecordedInvestmentByClassOfFinancingReceivableAxis."
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LoansAndLeasesReceivableGrossCarryingAmount, GeographicDistributionForeignMember, and members of FinancingReceivablePortfolioSegmentAxis and FinancingReceivableRecordedInvestmentByClassOfFinancingReceivableAxis."
 ],
 "LoansAndLeasesReceivableForeignDescription": [
 "2015-01-31",
@@ -3241,15 +3281,15 @@
 ],
 "LoansAndLeasesReceivableForeignFinancialInstitutions": [
 "2016-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LoansAndLeasesReceivableBeforeFeesGross, GeographicDistributionForeignMember and FinancialInstitutionsBorrowerMember."
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LoansAndLeasesReceivableGrossCarryingAmount, GeographicDistributionForeignMember and FinancialInstitutionsBorrowerMember."
 ],
 "LoansAndLeasesReceivableForeignGovernments": [
 "2016-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LoansAndLeasesReceivableBeforeFeesGross, GeographicDistributionForeignMember and MunicipalitiesBorrowerMember."
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LoansAndLeasesReceivableGrossCarryingAmount, GeographicDistributionForeignMember and MunicipalitiesBorrowerMember."
 ],
 "LoansAndLeasesReceivableForeignLeaseFinancing": [
 "2016-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LoansAndLeasesReceivableBeforeFeesGross, GeographicDistributionForeignMember and LeaseAgreementsMember."
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LoansAndLeasesReceivableGrossCarryingAmount, GeographicDistributionForeignMember and LeaseAgreementsMember."
 ],
 "LoansAndLeasesReceivableForeignLoansInProcess": [
 "2016-01-31",
@@ -3349,7 +3389,7 @@
 ],
 "LoansAndLeasesReceivableOther": [
 "2016-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LoansAndLeasesReceivableBeforeFeesGross and members of FinancingReceivablePortfolioSegmentAxis, FinancingReceivableRecordedInvestmentByClassOfFinancingReceivableAxis, CollateralAxis, GeographicDistributionAxis, ClassOfFinancingReceivableTypeOfBorrowerAxis, and EquitySecuritiesByIndustryAxis."
+"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is LoansAndLeasesReceivableGrossCarryingAmount and members of FinancingReceivablePortfolioSegmentAxis, FinancingReceivableRecordedInvestmentByClassOfFinancingReceivableAxis, CollateralAxis, GeographicDistributionAxis, ClassOfFinancingReceivableTypeOfBorrowerAxis, and EquitySecuritiesByIndustryAxis."
 ],
 "LoansAndLeasesReceivableOtherAllowance": [
 "2016-01-31",
@@ -3479,45 +3519,9 @@
 "2015-01-31",
 "Element deprecated due to redundancy. Possible replacement is DisposalGroupIncludingDiscontinuedOperationDescriptionAndTimingOfDisposal."
 ],
-"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInNextRollingTwelveMonths": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInNextRollingTwelveMonths."
-],
-"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInRemainderOfFiscalYear": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalRemainderOfFiscalYear."
-],
-"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInRollingAfterYearFive": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInRollingAfterYearFive."
-],
-"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInRollingYearFive": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInRollingYearFive."
-],
-"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInRollingYearFour": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInRollingYearFour."
-],
-"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInRollingYearThree": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInRollingYearThree."
-],
-"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalInRollingYearTwo": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is LongTermDebtMaturitiesRepaymentsOfPrincipalInRollingYearTwo."
-],
-"LongTermDebtOfRegistrantMaturitiesRepaymentsOfPrincipalRollingMaturityAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
 "LongTermPurchaseCommitmentPotentialAdverseConsequences": [
 "2015-01-31",
 "Element was deprecated because of low usage."
-],
-"LongTermPurchaseCommitmentTimePeriod": [
-"2014-01-31",
-"Element was deprecated because it has a stringItemType attribute. Possible replacement is LongtermPurchaseCommitmentPeriod."
 ],
 "LongtermDebtExcludingCurrentMaturitiesAbstract": [
 "2016-01-31",
@@ -3575,10 +3579,6 @@
 "2015-01-31",
 "Element was deprecated because of low usage."
 ],
-"MalpracticeLossContingencyAccrualAdjustment": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
 "MalpracticeLossContingencyAccrualNotRecognizedEstimateOfPossibleLoss": [
 "2016-01-31",
 "Element was deprecated because it has a credit balance attribute. Possible replacement is LossContingencyEstimateOfPossibleLoss."
@@ -3635,21 +3635,9 @@
 "2015-01-31",
 "Element was deprecated."
 ],
-"MaterialEffectOnLiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseFromChangeInAccountingPrincipleMember": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are members of AdjustmentsForChangeInAccountingPrincipleAxis."
-],
-"MaterialErrorInLiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseMember": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are members of ErrorCorrectionsAndPriorPeriodAdjustmentsRestatementByRestatementPeriodAndAmountAxis."
-],
 "MileageCreditPrice": [
 "2015-01-31",
 "Element was deprecated because of low usage."
-],
-"MinorRestatementOfOpeningLiabilityForUnpaidClaimsAndClaimsAdjustmentExpenseSAB108Member": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are members of ErrorCorrectionsAndPriorPeriodAdjustmentsRestatementByRestatementPeriodAndAmountAxis."
 ],
 "MinorityInterestPreferredStockAmount": [
 "2016-01-31",
@@ -3679,6 +3667,30 @@
 "2016-01-31",
 "Element was deprecated because of low usage."
 ],
+"MovementInIntangibleAssetsArisingFromInsuranceContractsAcquiredInBusinessCombinationRollForward": [
+"2017-01-31",
+"Element was deprecated."
+],
+"MultiemployerPlanPeriodContributions": [
+"2017-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is MultiemployerPlanContributionsByEmployer."
+],
+"MultiemployerPlansCollectiveBargainingArrangementPercentageOfContributions": [
+"2017-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is MultiemployerPlanCollectiveBargainingArrangementPercentageOfContributionsRequiredForMultipleCollectiveBargainingArrangements."
+],
+"MultiemployerPlansCollectiveBargainingArrangementPercentageOfEmployersContributions": [
+"2017-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is MultiemployerPlanCollectiveBargainingArrangementRequiredPercentageOfContributions."
+],
+"MultiemployerPlansContributionRateIncreaseDecrease": [
+"2017-01-31",
+"Element was deprecated because it has a pureItemType attribute. Possible replacement is MultiemployerPlanContributionRateIncreaseDecrease."
+],
+"MultiemployerPlansPlanContributions": [
+"2017-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is MultiemployerPlansPlanContributions1."
+],
 "NationalCreditUnionShareInsuranceFundNCUSIFDeposit": [
 "2016-01-31",
 "Element was deprecated because of low usage."
@@ -3686,6 +3698,10 @@
 "NaturalGasMidstreamRevenueAbstract": [
 "2016-01-31",
 "Element was deprecated."
+],
+"NatureOfPresentValueOfFutureInsuranceProfits": [
+"2017-01-31",
+"Element was deprecated because of low usage."
 ],
 "NetAmountAtRiskByProductAndGuaranteeGuaranteeTypeAxis": [
 "2015-01-31",
@@ -3715,10 +3731,6 @@
 "2015-01-31",
 "Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacements are the children of NetAmountAtRiskByProductAndGuaranteeLineItems and members of GuaranteedInsuranceContractTypeOfGuaranteeAxis."
 ],
-"NettingAndCollateralMember": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept is no longer conveyed dimensionally. Possible replacements are DerivativeAssetFairValueGrossLiability, DerivativeAssetCollateralObligationToReturnCashOffset, DerivativeAssetFairValueGrossLiabilityAndObligationToReturnCashOffset, SecuritiesPurchasedUnderAgreementsToResellLiability, SecuritiesBorrowedLiability, DerivativeAssetSecuritiesPurchasedUnderAgreementsToResellSecuritiesBorrowedLiability, DerivativeLiabilityFairValueGrossAsset, DerivativeLiabilityCollateralRightToReclaimCashOffset, DerivativeLiabilityFairValueGrossAssetAndRightToReclaimCashOffset, SecuritiesSoldUnderAgreementsToRepurchaseAsset, SecuritiesLoanedAsset, or DerivativeLiabilitySecuritiesSoldUnderAgreementsToResellSecuritiesLoanedAsset."
-],
 "NewAccountingPronouncementOrChangeInAccountingPrincipleCurrentPeriodDisclosuresAbstract": [
 "2016-01-31",
 "Element was deprecated."
@@ -3742,10 +3754,6 @@
 "NewAccountingPronouncementOrChangeInAccountingPrincipleName": [
 "2016-01-31",
 "Element was deprecated because it was inappropriately modeled. Possible replacements are members of AdjustmentsForNewAccountingPronouncementsAxis or AdjustmentsForChangeInAccountingPrincipleAxis."
-],
-"NewAccountingPronouncementOrChangeInAccountingPrincipleProFormaDisclosuresRevenueRecognizedAmount": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
 "NoncashCommissionAndClosingCosts": [
 "2016-01-31",
@@ -3778,18 +3786,6 @@
 "OpenOptionContractsWrittenTextBlock": [
 "2016-01-31",
 "Element deprecated due to redundancy. Possible replacement is OpenOptionContractsWrittenScheduleOfInvestmentsTextBlock."
-],
-"OptionIndexedToIssuersEquityStrikePrice": [
-"2014-01-31",
-"Element was deprecated because it has a perUnitItemType attribute. Possible replacement is OptionIndexedToIssuersEquityStrikePrice1."
-],
-"OtherAssetsHeldForSale": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DisposalGroupIncludingDiscontinuedOperationOtherAsset or AssetsHeldForSaleNotPartOfDisposalGroupOther."
-],
-"OtherAssetsHeldForSaleCurrent": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are DisposalGroupIncludingDiscontinuedOperationOtherCurrentAssets or AssetsHeldForSaleNotPartOfDisposalGroupCurrentOther."
 ],
 "OtherComprehensiveIncomeCumulativeEffectOfChangeInAccountingPrincipleBeforeTaxes": [
 "2016-01-31",
@@ -3855,17 +3851,13 @@
 "2015-01-31",
 "Element deprecated due to redundancy. Possible replacement is ParticipatingMortgageLoansAppreciationInMarketValue."
 ],
-"ParticipatingSecuritiesDistributedAndUndistributedEarnings": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are ParticipatingSecuritiesDistributedAndUndistributedEarningsLossBasic or ParticipatingSecuritiesDistributedAndUndistributedEarningsLossDiluted."
+"ParticipatingSecuritiesDistributedAndUndistributedEarningsAbstract": [
+"2017-01-31",
+"Element was deprecated."
 ],
-"PartiesToContractualArrangementAxis": [
-"2014-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacement is LeaseArrangementTypeAxis."
-],
-"PartiesToContractualArrangementMember": [
-"2014-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacement is LeaseArrangementTypeDomain."
+"ParticipatingSecuritiesDistributedAndUndistributedEarningsLossDilutedAbstract": [
+"2017-01-31",
+"Element was deprecated."
 ],
 "PartnersCapitalAccountDescriptionOfUnitsRedeemed": [
 "2016-01-31",
@@ -3915,9 +3907,33 @@
 "2015-01-31",
 "Element was deprecated because of low usage."
 ],
+"PercentageOfAmountAmortizedOfEndingPresentValueOfFutureInsuranceProfitsYearFive": [
+"2017-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsPercentageOfAmortizationExpenseYearFive."
+],
+"PercentageOfAmountAmortizedOfEndingPresentValueOfFutureInsuranceProfitsYearFour": [
+"2017-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsPercentageOfAmortizationExpenseYearFour."
+],
+"PercentageOfAmountAmortizedOfEndingPresentValueOfFutureInsuranceProfitsYearOne": [
+"2017-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsPercentageOfAmortizationExpenseYearOne."
+],
+"PercentageOfAmountAmortizedOfEndingPresentValueOfFutureInsuranceProfitsYearThree": [
+"2017-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsPercentageOfAmortizationExpenseYearThree."
+],
+"PercentageOfAmountAmortizedOfEndingPresentValueOfFutureInsuranceProfitsYearTwo": [
+"2017-01-31",
+"Element was deprecated because it has a duration period type attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsPercentageOfAmortizationExpenseYearTwo."
+],
 "PercentageOfInterestBearingDomesticDepositLiabilitiesToDepositLiabilitiesDescription": [
 "2015-01-31",
 "Element was deprecated because of low usage."
+],
+"PercentageOfParticipatingPoliciesDisclosure": [
+"2017-01-31",
+"Element was deprecated because it was inappropriately modeled."
 ],
 "PhysicalUnitOfProduction": [
 "2016-01-31",
@@ -3935,13 +3951,9 @@
 "2016-01-31",
 "Element was deprecated because of low usage."
 ],
-"PremiumsNetLifeInsuranceInForce": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is LifeInsuranceInForceNet."
-],
-"PremiumsNetLifeInsuranceInForceAbstract": [
-"2014-01-31",
-"Element was deprecated."
+"PostretirementMedicalPlansWithPrescriptionDrugBenefitsDescriptionOfOtherSignificantChange": [
+"2017-01-31",
+"Element was deprecated and replaced with a more encompassing element. Possible replacement is DefinedBenefitPlanExplanationOfSignificantChangeInBenefitObligationOrPlanAssetsNotApparentFromOtherRequiredDisclosures."
 ],
 "PremiumsReceivableAllowanceForDoubtfulAccountsProvisionChargedToExpense1": [
 "2016-01-31",
@@ -3951,13 +3963,53 @@
 "2015-01-31",
 "Element was deprecated because of low usage."
 ],
+"PrepaidPensionCosts": [
+"2017-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
 "PreproductionCostsRelatedToLongTermSupplyArrangementsDisclosures": [
 "2016-01-31",
 "Element was deprecated and replaced with a more encompassing element. Possible replacement is PropertyPlantAndEquipmentPreproductionDesignAndDevelopmentCosts."
 ],
-"PresentValueOfFutureInsuranceProfits": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is ValueOfBusinessAcquiredVOBA."
+"PrescriptionDrugBenefitReductionInAccumulatedPostretirementBenefitObligationForSubsidy": [
+"2017-01-31",
+"Element was deprecated because it has an instant period type attribute. Possible replacement is DefinedBenefitPlanPrescriptionDrugBenefitAccumulatedPostretirementBenefitObligationDecreaseForSubsidy."
+],
+"PrescriptionDrugSubsidyReceiptsNextRollingTwelveMonths": [
+"2017-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacement is PrescriptionDrugSubsidyReceiptsNextTwelveMonths."
+],
+"PrescriptionDrugSubsidyReceiptsRemainderOfFiscalYear": [
+"2017-01-31",
+"Element was deprecated because of low usage."
+],
+"PrescriptionDrugSubsidyReceiptsRollingAfterYearFive": [
+"2017-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacement is PrescriptionDrugSubsidyReceiptsAfterYearFive."
+],
+"PrescriptionDrugSubsidyReceiptsRollingMaturityAbstract": [
+"2017-01-31",
+"Element was deprecated."
+],
+"PrescriptionDrugSubsidyReceiptsRollingYearFive": [
+"2017-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacement is PrescriptionDrugSubsidyReceiptsYearFive1."
+],
+"PrescriptionDrugSubsidyReceiptsRollingYearFour": [
+"2017-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacement is PrescriptionDrugSubsidyReceiptsYearFour1."
+],
+"PrescriptionDrugSubsidyReceiptsRollingYearThree": [
+"2017-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacement is PrescriptionDrugSubsidyReceiptsYearThree1."
+],
+"PrescriptionDrugSubsidyReceiptsRollingYearTwo": [
+"2017-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacement is PrescriptionDrugSubsidyReceiptsYearTwo1."
+],
+"PresentValueOfFutureInsuranceProfitsAmortizationMethod": [
+"2017-01-31",
+"Element was deprecated because of low usage."
 ],
 "PresentValueOfFutureInsuranceProfitsDecrease": [
 "2015-01-31",
@@ -3967,6 +4019,10 @@
 "2015-01-31",
 "Element was deprecated."
 ],
+"PresentValueOfFutureInsuranceProfitsDisclosures": [
+"2017-01-31",
+"Element was deprecated because of low usage."
+],
 "PresentValueOfFutureInsuranceProfitsIncreases": [
 "2015-01-31",
 "Element was deprecated because of low usage."
@@ -3974,6 +4030,10 @@
 "PresentValueOfFutureInsuranceProfitsIncreasesAbstract": [
 "2015-01-31",
 "Element was deprecated."
+],
+"PresentValueOfFutureInsuranceProfitsInterestAccrued1": [
+"2017-01-31",
+"Element was deprecated because it has a credit balance attribute. Possible replacement is PresentValueOfFutureInsuranceProfitsAmortizationExpenseAccruedInterest."
 ],
 "PresentationOfUnusedProceedsOfPollutionControlFinancingPolicy": [
 "2016-01-31",
@@ -4115,18 +4175,6 @@
 "2015-01-31",
 "Element was deprecated because of low usage."
 ],
-"PurchasePriceAllocationAdjustmentsMember": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"QualitativeAndQuantitativeInformationAssetOrLiabilityTransferorsContinuingInvolvementSecuritizationOrAssetbackedFinancingPrincipalAmountOutstandingContinuedRecognitionAmount": [
-"2014-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is SecuritizedAssetsAndAnyOtherFinancialAssetsManagedTogetherPrincipalAmountOutstanding."
-],
-"QualitativeAndQuantitativeInformationAssetOrLiabilityTransferorsContinuingInvolvementSecuritizationOrAssetbackedFinancingPrincipalAmountOutstandingDerecognizedAmount": [
-"2014-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is DerecognizedAssetsSecuritizedOrAssetbackedFinancingArrangementAssetsAndAnyOtherFinancialAssetsManagedTogetherPrincipalAmountOutstanding."
-],
 "QualitativeAndQuantitativeInformationAssetsOrLiabilitiesForTransferorsContinuingInvolvementInSecuritizationOrAssetbackedFinancingArrangementNaturePurposeAndActivities": [
 "2016-01-31",
 "Element deprecated due to redundancy. Possible replacement is QualitativeAndQuantitativeInformationAssetsOrLiabilitiesForTransferorsContinuingInvolvementInSecuritizationOrAssetbackedFinancingArrangementArrangementsOfFinancialSupport."
@@ -4134,10 +4182,6 @@
 "QualitativeAndQuantitativeInformationAssetsOrLiabilitiesForTransferorsContinuingInvolvementInSecuritizationOrAssetbackedFinancingArrangementNotPreviouslyRequiredFinancialSupportProvided": [
 "2016-01-31",
 "Element was deprecated because it represents multiple distinct concepts. Possible replacements are NotPreviouslyRequiredFinancialSupportProvidedAmount and NotPreviouslyRequiredFinancialSupportProvidedTypeAndPrimaryReasons."
-],
-"QualitativeAndQuantitativeInformationAssetsOrLiabilitiesForTransferorsContinuingInvolvementInSecuritizationOrAssetbackedFinancingArrangementPrincipalAmountsOutstanding": [
-"2014-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is ContinuingInvolvementWithTransferredFinancialAssetsPrincipalAmountOutstanding."
 ],
 "QualitativeAndQuantitativeInformationAssetsOrLiabilitiesForTransferorsContinuingInvolvementInSecuritizationOrAssetbackedFinancingArrangementSize": [
 "2015-01-31",
@@ -4163,10 +4207,6 @@
 "2016-01-31",
 "Element was deprecated because of low usage."
 ],
-"RealEstateOwnedValuationAllowanceProvision": [
-"2014-01-31",
-"Element was deprecated because it has a credit balance attribute. Possible replacement is RealEstateOwnedValuationAllowanceProvision1."
-],
 "ReasonForChangingPlanToSellAssetsHeldForSale": [
 "2016-01-31",
 "Element was deprecated because of low usage."
@@ -4178,10 +4218,6 @@
 "ReceivableForRecoveryOfImportDutiesNetNoncurrent": [
 "2016-01-31",
 "Element was deprecated because of low usage."
-],
-"ReceivablesHeldForSaleNetAmount": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are TradeAndLoansReceivablesHeldForSaleNetNotPartOfDisposalGroup or DisposalGroupIncludingDiscontinuedOperationAccountsNotesAndLoansReceivableNet."
 ],
 "ReceivablesWithImputedInterestAmortizationDescription": [
 "2015-01-31",
@@ -4367,10 +4403,6 @@
 "2015-01-31",
 "Element was deprecated because of low usage."
 ],
-"ReportingEntityMember": [
-"2014-01-31",
-"Element was deprecated because it is an invalid concept."
-],
 "RepurchaseAgreementsBusinessPurposes": [
 "2016-01-31",
 "Element was deprecated and replaced with a more encompassing element. Possible replacement is RepurchaseAndResaleAgreementsPolicy."
@@ -4435,6 +4467,10 @@
 "2015-01-31",
 "Element was deprecated due to remodeling of topic area. Possible replacements are SubprimeMember and ResidentialPortfolioSegmentMember."
 ],
+"RestrictedCashAndCashEquivalentItemPurpose": [
+"2017-01-31",
+"Element deprecated due to redundancy. Possible replacement is RestrictedCashAndCashEquivalentItemDescription."
+],
 "RestrictionsOnLoansAndOtherFundTransfers": [
 "2016-01-31",
 "Element was deprecated because of low usage."
@@ -4446,18 +4482,6 @@
 "RestructuringAndRelatedActivitiesAuthorizedApproval": [
 "2016-01-31",
 "Element was deprecated because of low usage."
-],
-"RestructuringAndRelatedCostCostIncurredToDate": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is RestructuringAndRelatedCostCostIncurredToDate1."
-],
-"RestructuringAndRelatedCostExpectedCost": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is RestructuringAndRelatedCostExpectedCost1."
-],
-"RestructuringAndRelatedCostExpectedCostRemaining": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is RestructuringAndRelatedCostExpectedCostRemaining1."
 ],
 "RestructuringReserveAccrualAdjustment": [
 "2016-01-31",
@@ -4535,6 +4559,14 @@
 "2016-01-31",
 "Element was deprecated and replaced with a more encompassing element. Possible replacement is RevenueRecognitionPolicyTextBlock."
 ],
+"RevenueRecognitionGiftCards": [
+"2017-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"RevenueRecognitionGiftCardsBreakage": [
+"2017-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
 "RevenueRecognitionNewAccountingPronouncementAllocation": [
 "2015-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
@@ -4555,14 +4587,6 @@
 "2015-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
-"SaleLeasebackTransactionGrossProceeds": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are SaleLeasebackTransactionGrossProceedsInvestingActivities or SaleLeasebackTransactionGrossProceedsFinancingActivities."
-],
-"SaleLeasebackTransactionNetProceeds": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are SaleLeasebackTransactionNetProceedsInvestingActivities or SaleLeasebackTransactionNetProceedsFinancingActivities."
-],
 "SaleOfStockNatureOfConsiderationReceivedPerTransaction": [
 "2016-01-31",
 "Element was deprecated because of low usage."
@@ -4575,9 +4599,17 @@
 "2015-01-31",
 "Element was deprecated because of low usage."
 ],
+"ScenarioActualMember": [
+"2017-01-31",
+"Element was deprecated because it was inappropriately modeled."
+],
 "ScheduleOfAssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionTable": [
 "2015-01-31",
 "Element deprecated due to redundancy. Possible replacement is IncomeStatementBalanceSheetAndAdditionalDisclosuresByDisposalGroupsIncludingDiscontinuedOperationsTable."
+],
+"ScheduleOfCashProceedsReceivedFromShareBasedPaymentAwardsTableTextBlock": [
+"2017-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
 "ScheduleOfDerivativeFinancialInstrumentsIndexedToAndPotentiallySettledInEntitysOwnStockEquityTextBlock": [
 "2016-01-31",
@@ -4594,6 +4626,14 @@
 "ScheduleOfHealthCareTrustFundTextBlock": [
 "2016-01-31",
 "Element was deprecated because of low usage."
+],
+"ScheduleOfIncrementalEffectsOnBalanceSheetApplicationOfSFAS158RecognitionProvisionsTable": [
+"2017-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+],
+"ScheduleOfIncrementalEffectsOnBalanceSheetApplicationOfSFAS158RecognitionProvisionsTextBlock": [
+"2017-01-31",
+"Element was deprecated because the guidance from which this element is derived is no longer applicable."
 ],
 "ScheduleOfLongLivedAssetsToBeAbandonedTable": [
 "2015-01-31",
@@ -4627,14 +4667,6 @@
 "2015-01-31",
 "Element was deprecated because of low usage."
 ],
-"SecuritizedAssetsAndAnyOtherFinancialAssetsManagedTogetherAverageBalanceDuringPeriod": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"SecuritizedAssetsAndAnyOtherFinancialAssetsManagedTogetherByTypeOfFinancialInstrumentAxis": [
-"2014-01-31",
-"Element was deprecated due to rationalization of dimensions. Possible replacement is FinancialInstrumentAxis."
-],
 "SegmentReportingInformationUnallocatedExpenseInNoninterestExpense": [
 "2016-01-31",
 "Element was deprecated because of low usage."
@@ -4642,10 +4674,6 @@
 "SensitivityAnalysisOfFairValueOfInterestsContinuedToBeHeldByTransferorServicingAssetsOrLiabilitiesImpactOfAdverseChangeInAssumptionByTypeOfFinancialInstrumentAxis": [
 "2016-01-31",
 "Element deprecated due to redundancy. Possible replacement is FinancialInstrumentAxis."
-],
-"ServicingAssetAtFairValueChangesInFairValueLocationInIncomeStatementDescription": [
-"2014-01-31",
-"Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is AssetsDisposedOfByMethodOtherThanSaleInPeriodOfDispositionGainLossOnDisposition1 and members of IncomeStatementLocationAxis."
 ],
 "ServicingLiabilitiesAtFairValueByTypeOfFinancialInstrumentAxis": [
 "2016-01-31",
@@ -4658,14 +4686,6 @@
 "SettlementOfAssetRetirementObligationsThroughNoncashPayments": [
 "2016-01-31",
 "Element was deprecated because of low usage."
-],
-"ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsTotalShareBasedLiabilitiesPaid": [
-"2014-01-31",
-"Element was deprecated because it has an instant period type attribute. Possible replacement is ShareBasedCompensationArrangementByShareBasedPaymentAwardEquityInstrumentsOtherThanOptionsShareBasedLiabilitiesPaid."
-],
-"SharesSubjectToMandatoryRedemptionSettlementTermsForwardPriceOrOptionStrikePrice": [
-"2014-01-31",
-"Element was deprecated because it has a perUnitItemType attribute, it represents multiple distinct concepts and the financial reporting concept can be conveyed dimensionally. Possible replacements are OptionIndexedToIssuersEquityStrikePrice1 or ForwardContractIndexedToIssuersEquityForwardRate and members of ScheduleOfSharesSubjectToMandatoryRedemptionBySettlementTermsAxis."
 ],
 "ShortDurationContractsDiscountedLiabilitiesDiscountRateHighEndOfRange": [
 "2016-01-31",
@@ -4739,6 +4759,10 @@
 "2015-01-31",
 "Element was deprecated because of low usage."
 ],
+"SingleEmployerPlansAccountedForAsMultiemployerPlanContributions": [
+"2017-01-31",
+"Element was deprecated because it has a debit balance attribute. Possible replacement is MultipleEmployerPlanAccountedForAsMultiemployerPlanContributionByParticipatingEntity."
+],
 "SiteContingencyLossExposureInExcessOfAccrualHighEstimate": [
 "2016-01-31",
 "Element was deprecated because the financial reporting concept can be conveyed dimensionally. Possible replacement is SiteContingencyLossExposureInExcessOfAccrualBestEstimate, RangeAxis and MaximumMember."
@@ -4786,14 +4810,6 @@
 "StockIssuedDuringPeriodValueIssuedForNoncashConsiderations": [
 "2015-01-31",
 "Element was deprecated because the guidance from which this element is derived is no longer applicable."
-],
-"StockRepurchaseProgramAuthorizedAmount": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is StockRepurchaseProgramAuthorizedAmount1."
-],
-"StockRepurchaseProgramRemainingAuthorizedRepurchaseAmount": [
-"2014-01-31",
-"Element was deprecated because it has a duration period type attribute. Possible replacement is StockRepurchaseProgramRemainingAuthorizedRepurchaseAmount1."
 ],
 "StructuredSettlementAnnuitiesInterestRateHighEnd": [
 "2016-01-31",
@@ -4919,18 +4935,6 @@
 "2015-01-31",
 "Element deprecated due to redundancy. Possible replacement is DeferredTaxAssetsTaxCreditCarryforwards."
 ],
-"TemporaryEquityCarryingAmountAttributableToNoncontrollingInterest": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is RedeemableNoncontrollingInterestEquityCarryingAmount."
-],
-"TemporaryEquityCarryingAmountAttributableToNoncontrollingInterestAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"TemporaryEquityRedemptionValue": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TemporaryEquityCarryingAmountIncludingPortionAttributableToNoncontrollingInterests."
-],
 "TermOfUnrecordedUnconditionalPurchaseObligation": [
 "2016-01-31",
 "Element was deprecated because it has a stringItemType attribute. Possible replacements are UnrecordedUnconditionalPurchaseObligationTerm or UnrecordedUnconditionalPurchaseObligationDate."
@@ -4975,25 +4979,9 @@
 "2015-01-31",
 "Element was deprecated because it was inappropriately modeled. Possible replacement is TradeReceivablesHeldForSaleNetNotPartOfDisposalGroup."
 ],
-"TradingActivityGainsAndLossesNet": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TradingGainsLosses."
-],
 "TradingSecuritiesBasisForValuationOtherThanEquitySecurities": [
 "2016-01-31",
 "Element was deprecated because of low usage."
-],
-"TradingSecuritiesCurrent": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TradingSecurities."
-],
-"TradingSecuritiesCurrentAbstract": [
-"2014-01-31",
-"Element was deprecated."
-],
-"TradingSecuritiesEquityCurrent": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is TradingSecuritiesEquity."
 ],
 "TradingSecuritiesRestrictedAbstract": [
 "2015-01-31",
@@ -5051,17 +5039,9 @@
 "2016-01-31",
 "Element deprecated due to redundancy. Possible replacement is TreasuryStockShares."
 ],
-"TypeOfDeferredCompensationDomain": [
-"2014-01-31",
-"Element was deprecated because it was inappropriately modeled. Possible replacements are DeferredBonusAndProfitSharingArrangementIndividualContractTypeOfDeferredCompensationDomain, OtherPostretirementBenefitsIndividualContractsTypeOfDeferredCompensationDomain, or EquityBasedArrangementsIndividualContractsTypeOfDeferredCompensationDomain."
-],
 "TypesOfCostsForRecovery": [
 "2016-01-31",
 "Element was deprecated because of low usage."
-],
-"USGovernmentAndGovernmentAgenciesAndAuthoritiesMember": [
-"2014-01-31",
-"Element was deprecated due to redundancy. Possible replacement is USTreasuryAndGovernmentMember."
 ],
 "UnamortizedLoanCommitmentAndOriginationFeesAndUnamortizedDiscountsOrPremiumsAbstract": [
 "2016-01-31",
@@ -5095,13 +5075,21 @@
 "2016-01-31",
 "Element was deprecated because of low usage."
 ],
-"UndistributedEarningsAllocatedToParticipatingSecurities": [
-"2014-01-31",
-"Element was deprecated because it represents multiple distinct concepts. Possible replacements are UndistributedEarningsLossAllocatedToParticipatingSecuritiesBasic or UndistributedEarningsLossAllocatedToParticipatingSecuritiesDiluted."
+"UnearnedPremiumsLongDurationMember": [
+"2017-01-31",
+"Element was deprecated."
 ],
-"UnrecognizedTaxBenefitsResultingInNetOperatingLossCarryforward": [
-"2014-01-31",
-"Element was deprecated because the guidance from which this element is derived is no longer applicable."
+"UnearnedPremiumsShortDurationMember": [
+"2017-01-31",
+"Element was deprecated."
+],
+"UnitedStatesPensionPlansOfUSEntityDefinedBenefitMember": [
+"2017-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacement is RetirementPlanSponsorLocationAxis and DomesticPlanMember and US member of AllCountriesDomain."
+],
+"UnitedStatesPostretirementBenefitPlansOfUSEntityDefinedBenefitMember": [
+"2017-01-31",
+"Element was deprecated due to remodeling of topic area. Possible replacement is RetirementPlanSponsorLocationAxis and DomesticPlanMember and US member of AllCountriesDomain."
 ],
 "UnrecordedUnconditionalPurchaseObligationContractQuantityReceived": [
 "2015-01-31",
@@ -5118,6 +5106,10 @@
 "UseOfEstimatesQuarterlyChangesInEstimates": [
 "2016-01-31",
 "Element deprecated due to redundancy. Possible replacement is ChangeInAccountingEstimateDescription."
+],
+"UseOfRestrictedCashForAcquisitionOfOilAndGasProperty": [
+"2017-01-31",
+"Element was deprecated due to issuance of new guidance."
 ],
 "VariableInterestEntityActivityBetweenVIEAndEntityOtherMeasureOfActivityDescription": [
 "2016-01-31",


### PR DESCRIPTION
### Changes:

- Added support for 2017 taxonomy to rule 18.
- Date/label weren’t loaded right if order was reversed
- Sorted json file alphabetically.

### Pull request process

- [ ] Full description of changes provided above.
- [ ] Reviewed by another person. (+1)
- [ ] If this is a code change, reviewed by a second person. (+1)
- [ ] QA'd to the specifications listed [here](https://github.com/DataQualityCommittee/dqc_us_rules#quality-assurance-qa-of-a-pull-request). Documentation only changes do not require the formal code quality assurance process. (+10)

##### Once checklist is complete, @hefischer  @andrewperkins-wf please review for merge.
