### PR TITLE
Fix error handling so that XULE can exit gracefully if a ruleset is not found

### DIFF
--- a/plugin/xule/XuleUtility.py
+++ b/plugin/xule/XuleUtility.py
@@ -254,14 +254,11 @@ def determine_rule_set(model_xbrl, cntlr, rule_set_map_name):
     """
     # Open the rule set map file. This is a json file that maps namespace uris to a location for a rule set.
     rule_set_map = get_rule_set_map(cntlr, rule_set_map_name)
-    
+
     if rule_set_map is not None:
-        # Get a list of namespaces that are used by the facts.
-        used_namespaces = set(x.namespaceURI for x in model_xbrl.factsByQname.keys())
         # Go through the list of namespaces in the rule set map
         for mapped_namespace, rule_set_location in rule_set_map.items():
             if mapped_namespace in model_xbrl.namespaceDocs:
-            #if mapped_namespace in used_namespaces:
                 return rule_set_location
     
 #     # This is only reached if a rule set location was not found in the map.

--- a/plugin/xule/__init__.py
+++ b/plugin/xule/__init__.py
@@ -859,7 +859,7 @@ def xuleCompile(xule_file_names, ruleset_file_name, compile_type, max_recurse_de
 def runXule(cntlr, options, modelXbrl, rule_set_map=_xule_rule_set_map_name):
         try:
             if getattr(options, "xule_multi", True) and \
-                getattr(cntlr, "rule_set", None) is not None:
+                    getattr(cntlr, "rule_set", None) is not None:
                 rule_set = getattr(cntlr, "rule_set")
             else:
                 if getattr(options, 'xule_rule_set', None) is not None:
@@ -869,16 +869,23 @@ def runXule(cntlr, options, modelXbrl, rule_set_map=_xule_rule_set_map_name):
                     rule_set_location = xu.determine_rule_set(modelXbrl, cntlr, rule_set_map)
                     modelXbrl.log('INFO', 'info', 'Using ruleset {}'.format(rule_set_location))
                     if rule_set_location is None:
-                        # The rule set could not be determined.
-                        modelXbrl.log('ERROR', 'xule', "Cannot determine which rule set to use for the filing. Check the rule set map at '{}'.".format(xu.get_rule_set_map_file_name(cntlr, rule_set_map))) 
-                
-                rule_set = xr.XuleRuleSet(cntlr)              
+                        raise xr.XuleRuleSetError(
+                            "Cannot determine which rule set to use for the filing. Check the rule set map at '{}'.".format(
+                                xu.get_rule_set_map_file_name(cntlr, rule_set_map)
+                            )
+                        )
+                rule_set = xr.XuleRuleSet(cntlr)
                 rule_set.open(rule_set_location, open_packages=not getattr(options, 'xule_bypass_packages', False))
         except xr.XuleRuleCompatibilityError as err:
-            # output the message to the log and NOT raise an exception
-            cntlr.addToLog(err.args[0] if len(err.args)>0 else 'Unknown rule compatibility error', 'xule', level=logging.ERROR)
-        except xr.XuleRuleSetError:
-            raise
+            modelXbrl.error(
+                'xule:RulesetCompatabilityError',
+                'Rule compatibility error: {}'.format(err),
+            )
+        except xr.XuleRuleSetError as rse:
+            modelXbrl.error(
+                'xule:RulesetError',
+                'An issue occurred with the xule ruleset: {}'.format(rse)
+            )
         else:
             if getattr(options, "xule_multi", False):
                 xm.start_process(rule_set,


### PR DESCRIPTION
### Changes:

- Updated error handling around loading the xule rule set. Prior to this change, XULE will raise an error if a rule set can not be found. Since xule is part of the plugin architecture of Arelle, this causes Arelle to crash as well. With this change xule logs an error anytime a `XuleRuleCompatibilityError` or `XuleRuleSetError` occur and then exits gracefully.
- Cleaned up unnecessary code around determining the appropriate ruleset to use.

### Pull request process

- [ ] Full description of changes provided above.
- [ ] Reviewed by another person. (+1)
- [ ] If this is a code change, reviewed by a second person. (+1)
- [ ] QA'd to the specifications listed [here](https://github.com/DataQualityCommittee/dqc_us_rules#quality-assurance-qa-of-a-pull-request). Documentation only changes do not require the formal code quality assurance process. (+10)

##### Once checklist is complete, @campbellpryde @marcward @davidtauriello please review for merge.