### PR TITLE
Updated the 2024 DQC_IFRS_0202.xule check to look for the namespace-uri.

### DIFF
--- a/dqc_us_rules/source/ifrs/2024/DQC_IFRS_0202.xule
+++ b/dqc_us_rules/source/ifrs/2024/DQC_IFRS_0202.xule
@@ -15,7 +15,7 @@ $rule_id = (rule-name().split('.'))[rule-name().split('.').length];
 
 /** Identify if a cyber element has been used, applies to the 2024 taxonomy only. Need to confirm if 10-Q is required or 8-K incident is OK**/
 
-$concepts = filter taxonomy().concepts where $item.name.uri == 'http://xbrl.sec.gov/cyd/2024'returns $item.name
+$concepts = filter taxonomy().concepts where $item.name.namespace-uri == 'http://xbrl.sec.gov/cyd/2024'returns $item.name
 
 if set('10-K','20-F').contains([covered @concept.local-name ='DocumentType'])
     list({covered @concept in $concepts}).length == 0


### PR DESCRIPTION
### Changes:

- Updated the 2024 DQC_IFRS_0202.xule check to look for the namespace-uri.  It had been trying to inspect qname.uri.  uri is not a property of name and therefore was yielding: xule.XuleRunTime.XuleProcessingError: Rule: DQC.IFRS.0202.10703 - Property 'uri' is not a property of a 'qname'. 

### Pull request process

- [ ] Full description of changes provided above.
- [ ] Reviewed by another person. (+1)
- [ ] If this is a code change, reviewed by a second person. (+1)
- [ ] QA'd to the specifications listed [here](https://github.com/DataQualityCommittee/dqc_us_rules#quality-assurance-qa-of-a-pull-request). Documentation only changes do not require the formal code quality assurance process. (+10)

##### Once checklist is complete, @campbellpryde @marcward @davidtauriello please review for merge.