### PR TITLE
Fix rule set loading issue

### DIFF
--- a/plugin/xule/XuleUtility.py
+++ b/plugin/xule/XuleUtility.py
@@ -266,18 +266,10 @@ def determine_rule_set(model_xbrl, cntlr, rule_set_map_name):
     rule_set_map = get_rule_set_map(cntlr, rule_set_map_name)
     
     if rule_set_map is not None:
-        # Get a list of namespaces that are used by the facts.
-        used_namespaces = set(x.namespaceURI for x in model_xbrl.factsByQname.keys())
         # Go through the list of namespaces in the rule set map
         for mapped_namespace, rule_set_location in rule_set_map.items():
             if mapped_namespace in model_xbrl.namespaceDocs:
-            #if mapped_namespace in used_namespaces:
                 return rule_set_location
-    
-#     # This is only reached if a rule set location was not found in the map.
-#     rule_set_map_file_name = get_rule_set_map_file_name(cntlr, xc.RULE_SET_MAP)
-#     model_xbrl.log('ERROR', 'xule', "Cannot determine which rule set to use for the filing. Check the rule set map at '{}'.".format(rule_set_map_file_name))
-#     #raise XuleProcessingError(_("Cannot determine which rule set to use for the filing. Check the rule set map at '{}'.".format(rule_set_map_file_name)))
 
 def get_rule_set_map(cntlr, map_name):
     try:

--- a/plugin/xule/__init__.py
+++ b/plugin/xule/__init__.py
@@ -775,9 +775,7 @@ def xuleCmdXbrlLoaded(cntlr, options, modelXbrl, *args, **kwargs):
         runXule(cntlr, options, modelXbrl)
 
 def runXule(cntlr, options, modelXbrl, rule_set_map=_xule_rule_set_map_name):
-    rule_set = None
-    if getattr(options, "xule_multi", True) and \
-        getattr(cntlr, "rule_set", None) is not None:
+    if getattr(options, "xule_multi", True) and getattr(cntlr, "rule_set", None) is not None:
         rule_set = getattr(cntlr, "rule_set")
     else:
         if getattr(options, 'xule_rule_set', None) is not None:
@@ -785,7 +783,7 @@ def runXule(cntlr, options, modelXbrl, rule_set_map=_xule_rule_set_map_name):
         else:
             # Determine the rule set from the model.
             rule_set_location = xu.determine_rule_set(modelXbrl, cntlr, rule_set_map)
-            modelXbrl.log('INFO', 'info', 'Using ruleset {}'.format(rule_set_location))
+
             if rule_set_location is None:
                 # The rule set could not be determined.
                 modelXbrl.log(
@@ -795,9 +793,10 @@ def runXule(cntlr, options, modelXbrl, rule_set_map=_xule_rule_set_map_name):
                         xu.get_rule_set_map_file_name(cntlr, rule_set_map)
                     )
                 )
-        if rule_set_location is not None:
-            rule_set = xr.XuleRuleSet(cntlr)
-            rule_set.open(rule_set_location, open_packages=not getattr(options, 'xule_bypass_packages', False))
+                return
+        modelXbrl.log('INFO', 'info', 'Using ruleset {}'.format(rule_set_location))
+        rule_set = xr.XuleRuleSet(cntlr)
+        rule_set.open(rule_set_location, open_packages=not getattr(options, 'xule_bypass_packages', False))
 
     if rule_set is None:
         return

--- a/plugin/xule/__init__.py
+++ b/plugin/xule/__init__.py
@@ -775,52 +775,50 @@ def xuleCmdXbrlLoaded(cntlr, options, modelXbrl, *args, **kwargs):
         runXule(cntlr, options, modelXbrl)
 
 def runXule(cntlr, options, modelXbrl, rule_set_map=_xule_rule_set_map_name):
-        try:
-            if getattr(options, "xule_multi", True) and \
-                getattr(cntlr, "rule_set", None) is not None:
-                rule_set = getattr(cntlr, "rule_set")
-            else:
-                if getattr(options, 'xule_rule_set', None) is not None:
-                    rule_set_location = options.xule_rule_set
-                else:
-                    # Determine the rule set from the model.
-                    rule_set_location = xu.determine_rule_set(modelXbrl, cntlr, rule_set_map)
-                    modelXbrl.log('INFO', 'info', 'Using ruleset {}'.format(rule_set_location))
-                    if rule_set_location is None:
-                        # The rule set could not be determined.
-                        modelXbrl.log('ERROR', 'xule', "Cannot determine which rule set to use for the filing. Check the rule set map at '{}'.".format(xu.get_rule_set_map_file_name(cntlr, rule_set_map)))
-
-                rule_set = xr.XuleRuleSet(cntlr)
-                rule_set.open(rule_set_location, open_packages=not getattr(options, 'xule_bypass_packages', False))
-        except xr.XuleRuleSetError:
-            raise
-
-        if getattr(options, "xule_multi", False):
-            xm.start_process(rule_set,
-                         modelXbrl,
-                         cntlr,
-                         options
-                         )
+    rule_set = None
+    if getattr(options, "xule_multi", True) and \
+        getattr(cntlr, "rule_set", None) is not None:
+        rule_set = getattr(cntlr, "rule_set")
+    else:
+        if getattr(options, 'xule_rule_set', None) is not None:
+            rule_set_location = options.xule_rule_set
         else:
-            if modelXbrl is None:
-                # check if there are any rules that need a model
-                for rule in rule_set.catalog['rules'].values():
-                    if rule['dependencies']['instance'] == True and rule['dependencies']['rules-taxonomy'] != False:
-                        raise xr.XuleRuleSetError('Need instance to process rules')
+            # Determine the rule set from the model.
+            rule_set_location = xu.determine_rule_set(modelXbrl, cntlr, rule_set_map)
+            modelXbrl.log('INFO', 'info', 'Using ruleset {}'.format(rule_set_location))
+            if rule_set_location is None:
+                # The rule set could not be determined.
+                modelXbrl.log(
+                    'INFO',
+                    'xule',
+                    "Cannot determine which rule set to use for the filing. Check the rule set map at '{}'.".format(
+                        xu.get_rule_set_map_file_name(cntlr, rule_set_map)
+                    )
+                )
+        if rule_set_location is not None:
+            rule_set = xr.XuleRuleSet(cntlr)
+            rule_set.open(rule_set_location, open_packages=not getattr(options, 'xule_bypass_packages', False))
 
-            global _saved_taxonomies
-            used_taxonomies = process_xule(rule_set,
-                                           modelXbrl,
-                                           cntlr,
-                                           options,
-                                           _saved_taxonomies
-                                           )
-            # Save one loaded taxonomy
-            new_taxonomy_keys = used_taxonomies.keys() - _saved_taxonomies.keys()
-            if len(new_taxonomy_keys) > 0:
-                for tax_key in list(new_taxonomy_keys)[:2]: # This take at most 2 taxonomies.
-                    tax_key = next(iter(new_taxonomy_keys)) # randomly get one key
-                    _saved_taxonomies[tax_key] = used_taxonomies[tax_key]
+    if rule_set is None:
+        return
+
+    if getattr(options, "xule_multi", False):
+        xm.start_process(rule_set, modelXbrl, cntlr, options)
+    else:
+        if modelXbrl is None:
+            # check if there are any rules that need a model
+            for rule in rule_set.catalog['rules'].values():
+                if rule['dependencies']['instance'] == True and rule['dependencies']['rules-taxonomy'] != False:
+                    raise xr.XuleRuleSetError('Need instance to process rules')
+
+        global _saved_taxonomies
+        used_taxonomies = process_xule(rule_set, modelXbrl, cntlr, options, _saved_taxonomies)
+        # Save one loaded taxonomy
+        new_taxonomy_keys = used_taxonomies.keys() - _saved_taxonomies.keys()
+        if len(new_taxonomy_keys) > 0:
+            for tax_key in list(new_taxonomy_keys)[:2]: # This take at most 2 taxonomies.
+                tax_key = next(iter(new_taxonomy_keys)) # randomly get one key
+                _saved_taxonomies[tax_key] = used_taxonomies[tax_key]
 
 def xuleValidate(val):
     global _cntlr

--- a/plugin/xule/rulesetMap.json
+++ b/plugin/xule/rulesetMap.json
@@ -6,10 +6,5 @@
 "http://fasb.org/us-gaap/2019-01-31": "https://github.com/DataQualityCommittee/dqc_us_rules/raw/v11/dqc_us_rules/dqc-us-2019-V11-ruleset.zip",
 "http://fasb.org/us-gaap/2018-01-31": "https://github.com/DataQualityCommittee/dqc_us_rules/raw/v11/dqc_us_rules/dqc-us-2018-V11-ruleset.zip",
 "http://fasb.org/us-gaap/2017-01-31": "https://github.com/DataQualityCommittee/dqc_us_rules/raw/v11/dqc_us_rules/dqc-us-2017-V11-ruleset.zip",
-"http://fasb.org/us-gaap/2016-01-31": "https://github.com/DataQualityCommittee/dqc_us_rules/raw/v11/dqc_us_rules/dqc-us-2016-V11-ruleset.zip",
-"http://fasb.org/us-gaap/2015-01-31": "https://github.com/DataQualityCommittee/dqc_us_rules/raw/v11/dqc_us_rules/dqc-us-2015-V6-ruleset.zip",
-"http://fasb.org/us-gaap/2014-01-31": "https://github.com/DataQualityCommittee/dqc_us_rules/raw/v11/dqc_us_rules/dqc-us-2014-V5-ruleset.zip",
-"http://fasb.org/us-gaap/2013-01-31": "https://github.com/DataQualityCommittee/dqc_us_rules/raw/v11/dqc_us_rules/dqc-us-2013-V5-ruleset.zip",
-"http://fasb.org/us-gaap/2012-01-31": "https://github.com/DataQualityCommittee/dqc_us_rules/raw/v11/dqc_us_rules/dqc-us-2012-V5-ruleset.zip",
-"http://fasb.org/us-gaap/2011-01-31": "https://github.com/DataQualityCommittee/dqc_us_rules/raw/v11/dqc_us_rules/dqc-us-2011-V5-ruleset.zip"
+"http://fasb.org/us-gaap/2016-01-31": "https://github.com/DataQualityCommittee/dqc_us_rules/raw/v11/dqc_us_rules/dqc-us-2016-V11-ruleset.zip"
 }


### PR DESCRIPTION
### Changes:
- Updated the runXule function in __init__.py to stop an error from occurring when an appropriate rule set does not exist in the rulesetMap. Prior to this change the determine_rule_set function in XuleUtilty.py could return None. Xule would then pass the None value to arelle for loading and arelle would error with an attribute error. The code now checks for the existence of a rule_set_location prior to passing it to arelle for loading. If no rule set exists then XULE short circuits and stops running.
- Cleaned up the determine_rule_set function in XuleUtility.py.
- Cleaned up the rulesetMap.json to no longer have references to rulesets that dont exist.

### Pull request process

- [ ] Full description of changes provided above.
- [ ] Reviewed by another person. (+1)
- [ ] If this is a code change, reviewed by a second person. (+1)
- [ ] QA'd to the specifications listed [here](https://github.com/DataQualityCommittee/dqc_us_rules#quality-assurance-qa-of-a-pull-request). Documentation only changes do not require the formal code quality assurance process. (+10)

##### Once checklist is complete, @campbellpryde @marcward @davidtauriello please review for merge.