### PR TITLE
Update ModelRelationshipSet calls to utilize the relationship caching in arelle

### DIFF
--- a/plugin/xule/XuleProperties.py
+++ b/plugin/xule/XuleProperties.py
@@ -28,7 +28,6 @@ from . import XuleValue as xv
 from . import XuleUtility 
 from . import XuleFunctions
 from arelle.ModelDocument import Type
-from arelle.ModelRelationshipSet import ModelRelationshipSet
 from arelle.ModelValue import QName
 import collections
 import decimal
@@ -767,7 +766,7 @@ def property_label(xule_context, object_value, *args):
         return xv.XuleValue(xule_context, label, 'label')
      
 def get_label(xule_context, concept, base_label_type, base_lang):#label type
-    label_network = ModelRelationshipSet(concept.modelXbrl, CONCEPT_LABEL)
+    label_network = concept.modelXbrl.relationshipSet(CONCEPT_LABEL)
     label_rels = label_network.fromModelObject(concept)
     if len(label_rels) > 0:
         #filter the labels
@@ -854,7 +853,7 @@ def property_references(xule_context, object_value, *args):
     else:
         concept = object_value.value
  
-    reference_network = ModelRelationshipSet(concept.modelXbrl, CONCEPT_REFERENCE)
+    reference_network = concept.modelXbrl.relationshipSet(CONCEPT_REFERENCE)
     reference_rels = reference_network.fromModelObject(concept)
     if len(reference_rels) > 0:
         #filter the references
@@ -1053,14 +1052,13 @@ def property_arc_name(xule_context, object_value, *args):
 
 def property_network(xule_context, object_value, *args):
     network_info = (object_value.value.arcrole, object_value.value.linkrole, object_value.value.linkQname, object_value.value.qname, False)
-
-    network = (network_info, 
-               ModelRelationshipSet(object_value.value.modelXbrl, 
-                                    network_info[NETWORK_ARCROLE],
-                                    network_info[NETWORK_ROLE],
-                                    network_info[NETWORK_LINK],
-                                    network_info[NETWORK_ARC]))
-    
+    network_relationship_set = object_value.value.modelXbrl.relationshipSet(
+        network_info[NETWORK_ARCROLE],
+        network_info[NETWORK_ROLE],
+        network_info[NETWORK_LINK],
+        network_info[NETWORK_ARC]
+    )
+    network = (network_info, network_relationship_set)
     return xv.XuleValue(xule_context, network, 'network')
     
 def property_power(xule_context, object_value, *args):  
@@ -1349,21 +1347,15 @@ def get_networks(xule_context, dts_value, arcrole=None, role=None, link=None, ar
         '''I THINK THESE NETWORKS ARE REALLY COMBINATION OF NETWORKS, SO I AM IGNORING THEM.
            NEED TO CHECK IF THIS IS TRUE.'''
         if (network_info[NETWORK_ROLE] is not None and
-            network_info[NETWORK_LINK] is not None and
-            network_info[NETWORK_ARC] is not None):
-            
-            if network_info in dts.relationshipSets:
-                net = xv.XuleValue(xule_context, (network_info, dts.relationshipSets[network_info]), 'network')
-            else:
-                net = xv.XuleValue(xule_context, 
-                                (network_info, 
-                                    ModelRelationshipSet(dts, 
-                                               network_info[NETWORK_ARCROLE],
-                                               network_info[NETWORK_ROLE],
-                                               network_info[NETWORK_LINK],
-                                               network_info[NETWORK_ARC])),
-                                     'network')
-            
+                network_info[NETWORK_LINK] is not None and
+                network_info[NETWORK_ARC] is not None):
+            relationship_set = dts.relationshipSet(
+                network_info[NETWORK_ARCROLE],
+                network_info[NETWORK_ROLE],
+                network_info[NETWORK_LINK],
+                network_info[NETWORK_ARC]
+            )
+            net = xv.XuleValue(xule_context, (network_info, relationship_set), 'network')
             #final_result_set.append(net)
             networks.add(net)
     #return final_result_set


### PR DESCRIPTION
### Changes:

- Removed all calls to ModelRelationshipSet and replaced with modelXbrl.relationshipSet() calls to utilize the caching of relationship sets in arelle. 

### Pull request process

- [ ] Full description of changes provided above.
- [ ] Reviewed by another person. (+1)
- [ ] If this is a code change, reviewed by a second person. (+1)
- [ ] QA'd to the specifications listed [here](https://github.com/DataQualityCommittee/dqc_us_rules#quality-assurance-qa-of-a-pull-request). Documentation only changes do not require the formal code quality assurance process. (+10)

##### Once checklist is complete, @campbellpryde @marcward @davidtauriello please review for merge.