### PR TITLE
Xule update to support v6 DQC rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,3 +58,4 @@ after_script:
   - echo '===== START TEST RPOERT FILE (csv) =====' && cat $OUTPUTCSVFILE && echo '===== END TEST RPOERT FILE (csv) ====='
   - echo '===== START LOG FILE =====' && cat $OUTPUTLOGFILE && echo '===== END LOG FILE ====='
 
+

--- a/xule/XuleContext.py
+++ b/xule/XuleContext.py
@@ -22,7 +22,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-$Change: 22364 $
+$Change: 22441 $
 DOCSKIP
 """
 from .XuleRunTime import XuleProcessingError
@@ -478,7 +478,8 @@ class XuleRuleContext(object):
                     "other_values": {}}
 
         self.vars[node_id].append(var_info)
-        self.tags[name] = value
+        if tag is not None:
+            self.tags[tag] = value
     
     def del_arg(self, name, node_id):
         """Removes an argument from the variable stack"""

--- a/xule/XuleFunctions.py
+++ b/xule/XuleFunctions.py
@@ -19,7 +19,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-$Change: 22431 $
+$Change: 22443 $
 DOCSKIP
 """
 from . import XuleValue as xv
@@ -29,7 +29,7 @@ import collections
 from aniso8601 import parse_duration
 import decimal
 import json
-from json.decoder import JSONDecodeError
+#from json.decoder import JSONDecodeError
 
 
 def func_exists(xule_context, *args):   
@@ -642,7 +642,8 @@ def func_json_data(xule_context, *args):
     data_source = [x.decode('utf-8') for x in file[0].readlines()]
     try:
         json_source = json.loads(''.join(data_source))
-    except JSONDecodeError:
+    #except JSONDecodeError:
+    except ValueError:
         raise XuleProcessingError(_("The file '{}' is not a valid JSON file.".format(file_url.value)), xule_context)
     
     x = xv.system_collection_to_xule(json_source, xule_context)

--- a/xule/XuleProperties.py
+++ b/xule/XuleProperties.py
@@ -19,7 +19,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-$Change: 22389 $
+$Change: 22425 $
 DOCSKIP
 """
 
@@ -507,7 +507,7 @@ def property_denominator(xule_context, object_value, *args):
 def property_attribute(xule_context, object_value, *args):
     attribute_name_value = args[0]
     if attribute_name_value.type != 'qname':
-        raise XuleProcessingError(_("The argument for the 'attribute' property must be a qname, found '{}'".format(arttribute_name_value.type)), xule_context)
+        raise XuleProcessingError(_("The argument for the 'attribute' property must be a qname, found '{}'".format(attribute_name_value.type)), xule_context)
     
     attribute_value = object_value.value.get(attribute_name_value.value.clarkNotation)
     if attribute_value is None:

--- a/xule/rulesetMap.json
+++ b/xule/rulesetMap.json
@@ -1,11 +1,12 @@
 {
-	"http://xbrl.ifrs.org/taxonomy/2017-03-09/ifrs-full" : "https://github.com/DataQualityCommittee/dqc_us_rules/blob/next_q1_17v5/dqc_us_rules/dqc-ifrs-2017-V5-ruleset.zip?raw=true",
-	"http://xbrl.ifrs.org/taxonomy/2016-03-31/ifrs-full" : "https://github.com/DataQualityCommittee/dqc_us_rules/blob/next_q1_17v5/dqc_us_rules/dqc-ifrs-2016-V5-ruleset.zip?raw=true",
-	"http://fasb.org/us-gaap/2017-01-31" : "https://github.com/DataQualityCommittee/dqc_us_rules/blob/next_q1_17v5/dqc_us_rules/dqc-us-2017-V5-ruleset.zip?raw=true",
-	"http://fasb.org/us-gaap/2016-01-31" : "https://github.com/DataQualityCommittee/dqc_us_rules/blob/next_q1_17v5/dqc_us_rules/dqc-us-2016-V5-ruleset.zip?raw=true",
-	"http://fasb.org/us-gaap/2015-01-31" : "https://github.com/DataQualityCommittee/dqc_us_rules/blob/next_q1_17v5/dqc_us_rules/dqc-us-2015-V5-ruleset.zip?raw=true",
-	"http://fasb.org/us-gaap/2014-01-31" : "https://github.com/DataQualityCommittee/dqc_us_rules/blob/next_q1_17v5/dqc_us_rules/dqc-us-2014-V5-ruleset.zip?raw=true",	
-	"http://fasb.org/us-gaap/2013-01-31" : "https://github.com/DataQualityCommittee/dqc_us_rules/blob/next_q1_17v5/dqc_us_rules/dqc-us-2013-V5-ruleset.zip?raw=true",
-	"http://fasb.org/us-gaap/2012-01-31" : "https://github.com/DataQualityCommittee/dqc_us_rules/blob/next_q1_17v5/dqc_us_rules/dqc-us-2012-V5-ruleset.zip?raw=true",
-	"http://fasb.org/us-gaap/2011-01-31" : "https://github.com/DataQualityCommittee/dqc_us_rules/blob/next_q1_17v5/dqc_us_rules/dqc-us-2011-V5-ruleset.zip?raw=true"
+	"http://xbrl.ifrs.org/taxonomy/2017-03-09/ifrs-full" : "https://github.com/DataQualityCommittee/dqc_us_rules/blob/v6/dqc_us_rules/dqc-ifrs-2017-V6-ruleset.zip?raw=true",
+	"http://xbrl.ifrs.org/taxonomy/2016-03-31/ifrs-full" : "https://github.com/DataQualityCommittee/dqc_us_rules/blob/v6/dqc_us_rules/dqc-ifrs-2016-V6-ruleset.zip?raw=true",
+	"http://fasb.org/us-gaap/2018-01-31" : "https://github.com/DataQualityCommittee/dqc_us_rules/blob/v6/dqc_us_rules/dqc-us-2018-V6-ruleset.zip?raw=true",
+	"http://fasb.org/us-gaap/2017-01-31" : "https://github.com/DataQualityCommittee/dqc_us_rules/blob/v6/dqc_us_rules/dqc-us-2017-V6-ruleset.zip?raw=true",
+	"http://fasb.org/us-gaap/2016-01-31" : "https://github.com/DataQualityCommittee/dqc_us_rules/blob/v6/dqc_us_rules/dqc-us-2016-V6-ruleset.zip?raw=true",
+	"http://fasb.org/us-gaap/2015-01-31" : "https://github.com/DataQualityCommittee/dqc_us_rules/blob/v6/dqc_us_rules/dqc-us-2015-V5-ruleset.zip?raw=true",
+	"http://fasb.org/us-gaap/2014-01-31" : "https://github.com/DataQualityCommittee/dqc_us_rules/blob/v6/dqc_us_rules/dqc-us-2014-V5-ruleset.zip?raw=true",	
+	"http://fasb.org/us-gaap/2013-01-31" : "https://github.com/DataQualityCommittee/dqc_us_rules/blob/v6/dqc_us_rules/dqc-us-2013-V5-ruleset.zip?raw=true",
+	"http://fasb.org/us-gaap/2012-01-31" : "https://github.com/DataQualityCommittee/dqc_us_rules/blob/v6/dqc_us_rules/dqc-us-2012-V5-ruleset.zip?raw=true",
+	"http://fasb.org/us-gaap/2011-01-31" : "https://github.com/DataQualityCommittee/dqc_us_rules/blob/v6/dqc_us_rules/dqc-us-2011-V5-ruleset.zip?raw=true"
 }


### PR DESCRIPTION
### Changes:
- Changes to support rules DQC rules. 
  - Fix type when raising and error for property 'attribute'.
  - Added function 'json-data'.
  - Added property 'native_value' to class XuleValue.
  - Fix handing of index expressions for dictionaries when there are multiple indexes on the expressions. If the left value was a dictionary, it was returning with the value at the index instead of resetting the left value so the next index would be evaluated.
  - Added "stop when" to navigate expression.
  - Prevent built in variables (item, fact, relationship, factset dimension aliases) from being included as tags.


### Pull request process

- [ ] Full description of changes provided above.
- [ ] Reviewed by another person. (+1)
- [ ] If this is a code change, reviewed by a second person. (+1)
- [ ] QA'd to the specifications listed [here](https://github.com/DataQualityCommittee/dqc_us_rules#quality-assurance-qa-of-a-pull-request). Documentation only changes do not require the formal code quality assurance process. (+10)

##### Once checklist is complete, @hefischer please review for merge.
