### PR TITLE
skip 0084 for N-CSRS and variants

### DIFF
--- a/dqc_us_rules/source/us/2023/DQC_0084.xule
+++ b/dqc_us_rules/source/us/2023/DQC_0084.xule
@@ -13,7 +13,7 @@ assert US.0084.9298 satisfied
 
 $rule_id = (rule-name().split('.'))[rule-name().split('.').length];
 
-if set('N-CSR').contains([covered @concept.local-name ='DocumentType'])
+if set('N-CSR', 'N-CSRS', 'N-CSR/A', 'N-CSRS/A').contains([covered @concept.local-name ='DocumentType'])
 	skip
 else
 $decimal_tolerance_factor = 3

--- a/dqc_us_rules/source/us/2024/DQC_0084.xule
+++ b/dqc_us_rules/source/us/2024/DQC_0084.xule
@@ -13,7 +13,7 @@ assert US.0084.9298 satisfied
 
 $rule_id = (rule-name().split('.'))[rule-name().split('.').length];
 
-if set('N-CSR').contains([covered @concept.local-name ='DocumentType'])
+if set('N-CSR', 'N-CSRS', 'N-CSR/A', 'N-CSRS/A').contains([covered @concept.local-name ='DocumentType'])
 	skip
 else
 $decimal_tolerance_factor = 3

--- a/dqc_us_rules/source/us/2025/DQC_0084.xule
+++ b/dqc_us_rules/source/us/2025/DQC_0084.xule
@@ -14,7 +14,7 @@ assert US.0084.9298 satisfied
 $rule_id = (rule-name().split('.'))[rule-name().split('.').length];
 
 
-if set('N-CSR').contains([covered @concept.local-name ='DocumentType'])
+if set('N-CSR', 'N-CSRS', 'N-CSR/A', 'N-CSRS/A').contains([covered @concept.local-name ='DocumentType'])
 	skip
 else
 $decimal_tolerance_factor = 3


### PR DESCRIPTION
### Changes:

- Exclude DQC.US0084 for N-CSRS, N-CSRS/A and N-CSR/A document types. N-CSRS is the semi annual report and N-CSR is the annual report.

### Pull request process

- [x] Full description of changes provided above.
- [ ] Reviewed by another person. (+1)
- [ ] If this is a code change, reviewed by a second person. (+1)
- [ ] QA'd to the specifications listed [here](https://github.com/DataQualityCommittee/dqc_us_rules#quality-assurance-qa-of-a-pull-request). Documentation only changes do not require the formal code quality assurance process. (+10)

##### Once checklist is complete, @campbellpryde @marcward @davidtauriello please review for merge.